### PR TITLE
Add in-app auto-update, log IP masking, and App SDK 2.0 upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,11 +61,3 @@ jobs:
           }
           $size = (Get-Item $exe).Length
           Write-Host "OK: AOT exe found at $exe ($size bytes)"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: XrayUI-win-x64-${{ github.sha }}
-          path: bin/Release/net10.0-windows10.0.19041.0/win-x64/publish/
-          retention-days: 7
-          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,14 +109,14 @@ jobs:
         shell: pwsh
         run: |
           $publishDir = "bin/Release/net10.0-windows10.0.19041.0/${{ matrix.rid }}/publish"
-          $zipName = "XrayUI-${{ github.ref_name }}-${{ matrix.rid }}.zip"
+          $zipName = "XrayUI-${{ matrix.rid }}.zip"
           Compress-Archive -Path "$publishDir/*" -DestinationPath $zipName -CompressionLevel Optimal
           Write-Host "Created $zipName ($((Get-Item $zipName).Length) bytes)"
 
       - name: Generate SHA256
         shell: pwsh
         run: |
-          $zip = "XrayUI-${{ github.ref_name }}-${{ matrix.rid }}.zip"
+          $zip = "XrayUI-${{ matrix.rid }}.zip"
           $hash = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLower()
           # Standard sha256sum format: "<hash>  <filename>" (two spaces, no newline).
           [System.IO.File]::WriteAllText("$zip.sha256", "$hash  $zip", [System.Text.Encoding]::ASCII)
@@ -125,8 +125,8 @@ jobs:
       - name: Upload zip artifact
         uses: actions/upload-artifact@v4
         with:
-          name: XrayUI-${{ github.ref_name }}-${{ matrix.rid }}
-          path: XrayUI-${{ github.ref_name }}-${{ matrix.rid }}.zip*
+          name: XrayUI-${{ matrix.rid }}
+          path: XrayUI-${{ matrix.rid }}.zip*
           retention-days: 14
           if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,16 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Compute version from tag
+        id: ver
+        shell: pwsh
+        run: |
+          $tag = '${{ github.ref_name }}'
+          $ver = $tag -replace '^v',''
+          if ($ver -notmatch '^\d+(\.\d+){0,3}$') { $ver = '0.0.0' }
+          "version=$ver" | Out-File $env:GITHUB_OUTPUT -Append
+          Write-Host "Resolved version: $ver (from tag $tag)"
+
       # No separate `dotnet restore` step: PublishAot must be set at restore time
       # for ILCompiler to be pulled in. See build.yml for details.
       - name: Publish (${{ matrix.rid }}, AOT)
@@ -51,6 +61,32 @@ jobs:
           -p:PublishReadyToRun=false
           -p:WindowsAppSDKSelfContained=false
           -p:CopyOutputSymbolsToPublishDirectory=false
+          -p:Version=${{ steps.ver.outputs.version }}
+          -p:BuildingForCI=true
+
+      - name: Publish Updater (${{ matrix.rid }}, AOT)
+        run: >
+          dotnet publish XrayUI.Updater/XrayUI.Updater.csproj
+          -c Release
+          -r ${{ matrix.rid }}
+          -p:SelfContained=true
+          -p:PublishAot=true
+          -p:PublishTrimmed=true
+          -p:PublishSingleFile=false
+          -p:Version=${{ steps.ver.outputs.version }}
+          -o updater-out
+
+      - name: Bundle updater into staging
+        shell: pwsh
+        run: |
+          $publishDir = "bin/Release/net10.0-windows10.0.19041.0/${{ matrix.rid }}/publish"
+          $updaterExe = "updater-out/XrayUI.Updater.exe"
+          if (-not (Test-Path $updaterExe)) {
+            Write-Host "::error::Updater publish did not produce $updaterExe"
+            exit 1
+          }
+          Copy-Item $updaterExe -Destination "$publishDir/" -Force
+          Write-Host "Bundled XrayUI.Updater.exe into $publishDir"
 
       - name: Verify AOT exe produced
         shell: pwsh
@@ -77,11 +113,20 @@ jobs:
           Compress-Archive -Path "$publishDir/*" -DestinationPath $zipName -CompressionLevel Optimal
           Write-Host "Created $zipName ($((Get-Item $zipName).Length) bytes)"
 
+      - name: Generate SHA256
+        shell: pwsh
+        run: |
+          $zip = "XrayUI-${{ github.ref_name }}-${{ matrix.rid }}.zip"
+          $hash = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLower()
+          # Standard sha256sum format: "<hash>  <filename>" (two spaces, no newline).
+          [System.IO.File]::WriteAllText("$zip.sha256", "$hash  $zip", [System.Text.Encoding]::ASCII)
+          Write-Host "Wrote $zip.sha256 = $hash"
+
       - name: Upload zip artifact
         uses: actions/upload-artifact@v4
         with:
           name: XrayUI-${{ github.ref_name }}-${{ matrix.rid }}
-          path: XrayUI-${{ github.ref_name }}-${{ matrix.rid }}.zip
+          path: XrayUI-${{ github.ref_name }}-${{ matrix.rid }}.zip*
           retention-days: 14
           if-no-files-found: error
 
@@ -101,15 +146,17 @@ jobs:
         with:
           path: artifacts
 
-      - name: Flatten zips
+      - name: Flatten release files
         run: |
           mkdir -p release-files
-          find artifacts -name '*.zip' -exec mv {} release-files/ \;
+          find artifacts \( -name '*.zip' -o -name '*.sha256' \) -exec mv {} release-files/ \;
           ls -la release-files
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: release-files/*.zip
+          files: |
+            release-files/*.zip
+            release-files/*.sha256
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -83,9 +83,9 @@ namespace XrayUI
             }
         }
 
-        public void RequestShutdown()
+        public void RequestShutdown(bool fastShutdown = false)
         {
-            CleanupOnExit();
+            CleanupOnExit(fastShutdown);
             Environment.Exit(0);
         }
 

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.Windows.AppLifecycle;

--- a/Helpers/AppPaths.cs
+++ b/Helpers/AppPaths.cs
@@ -1,0 +1,14 @@
+using System;
+using System.IO;
+
+namespace XrayUI.Helpers
+{
+    public static class AppPaths
+    {
+        public static string LocalAppDataDir { get; } = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "XrayUI");
+
+        public static string UpdatesDir { get; } = Path.Combine(LocalAppDataDir, "Updates");
+    }
+}

--- a/Helpers/AppVersion.cs
+++ b/Helpers/AppVersion.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace XrayUI.Helpers
+{
+    public static class AppVersion
+    {
+        public static Version Current { get; } =
+            typeof(AppVersion).Assembly.GetName().Version ?? new Version(0, 0, 0);
+
+        // Local Debug builds inherit the csproj default <Version>0.0.0-dev</Version>,
+        // which Assembly.Version surfaces as 0.0.0.0. Skip update checks for those
+        // so dev iteration never tries to "upgrade" to the latest public release.
+        public static bool IsDevBuild =>
+            Current.Major == 0 && Current.Minor == 0 && Current.Build == 0;
+    }
+}

--- a/Helpers/ThemeHelper.cs
+++ b/Helpers/ThemeHelper.cs
@@ -1,4 +1,3 @@
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 
 namespace XrayUI.Helpers

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -53,8 +53,9 @@ namespace XrayUI
             var tunService      = new TunService();
             var startupService  = new StartupService();
             var dialogService   = new DialogService(() => _initialized ? Content?.XamlRoot : null);
+            var updateService   = new UpdateService();
 
-            ViewModel = new MainViewModel(dialogService, settingsService, xrayService, tunService, startupService);
+            ViewModel = new MainViewModel(dialogService, settingsService, xrayService, tunService, startupService, updateService);
 
             InitializeComponent();
 

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -18,6 +18,8 @@ namespace XrayUI.Models
         public string? LastAutoConnectServerId { get; set; }
         /// <summary>Legacy (pre-Id) name-based setting. Read once for migration on first load after upgrade.</summary>
         public string? LastAutoConnectServerName { get; set; }
+        /// <summary>"" | "quarter" | "half" | "full"; controls Xray log IP masking.</summary>
+        public string LogMaskAddress { get; set; } = string.Empty;
 
         // ── Personalization ───────────────────────────────────────────────────
         /// <summary>"Light" | "Dark" | "Default" (follows system)</summary>

--- a/Models/CustomRoutingRule.cs
+++ b/Models/CustomRoutingRule.cs
@@ -1,5 +1,4 @@
 using System.Text.Json.Serialization;
-using Microsoft.UI.Xaml;
 
 namespace XrayUI.Models
 {

--- a/Models/ServerEntry.cs
+++ b/Models/ServerEntry.cs
@@ -27,6 +27,7 @@ namespace XrayUI.Models
             ShortId = string.Empty;
             SpiderX = string.Empty;
             Flow = string.Empty;
+            Finalmask = string.Empty;
         }
 
         /// <summary>ID of the subscription this node was imported from; empty = manually added.</summary>
@@ -100,6 +101,10 @@ namespace XrayUI.Models
         /// <summary>VLESS flow: "xtls-rprx-vision" or empty string.</summary>
         [ObservableProperty]
         public partial string Flow { get; set; }
+
+        /// <summary>Raw Xray streamSettings.finalmask JSON, shared as the "fm" URI parameter.</summary>
+        [ObservableProperty]
+        public partial string Finalmask { get; set; }
 
         public string Id
         {

--- a/Models/UpdateInfo.cs
+++ b/Models/UpdateInfo.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace XrayUI.Models
+{
+    // Minimal subset of the GitHub Releases API response — only the fields we use.
+    internal sealed class GhRelease
+    {
+        [JsonPropertyName("tag_name")]   public string? TagName { get; set; }
+        [JsonPropertyName("prerelease")] public bool Prerelease { get; set; }
+        [JsonPropertyName("draft")]      public bool Draft { get; set; }
+        [JsonPropertyName("assets")]     public List<GhAsset>? Assets { get; set; }
+    }
+
+    internal sealed class GhAsset
+    {
+        [JsonPropertyName("name")]                 public string? Name { get; set; }
+        [JsonPropertyName("browser_download_url")] public string? Url { get; set; }
+    }
+
+    public sealed record UpdateInfo(
+        Version NewVersion,
+        string TagName,
+        string ZipUrl,
+        string Sha256Url,
+        string ZipAssetName);
+}

--- a/Services/AppJsonSerializerContext.cs
+++ b/Services/AppJsonSerializerContext.cs
@@ -19,6 +19,8 @@ namespace XrayUI.Services;
 [JsonSerializable(typeof(List<SubscriptionEntry>))]
 [JsonSerializable(typeof(SubscriptionEntry))]
 [JsonSerializable(typeof(PresetSettings))]
+[JsonSerializable(typeof(GhRelease))]
+[JsonSerializable(typeof(GhAsset))]
 internal partial class AppJsonSerializerContext : JsonSerializerContext
 {
     // Write-side options that emit CJK / emoji as literal UTF-8 instead of \uXXXX escapes.

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -388,7 +388,15 @@ namespace XrayUI.Services
             var progress = new Progress<string>(s => statusText.Text = s);
 
             Exception? error   = null;
-            bool workFinished = false;
+            int workFinished = 0;
+
+            dialog.Opened += (_, _) =>
+            {
+                if (Volatile.Read(ref workFinished) == 1)
+                {
+                    try { dialog.Hide(); } catch { }
+                }
+            };
 
             var workTask = Task.Run(async () =>
             {
@@ -409,7 +417,7 @@ namespace XrayUI.Services
                 }
                 finally
                 {
-                    workFinished = true;
+                    Volatile.Write(ref workFinished, 1);
                     dialog.DispatcherQueue.TryEnqueue(() =>
                     {
                         try { dialog.Hide(); } catch { }
@@ -420,7 +428,7 @@ namespace XrayUI.Services
             await dialog.ShowAsync();
 
             // If the dialog closed because the user clicked Cancel (work still running), signal it.
-            if (!workFinished) cts.Cancel();
+            if (Volatile.Read(ref workFinished) == 0) cts.Cancel();
 
             await workTask;
 

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -425,7 +425,7 @@ namespace XrayUI.Services
             await workTask;
 
             if (error != null) throw error;
-            if (cts.IsCancellationRequested) throw new OperationCanceledException();
+            if (cts.IsCancellationRequested) throw new OperationCanceledException(cts.Token);
         }
 
         // ── Share link ────────────────────────────────────────────────────────

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -600,7 +600,7 @@ namespace XrayUI.Services
             RequestedTheme = ThemeHelper.ActualTheme,
         };
 
-        private static FrameworkElement Wrap(FrameworkElement child) =>
+        private static Border Wrap(FrameworkElement child) =>
             new Border { Child = child };
     }
 }

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -146,6 +146,14 @@ namespace XrayUI.Services
             var txtSid  = new TextBox { Header = "ShortId (Reality)", Text = existing?.ShortId ?? string.Empty };
             var txtSpx  = new TextBox { Header = "SpiderX (Reality)", Text = existing?.SpiderX ?? string.Empty };
             var txtFlow = new TextBox { Header = "Flow (VLESS)", PlaceholderText = "xtls-rprx-vision 或留空", Text = existing?.Flow ?? string.Empty };
+            var txtFinalmask = new TextBox
+            {
+                Header = "Finalmask (JSON)",
+                Text = existing?.Finalmask ?? string.Empty,
+                AcceptsReturn = true,
+                Height = 104,
+                TextWrapping = TextWrapping.NoWrap
+            };
 
             // Row containers for conditional visibility
             var rowEncryption = Wrap(cmbEncryption);
@@ -161,6 +169,7 @@ namespace XrayUI.Services
             var rowSid        = Wrap(txtSid);
             var rowSpx        = Wrap(txtSpx);
             var rowFlow       = Wrap(txtFlow);
+            var rowFinalmask  = Wrap(txtFinalmask);
 
             void UpdateVisibility()
             {
@@ -221,7 +230,8 @@ namespace XrayUI.Services
                     txtName, txtHost, numPort, cmbProtocol,
                     rowEncryption, rowPassword, rowUuid, rowAlterId,
                     cmbNetwork, rowPath, rowWsHost,
-                    cmbSecurity, rowSni, rowFp, rowAllowInsecure, rowPk, rowSid, rowSpx, rowFlow
+                    cmbSecurity, rowSni, rowFp, rowAllowInsecure, rowPk, rowSid, rowSpx, rowFlow,
+                    rowFinalmask
                 }
             };
 
@@ -262,6 +272,7 @@ namespace XrayUI.Services
             entry.ShortId     = txtSid.Text.Trim();
             entry.SpiderX     = txtSpx.Text.Trim();
             entry.Flow        = txtFlow.Text.Trim();
+            entry.Finalmask   = FinalmaskJson.NormalizeForStorage(txtFinalmask.Text);
 
             if (entry.Protocol == "hysteria2")
             {

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -5,7 +5,6 @@ using System.ComponentModel;
 using Windows.ApplicationModel.DataTransfer;
 using XrayUI.Helpers;
 using XrayUI.Models;
-using XrayUI.ViewModels;
 using XrayUI.Views;
 
 namespace XrayUI.Services

--- a/Services/FinalmaskJson.cs
+++ b/Services/FinalmaskJson.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace XrayUI.Services
+{
+    internal static class FinalmaskJson
+    {
+        // Compact + default escaping — output is embedded in share URLs, where
+        // the conservative default encoder (escapes `<`, `>`, `&`, `+`) is the
+        // right choice. Storage path reuses AppJsonSerializerContext.WriteReadable
+        // (indented + relaxed escaping, appropriate for the local config file).
+        private static readonly JsonSerializerOptions CompactJson = new()
+        {
+            WriteIndented = false
+        };
+
+        public static string NormalizeForStorage(string? value)
+        {
+            value = value?.Trim();
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            var node = Parse(value);
+            return node?.ToJsonString(AppJsonSerializerContext.WriteReadable) ?? value;
+        }
+
+        public static string NormalizeForShare(string? value)
+        {
+            value = value?.Trim();
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            var node = Parse(value);
+            return node?.ToJsonString(CompactJson) ?? value;
+        }
+
+        public static JsonNode? Parse(string? value)
+        {
+            value = value?.Trim();
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+
+            try
+            {
+                return JsonNode.Parse(value);
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Services/GeoDataUpdateService.cs
+++ b/Services/GeoDataUpdateService.cs
@@ -47,7 +47,8 @@ namespace XrayUI.Services
                 handler.UseProxy = false;
             }
 
-            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromMinutes(5) };
+            using var client = new HttpClient(handler);
+            client.Timeout = TimeSpan.FromMinutes(5);
             client.DefaultRequestHeaders.UserAgent.ParseAdd("XrayUI");
 
             Directory.CreateDirectory(XrayService.RulesDir);

--- a/Services/IDialogService.cs
+++ b/Services/IDialogService.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.UI.Xaml;
 using XrayUI.Models;
-using XrayUI.ViewModels;
 
 namespace XrayUI.Services
 {

--- a/Services/IUpdateService.cs
+++ b/Services/IUpdateService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using XrayUI.Models;
+
+namespace XrayUI.Services
+{
+    public sealed record UpdateStaging(
+        string ExtractedDir,
+        string RunnerExePath,
+        string InstallDir,
+        Version NewVersion);
+
+    public interface IUpdateService
+    {
+        /// <summary>
+        /// Returns null when no update is available, the architecture has no matching
+        /// release asset, the .sha256 sidecar is missing, or the running build is dev
+        /// (per <see cref="Helpers.AppVersion.IsDevBuild"/>).
+        /// </summary>
+        Task<UpdateInfo?> CheckAsync(string? proxyUrl, CancellationToken ct);
+
+        /// <summary>
+        /// Downloads the zip + .sha256, verifies the hash, extracts to a staging
+        /// directory, and validates the extracted exe's FileVersion. Stages a copy
+        /// of the currently installed XrayUI.Updater.exe so it can run while the
+        /// install dir is being overwritten. Throws on any verification failure
+        /// without touching the install dir.
+        /// </summary>
+        Task<UpdateStaging> DownloadVerifyAndExtractAsync(
+            UpdateInfo info, string? proxyUrl, IProgress<string> progress, CancellationToken ct);
+
+        /// <summary>
+        /// Spawns the staged updater with handoff arguments. Caller is responsible
+        /// for shutting the app down (via <c>App.RequestShutdown</c>) immediately after.
+        /// </summary>
+        void LaunchUpdater(UpdateStaging staging);
+
+        /// <summary>
+        /// Removes staging directories older than 24h under
+        /// <c>%LocalAppData%\XrayUI\Updates</c>. Best-effort, non-throwing.
+        /// </summary>
+        void CleanupOldStagingDirs();
+    }
+}

--- a/Services/IUpdateService.cs
+++ b/Services/IUpdateService.cs
@@ -37,8 +37,9 @@ namespace XrayUI.Services
         void LaunchUpdater(UpdateStaging staging);
 
         /// <summary>
-        /// Removes staging directories older than 24h under
-        /// <c>%LocalAppData%\XrayUI\Updates</c>. Best-effort, non-throwing.
+        /// Removes leftover staging directories under
+        /// <c>%LocalAppData%\XrayUI\Updates</c>. Best-effort, non-throwing; a
+        /// still-locked runner may remain until the next startup.
         /// </summary>
         void CleanupOldStagingDirs();
     }

--- a/Services/LogMaskAddress.cs
+++ b/Services/LogMaskAddress.cs
@@ -1,0 +1,22 @@
+namespace XrayUI.Services
+{
+    /// <summary>
+    /// Canonical names + validation for Xray's <c>log.maskAddress</c> setting,
+    /// which controls IP redaction in xray's log output. Empty = feature off.
+    /// </summary>
+    internal static class LogMaskAddress
+    {
+        public const string Off = "";
+        public const string Quarter = "quarter";
+        public const string Half = "half";
+        public const string Full = "full";
+
+        /// <summary>True iff the value is one of the three xray-recognized levels.</summary>
+        public static bool IsEnabled(string? value) =>
+            value is Quarter or Half or Full;
+
+        /// <summary>Returns the value if recognized, otherwise empty.</summary>
+        public static string Normalize(string? value) =>
+            value is Quarter or Half or Full ? value : Off;
+    }
+}

--- a/Services/NodeLinkParser.cs
+++ b/Services/NodeLinkParser.cs
@@ -165,6 +165,7 @@ namespace XrayUI.Services
                 var tls      = GetStr("tls", "");
                 var security = tls == "tls" ? "tls" : "none";
                 var allowInsecure = IsTruthy(GetStr("allowInsecure")) || IsTruthy(GetStr("insecure"));
+                var finalmask = FinalmaskJson.NormalizeForStorage(GetStr("fm", GetStr("finalmask")));
 
                 return new ServerEntry
                 {
@@ -181,6 +182,7 @@ namespace XrayUI.Services
                     Sni         = GetStr("sni"),
                     Fingerprint = GetStr("fp"),
                     AllowInsecure = allowInsecure,
+                    Finalmask   = finalmask,
                     Encryption  = security == "tls" ? "TLS" : "None"
                 };
             }
@@ -217,6 +219,7 @@ namespace XrayUI.Services
                 var path     = Q(query, "path") ?? Q(query, "serviceName") ?? string.Empty;
                 var wsHost   = Q(query, "host", string.Empty) ?? string.Empty;
                 var flow     = Q(query, "flow", string.Empty) ?? string.Empty;
+                var finalmask = FinalmaskJson.NormalizeForStorage(Q(query, "fm"));
                 var allowInsecure = IsTruthy(Q(query, "allowInsecure")) || IsTruthy(Q(query, "insecure"));
 
                 return new ServerEntry
@@ -237,6 +240,7 @@ namespace XrayUI.Services
                     Path        = path,
                     WsHost      = wsHost,
                     Flow        = flow,
+                    Finalmask   = finalmask,
                     Encryption  = security == "reality" ? "Reality"
                                 : security == "tls"     ? "TLS"
                                                         : "None"
@@ -264,6 +268,7 @@ namespace XrayUI.Services
 
                 var query = ParseQuery(uri.Query);
                 var sni   = Q(query, "sni", string.Empty) ?? string.Empty;
+                var finalmask = FinalmaskJson.NormalizeForStorage(Q(query, "fm"));
                 var allowInsecure = IsTruthy(Q(query, "allowInsecure")) || IsTruthy(Q(query, "insecure"));
 
                 return new ServerEntry
@@ -277,6 +282,7 @@ namespace XrayUI.Services
                     Security   = "tls",
                     Sni        = sni,
                     AllowInsecure = allowInsecure,
+                    Finalmask  = finalmask,
                     Encryption = "TLS"
                 };
             }
@@ -314,6 +320,7 @@ namespace XrayUI.Services
                 var fp     = Q(query, "fp", string.Empty) ?? string.Empty;
                 var path   = Q(query, "path") ?? Q(query, "serviceName") ?? string.Empty;
                 var wsHost = Q(query, "host", string.Empty) ?? string.Empty;
+                var finalmask = FinalmaskJson.NormalizeForStorage(Q(query, "fm"));
                 var allowInsecure = IsTruthy(Q(query, "allowInsecure")) || IsTruthy(Q(query, "insecure"));
 
                 return new ServerEntry
@@ -330,6 +337,7 @@ namespace XrayUI.Services
                     AllowInsecure = allowInsecure,
                     Path          = path,
                     WsHost        = wsHost,
+                    Finalmask     = finalmask,
                     Encryption    = security == "reality" ? "Reality"
                                   : security == "tls"     ? "TLS"
                                                           : "None"

--- a/Services/NodeLinkSerializer.cs
+++ b/Services/NodeLinkSerializer.cs
@@ -70,6 +70,7 @@ namespace XrayUI.Services
                 ["tls"] = tls,
                 ["sni"] = s.Sni ?? string.Empty,
                 ["fp"] = s.Fingerprint ?? string.Empty,
+                ["fm"] = FinalmaskJson.NormalizeForShare(s.Finalmask),
                 // IsTruthy("1") = true, IsTruthy("") = false — clean round-trip
                 ["allowInsecure"] = s.AllowInsecure ? "1" : ""
             };
@@ -128,6 +129,7 @@ namespace XrayUI.Services
 
             // VLESS flow (xtls-rprx-vision etc.)
             AppendIfNotEmpty(sb, "flow", s.Flow);
+            AppendIfNotEmpty(sb, "fm", FinalmaskJson.NormalizeForShare(s.Finalmask));
 
             // Fragment
             if (!string.IsNullOrEmpty(s.Name))
@@ -156,7 +158,8 @@ namespace XrayUI.Services
             sb.Append(':');
             sb.Append(s.Port);
 
-            bool hasQuery = !string.IsNullOrEmpty(s.Sni) || s.AllowInsecure;
+            var finalmask = FinalmaskJson.NormalizeForShare(s.Finalmask);
+            bool hasQuery = !string.IsNullOrEmpty(s.Sni) || s.AllowInsecure || !string.IsNullOrEmpty(finalmask);
             if (hasQuery)
             {
                 sb.Append('?');
@@ -167,7 +170,14 @@ namespace XrayUI.Services
                     first = false;
                 }
                 if (s.AllowInsecure)
+                {
                     AppendParam(sb, "insecure", "1", first: first);
+                    first = false;
+                }
+                if (!string.IsNullOrEmpty(finalmask))
+                {
+                    AppendParam(sb, "fm", finalmask, first: first);
+                }
             }
 
             if (!string.IsNullOrEmpty(s.Name))
@@ -198,13 +208,15 @@ namespace XrayUI.Services
             sb.Append(':');
             sb.Append(s.Port > 0 ? s.Port : 443);
 
+            var finalmask = FinalmaskJson.NormalizeForShare(s.Finalmask);
             bool hasQuery = network != "tcp"
                             || security != "tls"
                             || !string.IsNullOrEmpty(s.Sni)
                             || !string.IsNullOrEmpty(s.Fingerprint)
                             || s.AllowInsecure
                             || !string.IsNullOrEmpty(s.Path)
-                            || !string.IsNullOrEmpty(s.WsHost);
+                            || !string.IsNullOrEmpty(s.WsHost)
+                            || !string.IsNullOrEmpty(finalmask);
             if (hasQuery)
             {
                 sb.Append('?');
@@ -238,6 +250,7 @@ namespace XrayUI.Services
 
                 if (network == "ws")
                     AddIfNotEmpty("host", s.WsHost);
+                AddIfNotEmpty("fm", finalmask);
             }
 
             if (!string.IsNullOrEmpty(s.Name))

--- a/Services/PingProbeService.cs
+++ b/Services/PingProbeService.cs
@@ -24,7 +24,7 @@ namespace XrayUI.Services
 
             try
             {
-                using var registration = cancellationToken.Register(() => ping.SendAsyncCancel());
+                using var registration = cancellationToken.Register(ping.SendAsyncCancel);
                 var reply = await ping.SendPingAsync(host, (int)Math.Ceiling(timeout.TotalMilliseconds));
 
                 return reply.Status switch

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -5,15 +5,14 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using XrayUI.Helpers;
 using XrayUI.Models;
 
 namespace XrayUI.Services
 {
     public class SettingsService
     {
-        private static readonly string DataDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "XrayUI");
+        private static readonly string DataDir = AppPaths.LocalAppDataDir;
 
         private static readonly string SettingsFile = Path.Combine(DataDir, "settings.json");
         private static readonly string ServersFile  = Path.Combine(DataDir, "servers.json");

--- a/Services/StartupService.cs
+++ b/Services/StartupService.cs
@@ -209,12 +209,11 @@ namespace XrayUI.Services
             }
         }
 
-        private static uint Release(IntPtr pUnk)
+        private static void Release(IntPtr pUnk)
         {
-            if (pUnk == IntPtr.Zero) return 0;
+            if (pUnk == IntPtr.Zero) return;
             void** vtbl = *(void***)pUnk;
             var fn = (delegate* unmanaged[Stdcall]<IntPtr, uint>)vtbl[2];
-            return fn(pUnk);
         }
 
         [DllImport("ole32.dll", ExactSpelling = true)]

--- a/Services/StartupService.cs
+++ b/Services/StartupService.cs
@@ -214,6 +214,7 @@ namespace XrayUI.Services
             if (pUnk == IntPtr.Zero) return;
             void** vtbl = *(void***)pUnk;
             var fn = (delegate* unmanaged[Stdcall]<IntPtr, uint>)vtbl[2];
+            fn(pUnk);
         }
 
         [DllImport("ole32.dll", ExactSpelling = true)]

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -140,6 +140,8 @@ namespace XrayUI.Services
             }
 
             // ── 5. Sanity check extracted contents ──────────────────────────────────
+            progress.Report("正在验证更新包…");
+
             var newAppExe     = Path.Combine(extractDir, AppExeName);
             var newUpdaterExe = Path.Combine(extractDir, UpdaterExeName);
 
@@ -172,6 +174,8 @@ namespace XrayUI.Services
             var stagedRunner = Path.Combine(runnerDir, UpdaterExeName);
             File.Copy(currentUpdater, stagedRunner, overwrite: true);
 
+            progress.Report("正在准备重启…");
+
             return new UpdateStaging(extractDir, stagedRunner, installDir, info.NewVersion);
         }
 
@@ -197,15 +201,13 @@ namespace XrayUI.Services
             {
                 if (!Directory.Exists(AppPaths.UpdatesDir)) return;
 
-                var cutoff = DateTime.Now.AddHours(-24);
                 foreach (var sub in Directory.EnumerateDirectories(AppPaths.UpdatesDir))
                 {
                     try
                     {
-                        if (Directory.GetCreationTime(sub) < cutoff)
-                            Directory.Delete(sub, recursive: true);
+                        Directory.Delete(sub, recursive: true);
                     }
-                    catch { /* one bad dir shouldn't break the sweep */ }
+                    catch { /* locked runner or one bad dir shouldn't break the sweep */ }
                 }
             }
             catch { /* best-effort */ }

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -62,7 +62,7 @@ namespace XrayUI.Services
             var rid = CurrentRid();
             if (rid is null) return null;
 
-            var zipName    = $"XrayUI-{release.TagName}-{rid}.zip";
+            var zipName    = $"XrayUI-{rid}.zip";
             var sha256Name = $"{zipName}.sha256";
 
             string? zipUrl = null, shaUrl = null;

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using XrayUI.Helpers;
+using XrayUI.Models;
+
+namespace XrayUI.Services
+{
+    /// <summary>
+    /// Checks GitHub Releases for a newer XrayUI build, downloads + verifies the
+    /// matching zip asset, extracts and validates it, then hands off to the
+    /// standalone XrayUI.Updater.exe to overwrite the install directory.
+    ///
+    /// HTTP / SHA256 / progress patterns are intentionally cloned from
+    /// <see cref="GeoDataUpdateService"/> rather than refactored into a shared
+    /// helper — they are ~50 LOC each and the two services have different
+    /// failure-policy requirements.
+    /// </summary>
+    public sealed class UpdateService : IUpdateService
+    {
+        private const string ReleaseApiUrl =
+            "https://api.github.com/repos/PhoenixNil/XrayUI-dev/releases/latest";
+
+        private const string AppExeName     = "XrayUI-dev.exe";
+        private const string UpdaterExeName = "XrayUI.Updater.exe";
+
+        public async Task<UpdateInfo?> CheckAsync(string? proxyUrl, CancellationToken ct)
+        {
+            // Local builds carry the csproj default <Version>0.0.0-dev</Version>;
+            // skip so dev iteration never tries to "upgrade" to the latest public release.
+            if (AppVersion.IsDevBuild) return null;
+
+            using var client = CreateHttpClient(proxyUrl, TimeSpan.FromSeconds(20));
+
+            GhRelease? release;
+            try
+            {
+                release = await client.GetFromJsonAsync(
+                    ReleaseApiUrl, AppJsonSerializerContext.Default.GhRelease, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch
+            {
+                // Network down, GitHub rate-limited, etc. — silent per failure policy.
+                return null;
+            }
+
+            if (release is null || release.Draft || release.Prerelease) return null;
+
+            var tag = (release.TagName ?? string.Empty).TrimStart('v');
+            if (!Version.TryParse(tag, out var remoteVersion)) return null;
+            if (remoteVersion <= AppVersion.Current) return null;
+
+            var rid = CurrentRid();
+            if (rid is null) return null;
+
+            var zipName    = $"XrayUI-{release.TagName}-{rid}.zip";
+            var sha256Name = $"{zipName}.sha256";
+
+            string? zipUrl = null, shaUrl = null;
+            if (release.Assets is not null)
+            {
+                foreach (var a in release.Assets)
+                {
+                    if (a?.Name is null || a.Url is null) continue;
+                    if (a.Name == zipName)    zipUrl = a.Url;
+                    if (a.Name == sha256Name) shaUrl = a.Url;
+                }
+            }
+
+            // Both must be present. Missing zip = no asset for this arch; missing
+            // .sha256 = release mid-deploy or pre-feature build. Either way: silent skip.
+            if (zipUrl is null || shaUrl is null) return null;
+
+            return new UpdateInfo(remoteVersion, release.TagName!, zipUrl, shaUrl, zipName);
+        }
+
+        public async Task<UpdateStaging> DownloadVerifyAndExtractAsync(
+            UpdateInfo info, string? proxyUrl, IProgress<string> progress, CancellationToken ct)
+        {
+            var stageRoot   = Path.Combine(AppPaths.UpdatesDir, info.NewVersion.ToString());
+            var downloadDir = Path.Combine(stageRoot, "download");
+            var extractDir  = Path.Combine(stageRoot, "extracted");
+            var runnerDir   = Path.Combine(stageRoot, "runner");
+
+            // Always start from a clean stage dir — partial leftovers from a previous
+            // failed attempt would otherwise confuse the version sanity check.
+            if (Directory.Exists(stageRoot))
+            {
+                try { Directory.Delete(stageRoot, recursive: true); } catch { }
+            }
+            Directory.CreateDirectory(downloadDir);
+            Directory.CreateDirectory(extractDir);
+            Directory.CreateDirectory(runnerDir);
+
+            using var client = CreateHttpClient(proxyUrl, TimeSpan.FromMinutes(10));
+
+            // ── 1. .sha256 first (small, fail-fast on bad release) ─────────────────
+            progress.Report("正在获取校验文件…");
+            string expectedHash;
+            try
+            {
+                var shaText = await client.GetStringAsync(info.Sha256Url, ct);
+                expectedHash = ParseSha256SumLine(shaText)
+                    ?? throw new InvalidDataException("更新校验文件格式异常");
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (InvalidDataException) { throw; }
+            catch (Exception ex)
+            {
+                throw new InvalidDataException("无法下载更新校验文件：" + ex.Message);
+            }
+
+            // ── 2. zip — hash is computed during the streaming write so we don't ──
+            //    need a second pass over the (~100MB+) file just to verify.
+            var zipPath = Path.Combine(downloadDir, info.ZipAssetName);
+            var actualHash = await DownloadAndHashAsync(
+                client, info.ZipUrl, zipPath, info.ZipAssetName, progress, ct);
+
+            if (!string.Equals(actualHash, expectedHash, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidDataException("更新包校验失败：SHA256 与服务器公布的不一致。");
+
+            // ── 4. Extract ──────────────────────────────────────────────────────────
+            progress.Report("正在解压更新包…");
+            try
+            {
+                ZipFile.ExtractToDirectory(zipPath, extractDir, overwriteFiles: true);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidDataException("更新包解压失败：" + ex.Message);
+            }
+
+            // ── 5. Sanity check extracted contents ──────────────────────────────────
+            var newAppExe     = Path.Combine(extractDir, AppExeName);
+            var newUpdaterExe = Path.Combine(extractDir, UpdaterExeName);
+
+            if (!File.Exists(newAppExe) || !File.Exists(newUpdaterExe))
+                throw new InvalidDataException("更新包内容异常：缺少必要文件。");
+
+            var actualFileVersion = FileVersionInfo.GetVersionInfo(newAppExe).FileVersion;
+            if (string.IsNullOrEmpty(actualFileVersion) ||
+                !Version.TryParse(actualFileVersion, out var parsedFv) ||
+                NormalizeForCompare(parsedFv) != NormalizeForCompare(info.NewVersion))
+            {
+                throw new InvalidDataException(
+                    $"更新包版本不匹配：期望 {info.NewVersion}，实际 {actualFileVersion}。");
+            }
+
+            // ── 6. Stage a runnable copy of the CURRENT updater ─────────────────────
+            // We can't run the updater that's about to be overwritten — it must run
+            // from a location outside the install dir. Since the *new* updater hasn't
+            // been deployed yet, copy the currently-installed one.
+            var installDir = Path.GetDirectoryName(Environment.ProcessPath)
+                             ?? AppContext.BaseDirectory;
+            var currentUpdater = Path.Combine(installDir, UpdaterExeName);
+            if (!File.Exists(currentUpdater))
+            {
+                throw new FileNotFoundException(
+                    "缺少升级器组件，请重新下载完整安装包。",
+                    currentUpdater);
+            }
+
+            var stagedRunner = Path.Combine(runnerDir, UpdaterExeName);
+            File.Copy(currentUpdater, stagedRunner, overwrite: true);
+
+            return new UpdateStaging(extractDir, stagedRunner, installDir, info.NewVersion);
+        }
+
+        public void LaunchUpdater(UpdateStaging staging)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = staging.RunnerExePath,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            psi.ArgumentList.Add($"--parent-pid={Environment.ProcessId}");
+            psi.ArgumentList.Add($"--extracted-dir={staging.ExtractedDir}");
+            psi.ArgumentList.Add($"--install-dir={staging.InstallDir}");
+            psi.ArgumentList.Add($"--launch-after={AppExeName}");
+
+            Process.Start(psi);
+        }
+
+        public void CleanupOldStagingDirs()
+        {
+            try
+            {
+                if (!Directory.Exists(AppPaths.UpdatesDir)) return;
+
+                var cutoff = DateTime.Now.AddHours(-24);
+                foreach (var sub in Directory.EnumerateDirectories(AppPaths.UpdatesDir))
+                {
+                    try
+                    {
+                        if (Directory.GetCreationTime(sub) < cutoff)
+                            Directory.Delete(sub, recursive: true);
+                    }
+                    catch { /* one bad dir shouldn't break the sweep */ }
+                }
+            }
+            catch { /* best-effort */ }
+        }
+
+        // ── Helpers ───────────────────────────────────────────────────────────────
+
+        private static string? CurrentRid() => RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64   => "win-x64",
+            Architecture.X86   => "win-x86",
+            Architecture.Arm64 => "win-arm64",
+            _ => null,
+        };
+
+        // System.Version normalizes missing components to -1; align so 1.2.3 == 1.2.3.0.
+        private static (int, int, int, int) NormalizeForCompare(Version v) =>
+            (v.Major, v.Minor, Math.Max(v.Build, 0), Math.Max(v.Revision, 0));
+
+        private static HttpClient CreateHttpClient(string? proxyUrl, TimeSpan timeout)
+        {
+            var handler = new HttpClientHandler();
+            if (!string.IsNullOrEmpty(proxyUrl))
+            {
+                handler.Proxy    = new WebProxy(proxyUrl);
+                handler.UseProxy = true;
+            }
+            else
+            {
+                handler.UseProxy = false;
+            }
+
+            var client = new HttpClient(handler) { Timeout = timeout };
+            client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+            client.DefaultRequestHeaders.UserAgent.ParseAdd($"XrayUI/{AppVersion.Current}");
+            return client;
+        }
+
+        private static string? ParseSha256SumLine(string content)
+        {
+            var line = content.Trim();
+            if (line.Length == 0) return null;
+
+            int sep = 0;
+            while (sep < line.Length && !char.IsWhiteSpace(line[sep])) sep++;
+            var token = line[..sep];
+
+            if (token.Length != 64) return null;
+            foreach (var c in token)
+            {
+                if (!char.IsAsciiHexDigit(c)) return null;
+            }
+            return token.ToLowerInvariant();
+        }
+
+        private static async Task<string> DownloadAndHashAsync(
+            HttpClient client, string url, string destPath, string displayName,
+            IProgress<string> progress, CancellationToken ct)
+        {
+            using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
+            response.EnsureSuccessStatusCode();
+
+            var total = response.Content.Headers.ContentLength;
+            progress.Report(FormatProgress(displayName, 0, total));
+
+            await using var src = await response.Content.ReadAsStreamAsync(ct);
+            await using var dst = new FileStream(
+                destPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true);
+
+            using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            var buffer      = new byte[81920];
+            long received   = 0;
+            long lastReport = 0;
+
+            while (true)
+            {
+                var read = await src.ReadAsync(buffer.AsMemory(0, buffer.Length), ct);
+                if (read == 0) break;
+
+                await dst.WriteAsync(buffer.AsMemory(0, read), ct);
+                hasher.AppendData(buffer, 0, read);
+                received += read;
+
+                if (received - lastReport >= 512 * 1024)
+                {
+                    progress.Report(FormatProgress(displayName, received, total));
+                    lastReport = received;
+                }
+            }
+
+            progress.Report(FormatProgress(displayName, received, total));
+            return Convert.ToHexString(hasher.GetHashAndReset()).ToLowerInvariant();
+        }
+
+        private static string FormatProgress(string name, long received, long? total)
+        {
+            var mbReceived = received / 1024.0 / 1024.0;
+            return total.HasValue
+                ? $"正在下载 {name} … {mbReceived:0.0} / {total.Value / 1024.0 / 1024.0:0.0} MB"
+                : $"正在下载 {name} … {mbReceived:0.0} MB";
+        }
+    }
+}

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -14,16 +14,16 @@ using XrayUI.Models;
 
 namespace XrayUI.Services
 {
-    /// <summary>
-    /// Checks GitHub Releases for a newer XrayUI build, downloads + verifies the
-    /// matching zip asset, extracts and validates it, then hands off to the
-    /// standalone XrayUI.Updater.exe to overwrite the install directory.
-    ///
-    /// HTTP / SHA256 / progress patterns are intentionally cloned from
-    /// <see cref="GeoDataUpdateService"/> rather than refactored into a shared
-    /// helper — they are ~50 LOC each and the two services have different
-    /// failure-policy requirements.
-    /// </summary>
+     /*<summary>
+     Checks GitHub Releases for a newer XrayUI build, downloads +verifies the
+     matching zip asset, extracts and validates it, then hands off to the
+     standalone XrayUI.Updater.exe to overwrite the install directory.
+    
+     HTTP / SHA256 / progress patterns are intentionally cloned from
+     <see cref = "GeoDataUpdateService" /> rather than refactored into a shared
+     helper — they are ~50 LOC each and the two services have different
+     failure-policy requirements.
+     </summary> */
     public sealed class UpdateService : IUpdateService
     {
         private const string ReleaseApiUrl =

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -22,10 +22,7 @@ namespace XrayUI.Services
         {
             var config = new JsonObject
             {
-                ["log"] = new JsonObject
-                {
-                    ["loglevel"] = DefaultLogLevel
-                },
+                ["log"] = BuildLog(settings),
                 ["dns"] = BuildDns(settings),
                 ["inbounds"] = BuildInbounds(settings),
                 ["outbounds"] = BuildOutbounds(server, settings, tunOutboundInterfaceName),
@@ -33,6 +30,21 @@ namespace XrayUI.Services
             };
 
             return config.ToJsonString(JsonOpts);
+        }
+
+        private static JsonObject BuildLog(AppSettings settings)
+        {
+            var log = new JsonObject
+            {
+                ["loglevel"] = DefaultLogLevel
+            };
+
+            if (LogMaskAddress.IsEnabled(settings.LogMaskAddress))
+            {
+                log["maskAddress"] = settings.LogMaskAddress;
+            }
+
+            return log;
         }
 
         private static JsonArray BuildInbounds(AppSettings settings)
@@ -168,7 +180,7 @@ namespace XrayUI.Services
                 ["password"] = server.Password
             });
 
-            return new JsonObject
+            var outbound = new JsonObject
             {
                 ["tag"] = "proxy",
                 ["protocol"] = "shadowsocks",
@@ -181,6 +193,9 @@ namespace XrayUI.Services
                     ["network"] = "tcp"
                 }
             };
+
+            ApplyFinalmask((JsonObject)outbound["streamSettings"]!, server);
+            return outbound;
         }
 
         private static JsonObject BuildVmessOutbound(ServerEntry server)
@@ -253,6 +268,23 @@ namespace XrayUI.Services
         {
             var sni = string.IsNullOrWhiteSpace(server.Sni) ? server.Host : server.Sni;
 
+            var streamSettings = new JsonObject
+            {
+                ["network"] = "hysteria",
+                ["security"] = "tls",
+                ["tlsSettings"] = new JsonObject
+                {
+                    ["serverName"] = sni,
+                    ["allowInsecure"] = server.AllowInsecure
+                },
+                ["hysteriaSettings"] = new JsonObject
+                {
+                    ["version"] = 2,
+                    ["auth"] = server.Password
+                }
+            };
+            ApplyFinalmask(streamSettings, server);
+
             return new JsonObject
             {
                 ["tag"] = "proxy",
@@ -263,21 +295,7 @@ namespace XrayUI.Services
                     ["address"] = server.Host,
                     ["port"] = server.Port
                 },
-                ["streamSettings"] = new JsonObject
-                {
-                    ["network"] = "hysteria",
-                    ["security"] = "tls",
-                    ["tlsSettings"] = new JsonObject
-                    {
-                        ["serverName"] = sni,
-                        ["allowInsecure"] = server.AllowInsecure
-                    },
-                    ["hysteriaSettings"] = new JsonObject
-                    {
-                        ["version"] = 2,
-                        ["auth"] = server.Password
-                    }
-                }
+                ["streamSettings"] = streamSettings
             };
         }
 
@@ -382,7 +400,17 @@ namespace XrayUI.Services
                 stream["xhttpSettings"] = settings;
             }
 
+            ApplyFinalmask(stream, server);
             return stream;
+        }
+
+        private static void ApplyFinalmask(JsonObject streamSettings, ServerEntry server)
+        {
+            var finalmask = FinalmaskJson.Parse(server.Finalmask);
+            if (finalmask is JsonObject)
+            {
+                streamSettings["finalmask"] = finalmask;
+            }
         }
 
         private static JsonObject BuildRouting(AppSettings settings)

--- a/Services/XrayService.cs
+++ b/Services/XrayService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace XrayUI.Services
@@ -28,7 +29,7 @@ namespace XrayUI.Services
         private readonly string[] _logBuffer = new string[LogBufferMax];
         private int _logHead;    // index of the next write slot
         private int _logCount;   // number of valid entries (<= LogBufferMax)
-        private readonly object _bufferLock = new();
+        private readonly Lock _bufferLock = new();
 
         public bool IsRunning => _process is { HasExited: false };
 

--- a/ViewModels/BaseViewModel.cs
+++ b/ViewModels/BaseViewModel.cs
@@ -1,6 +1,4 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
-
-namespace XrayUI.ViewModels
+﻿namespace XrayUI.ViewModels
 {
     public partial class BaseViewModel : ObservableObject
     {

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -16,6 +16,9 @@ namespace XrayUI.ViewModels
         private readonly TunService _tunService;
         private readonly StartupService _startupService;
         private readonly GeoDataUpdateService _geoUpdate = new();
+        private readonly IUpdateService _update;
+        private UpdateInfo? _availableUpdate;
+        private bool _isUpdateAvailable;
         private string _startStopButtonContent = "启动";
         private bool _startStopButtonChecked;
         private bool _isRunning;
@@ -75,13 +78,15 @@ namespace XrayUI.ViewModels
             SettingsService settings,
             XrayService xray,
             TunService tunService,
-            StartupService startupService)
+            StartupService startupService,
+            IUpdateService update)
         {
             _dialogs        = dialogs;
             _settings       = settings;
             _xray           = xray;
             _tunService     = tunService;
             _startupService = startupService;
+            _update         = update;
         }
 
         // ── Running state ─────────────────────────────────────────────────────────────────────────────────────────────
@@ -808,6 +813,79 @@ namespace XrayUI.ViewModels
             {
                 Debug.WriteLine($"[Settings] Failed to {scenario}: {ex.Message}");
             }
+        }
+
+        // ── App update notification ───────────────────────────────────────────────
+
+        /// <summary>True iff a newer release was found at startup. Drives the gear
+        /// button's yellow dot and the "更新至新版" menu item.</summary>
+        public bool IsUpdateAvailable
+        {
+            get => _isUpdateAvailable;
+            private set
+            {
+                if (SetProperty(ref _isUpdateAvailable, value))
+                {
+                    OnPropertyChanged(nameof(UpdateBadgeVisibility));
+                    OnPropertyChanged(nameof(UpdateMenuText));
+                }
+            }
+        }
+
+        public Visibility UpdateBadgeVisibility => _isUpdateAvailable ? Visibility.Visible : Visibility.Collapsed;
+        public string     UpdateMenuText        => $"发现新版本 {_availableUpdate?.NewVersion}";
+
+        /// <summary>Called from MainViewModel after the background check completes.
+        /// Pass null to clear (e.g. after a failed update attempt).</summary>
+        public void SetAvailableUpdate(UpdateInfo? info)
+        {
+            _availableUpdate = info;
+            IsUpdateAvailable = info is not null;
+        }
+
+        [RelayCommand]
+        private async Task UpdateAppAsync()
+        {
+            var info = _availableUpdate;
+            if (info is null) return;
+
+            // Route the download through xray when it's running so users behind GFW
+            // can still reach github.com / objects.githubusercontent.com.
+            var proxy = IsRunning ? $"socks5://127.0.0.1:{LocalPort}" : null;
+
+            UpdateStaging? staging = null;
+            try
+            {
+                await _dialogs.ShowProgressDialogAsync("正在更新 XrayUI",
+                    async (progress, ct) =>
+                    {
+                        staging = await _update.DownloadVerifyAndExtractAsync(info, proxy, progress, ct);
+                    });
+            }
+            catch (OperationCanceledException ex) when (ex.CancellationToken.IsCancellationRequested)
+            {
+                // User cancel — silent.
+                return;
+            }
+            catch (Exception ex)
+            {
+                await _dialogs.ShowErrorAsync("更新失败", ex.Message);
+                return;
+            }
+
+            if (staging is null) return;
+
+            // Stop xray + clear proxy + cleanup TUN state before handing control to
+            // the standalone updater. App.RequestShutdown will additionally run
+            // CleanupOnExit but doing it here keeps shutdown fast and predictable.
+            await StopCurrentSessionAsync();
+
+            _update.LaunchUpdater(staging);
+
+            if (Microsoft.UI.Xaml.Application.Current is App app)
+                app.RequestShutdown();
+            else
+                Environment.Exit(0);
         }
     }
 }

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -875,17 +875,28 @@ namespace XrayUI.ViewModels
 
             if (staging is null) return;
 
-            // Stop xray + clear proxy + cleanup TUN state before handing control to
-            // the standalone updater. App.RequestShutdown will additionally run
-            // CleanupOnExit but doing it here keeps shutdown fast and predictable.
-            await StopCurrentSessionAsync();
-
-            _update.LaunchUpdater(staging);
+            // Start the updater first; it waits for our PID to exit. The normal
+            // interactive stop path can block on route/process cleanup, so update
+            // handoff uses the bounded shutdown cleanup instead.
+            try
+            {
+                _update.LaunchUpdater(staging);
+            }
+            catch (Exception ex)
+            {
+                await _dialogs.ShowErrorAsync("更新失败", "无法启动升级器：" + ex.Message);
+                return;
+            }
 
             if (Microsoft.UI.Xaml.Application.Current is App app)
-                app.RequestShutdown();
+                app.RequestShutdown(fastShutdown: true);
             else
+            {
+                SystemProxyService.ClearProxy();
+                _xray.StopForShutdown();
+                CleanupTunOnExit(fastShutdown: true);
                 Environment.Exit(0);
+            }
         }
     }
 }

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -272,9 +272,6 @@ namespace XrayUI.ViewModels
             _activeServerName = server.Name;
             IsRunning = true;
 
-            // Warm up connectivity in the background after TUN startup.
-            if (IsTunMode)
-                _ = WarmUpTunInBackgroundAsync();
 
             return true;
         }
@@ -372,38 +369,7 @@ namespace XrayUI.ViewModels
             await _dialogs.ShowErrorAsync("应用新配置失败", detail);
         }
 
-        /// <summary>
-        /// 后台轻量预热：发几个 HTTP 探测让 Windows 路由表和 DNS 缓存生效。
-        /// 最多 3 轮 × 1.5s 超时 + 500ms 间隔 ≈ 最坏 ~7 秒，且完全不阻塞 UI。
-        /// </summary>
-        private async Task WarmUpTunInBackgroundAsync()
-        {
-            try
-            {
-                using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(1.5) };
 
-                for (var attempt = 1; attempt <= 3; attempt++)
-                {
-                    try
-                    {
-                        using var response = await client.GetAsync("https://www.gstatic.com/generate_204",
-                            HttpCompletionOption.ResponseHeadersRead);
-                        if ((int)response.StatusCode < 500)
-                            return;
-                    }
-                    catch
-                    {
-                        // Ignore and retry.
-                    }
-
-                    await Task.Delay(500);
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"[TUN] 后台预热异常: {ex.Message}");
-            }
-        }
 
         private void CleanupTunRoutesSafely()
         {

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using XrayUI.Helpers;

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -35,6 +35,7 @@ namespace XrayUI.ViewModels
         private string? _currentTunServerHost;
 
         public XrayService XrayService => _xray;
+        public SettingsService SettingsService => _settings;
 
         public Func<ServerEntry?> GetSelectedServer { get; set; } = () => null;
 

--- a/ViewModels/CustomRulesViewModel.cs
+++ b/ViewModels/CustomRulesViewModel.cs
@@ -177,7 +177,7 @@ namespace XrayUI.ViewModels
             }
             catch (OperationCanceledException ex) when (ex.GetType() == typeof(OperationCanceledException))
             {
-                // DialogService throws exactly `new OperationCanceledException()` for user cancel.
+                // DialogService throws exactly `OperationCanceledException` for user cancel.
                 // Any subclass (e.g. TaskCanceledException from HttpClient.Timeout) falls through
                 // to the generic Exception catch below so the failure is surfaced, not swallowed.
                 return;

--- a/ViewModels/CustomRulesViewModel.cs
+++ b/ViewModels/CustomRulesViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;

--- a/ViewModels/CustomRulesViewModel.cs
+++ b/ViewModels/CustomRulesViewModel.cs
@@ -3,7 +3,6 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.UI.Xaml;
 using XrayUI.Models;
 using XrayUI.Services;
 

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using XrayUI.Models;
 using XrayUI.Services;
@@ -10,6 +11,9 @@ namespace XrayUI.ViewModels
     {
         private readonly SettingsService _settings;
         private readonly StartupService _startupService;
+        private readonly IUpdateService _updateService;
+        private readonly Microsoft.UI.Dispatching.DispatcherQueue? _uiDispatcher;
+        private bool _updateCheckQueued;
         private ServerEntry? _activeServer;
         private string _activeLatencyText = string.Empty;
         private bool _showPersonalize;
@@ -50,10 +54,16 @@ namespace XrayUI.ViewModels
             SettingsService settings,
             XrayService     xray,
             TunService      tunService,
-            StartupService  startupService)
+            StartupService  startupService,
+            IUpdateService  updateService)
         {
             _settings       = settings;
             _startupService = startupService;
+            _updateService  = updateService;
+            // MainViewModel is constructed on the UI thread (in MainWindow ctor before
+            // InitializeComponent), so capturing the dispatcher here is safe and avoids
+            // depending on Application.Current later from a background thread.
+            _uiDispatcher   = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
             var latencyProbe = new LatencyProbeService(
                 new TcpConnectProbeService(),
                 new PingProbeService());
@@ -63,7 +73,7 @@ namespace XrayUI.ViewModels
 
             ServerList   = new ServerListViewModel(dialogs, settings);
             ServerDetail = new ServerDetailViewModel(latencyProbe, aiUnlockCheck);
-            ControlPanel = new ControlPanelViewModel(dialogs, settings, xray, tunService, startupService);
+            ControlPanel = new ControlPanelViewModel(dialogs, settings, xray, tunService, startupService, updateService);
             Personalize  = new PersonalizeViewModel(settings);
 
             // Wire ControlPanel so it knows the current selected server
@@ -126,6 +136,41 @@ namespace XrayUI.ViewModels
             // (which passes --startup-minimized). Manual launches must not auto-connect.
             if (isBootLaunch && s.IsStartupEnabled && s.IsAutoConnect)
                 await TryAutoConnectAsync(s);
+
+            // Fire-and-forget background tasks. Failures here must never block
+            // startup or surface as dialogs (per the auto-update failure policy).
+            _ = Task.Run(() => _updateService.CleanupOldStagingDirs());
+            QueueUpdateCheck(CurrentProxyUrl());
+        }
+
+        private string? CurrentProxyUrl() =>
+            ControlPanel.IsRunning ? $"socks5://127.0.0.1:{ControlPanel.LocalPort}" : null;
+
+        private void QueueUpdateCheck(string? proxyUrl)
+        {
+            if (_updateCheckQueued) return;
+            _updateCheckQueued = true;
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    var info = await _updateService.CheckAsync(proxyUrl, CancellationToken.None);
+                    if (info is null)
+                    {
+                        // Allow one retry path: e.g. direct check failed because the
+                        // user is behind GFW; once xray comes up the recheck in
+                        // OnControlPanelPropertyChanged can try again via SOCKS.
+                        _updateCheckQueued = false;
+                        return;
+                    }
+                    _uiDispatcher?.TryEnqueue(() => ControlPanel.SetAvailableUpdate(info));
+                }
+                catch
+                {
+                    _updateCheckQueued = false;
+                }
+            });
         }
 
         private async Task TryAutoConnectAsync(AppSettings s)
@@ -228,6 +273,9 @@ namespace XrayUI.ViewModels
             SwitchToSelectedServerCommand.NotifyCanExecuteChanged();
 
             ServerDetail.OnProxyRunningChanged(isRunning, ControlPanel.LocalPort);
+
+            if (isRunning && !ControlPanel.IsUpdateAvailable)
+                QueueUpdateCheck(CurrentProxyUrl());
         }
 
         private void UpdateActiveServer(ServerEntry? server)

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,8 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
-using CommunityToolkit.Mvvm.Input;
-using Microsoft.UI.Xaml;
 using XrayUI.Models;
 using XrayUI.Services;
 

--- a/ViewModels/ManageSubscriptionsViewModel.cs
+++ b/ViewModels/ManageSubscriptionsViewModel.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
-using Microsoft.UI.Xaml;
 using XrayUI.Models;
 
 namespace XrayUI.ViewModels

--- a/ViewModels/ServerDetailViewModel.cs
+++ b/ViewModels/ServerDetailViewModel.cs
@@ -2,9 +2,6 @@
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using XrayUI.Models;
 using XrayUI.Services;

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -819,7 +819,7 @@ namespace XrayUI.ViewModels
             Servers.Remove(toRemove);
 
             SelectedServer = Servers.Count > 0
-                ? Servers[System.Math.Max(0, idx - 1)]
+                ? Servers[Math.Max(0, idx - 1)]
                 : null;
 
             await SaveAsync();

--- a/Views/ControlPanelControl.xaml
+++ b/Views/ControlPanelControl.xaml
@@ -36,10 +36,22 @@
                         BorderBrush="Transparent"
                         VerticalAlignment="Center"
                         Padding="8">
-                    <FontIcon Glyph="&#xE713;" FontSize="16" />
+                    <Grid Width="20" Height="20">
+                        <FontIcon Glyph="&#xE713;" FontSize="16"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center" />
+                        <InfoBadge Style="{StaticResource AttentionDotInfoBadgeStyle}"
+                                   HorizontalAlignment="Right" VerticalAlignment="Top"
+                                   Height="6" Width="6"
+                                   Visibility="{x:Bind ViewModel.UpdateBadgeVisibility, Mode=OneWay}" />
+                    </Grid>
                     <Button.Flyout>
                         <MenuFlyout>
-                            <MenuFlyoutItem Text="编辑本地端口" 
+                            <MenuFlyoutItem Text="{x:Bind ViewModel.UpdateMenuText, Mode=OneWay}"
+                                            Command="{x:Bind ViewModel.UpdateAppCommand}"
+                                            Visibility="{x:Bind ViewModel.UpdateBadgeVisibility, Mode=OneWay}" />
+                            <MenuFlyoutSeparator Visibility="{x:Bind ViewModel.UpdateBadgeVisibility, Mode=OneWay}" />
+                            <MenuFlyoutItem Text="编辑本地端口"
                                             Command="{x:Bind ViewModel.EditLocalPortCommand}" />
                             <MenuFlyoutItem Text="查看日志" 
                                             Command="{x:Bind ViewModel.ShowLogsCommand}" />

--- a/Views/ControlPanelControl.xaml.cs
+++ b/Views/ControlPanelControl.xaml.cs
@@ -62,7 +62,10 @@ namespace XrayUI.Views
         {
             if (_logWindow is null)
             {
-                _logWindow = new LogWindow(ViewModel.XrayService);
+                _logWindow = new LogWindow(
+                    ViewModel.XrayService,
+                    ViewModel.SettingsService,
+                    ViewModel.ReapplyRoutingAsync);
                 _logWindow.Closed += (_, _) => _logWindow = null;
             }
             _logWindow.Activate();

--- a/Views/CustomRulesWindow.xaml.cs
+++ b/Views/CustomRulesWindow.xaml.cs
@@ -2,12 +2,9 @@
 using System.Runtime.InteropServices;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Windows.Graphics;
 using XrayUI.Helpers;
 using XrayUI.Models;
-using XrayUI.ViewModels;
 
 namespace XrayUI.Views
 {

--- a/Views/LogWindow.xaml
+++ b/Views/LogWindow.xaml
@@ -60,6 +60,38 @@
                 <StackPanel Grid.Column="1"
                             Orientation="Horizontal"
                             Spacing="8">
+                    <Button x:Name="LogPrivacyButton"
+                            Padding="8,5"
+                            ToolTipService.ToolTip="日志隐私设置">
+                        <FontIcon Glyph="&#xE72E;"
+                                  FontSize="13" />
+                        <Button.Flyout>
+                            <MenuFlyout>
+                                <MenuFlyoutSubItem Text="IP地址遮罩">
+                                    <RadioMenuFlyoutItem x:Name="MaskOffMenuItem"
+                                                         Text="关闭"
+                                                         GroupName="LogMaskAddressGroup"
+                                                         Tag=""
+                                                         Click="MaskAddressMenuItem_Click" />
+                                    <RadioMenuFlyoutItem x:Name="MaskQuarterMenuItem"
+                                                         Text="quarter"
+                                                         GroupName="LogMaskAddressGroup"
+                                                         Tag="quarter"
+                                                         Click="MaskAddressMenuItem_Click" />
+                                    <RadioMenuFlyoutItem x:Name="MaskHalfMenuItem"
+                                                         Text="half"
+                                                         GroupName="LogMaskAddressGroup"
+                                                         Tag="half"
+                                                         Click="MaskAddressMenuItem_Click" />
+                                    <RadioMenuFlyoutItem x:Name="MaskFullMenuItem"
+                                                         Text="full"
+                                                         GroupName="LogMaskAddressGroup"
+                                                         Tag="full"
+                                                         Click="MaskAddressMenuItem_Click" />
+                                </MenuFlyoutSubItem>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
                     <ToggleButton x:Name="AutoScrollToggle"
                                   IsChecked="True"
                                   Content="自动滚动"

--- a/Views/LogWindow.xaml.cs
+++ b/Views/LogWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Media;
 using Windows.ApplicationModel.DataTransfer;
@@ -20,17 +21,24 @@ namespace XrayUI.Views
             new(Windows.UI.Color.FromArgb(255, 156, 163, 175)); // grey
 
         private readonly XrayService     _xray;
+        private readonly SettingsService _settings;
+        private readonly Func<Task> _reapplyConfigAsync;
         private readonly DispatcherQueue _queue;
         private readonly DispatcherQueueTimer _flushTimer;
 
         // Set from background thread when new lines arrive; consumed on UI thread.
         private volatile bool _dirty;
 
-        public LogWindow(XrayService xray)
+        public LogWindow(
+            XrayService xray,
+            SettingsService settings,
+            Func<Task> reapplyConfigAsync)
         {
             this.InitializeComponent();
-            _xray  = xray;
-            _queue = DispatcherQueue.GetForCurrentThread();
+            _xray               = xray;
+            _settings           = settings;
+            _reapplyConfigAsync = reapplyConfigAsync;
+            _queue              = DispatcherQueue.GetForCurrentThread();
 
             var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
             var scale = DpiHelper.GetWindowScale(hWnd);
@@ -42,6 +50,7 @@ namespace XrayUI.Views
 
             RenderLog();
             UpdateStatus();
+            _ = InitializeMaskAddressMenuAsync();
 
             _flushTimer = _queue.CreateTimer();
             _flushTimer.Interval = FlushInterval;
@@ -94,6 +103,27 @@ namespace XrayUI.Views
             LineCountText.Text = $"({lines.Count} 行)";
         }
 
+        private async Task InitializeMaskAddressMenuAsync()
+        {
+            try
+            {
+                var settings = await _settings.LoadSettingsAsync();
+                SetMaskAddressSelection(LogMaskAddress.Normalize(settings.LogMaskAddress));
+            }
+            catch
+            {
+                SetMaskAddressSelection(LogMaskAddress.Off);
+            }
+        }
+
+        private void SetMaskAddressSelection(string value)
+        {
+            MaskOffMenuItem.IsChecked     = value == LogMaskAddress.Off;
+            MaskQuarterMenuItem.IsChecked = value == LogMaskAddress.Quarter;
+            MaskHalfMenuItem.IsChecked    = value == LogMaskAddress.Half;
+            MaskFullMenuItem.IsChecked    = value == LogMaskAddress.Full;
+        }
+
         private void UpdateStatus()
         {
             var running = _xray.IsRunning;
@@ -114,6 +144,60 @@ namespace XrayUI.Views
         {
             _xray.ClearLogBuffer();
             RenderLog();
+        }
+
+        private async void MaskAddressMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not RadioMenuFlyoutItem item)
+            {
+                return;
+            }
+
+            var value = LogMaskAddress.Normalize(item.Tag as string);
+            SetMaskAddressSelection(value);
+
+            try
+            {
+                var settings = await _settings.LoadSettingsAsync();
+                if (LogMaskAddress.Normalize(settings.LogMaskAddress) == value)
+                {
+                    return;
+                }
+
+                settings.LogMaskAddress = value;
+                await _settings.SaveSettingsAsync(settings);
+
+                if (!_xray.IsRunning)
+                {
+                    return;
+                }
+
+                if (settings.IsTunMode)
+                {
+                    await ShowInfoAsync("日志隐私设置", "已保存，当前 TUN 会话下次启动时生效。");
+                    return;
+                }
+
+                await _reapplyConfigAsync();
+            }
+            catch (Exception ex)
+            {
+                await ShowInfoAsync("日志隐私设置", $"保存失败：{ex.Message}");
+            }
+        }
+
+        private async Task ShowInfoAsync(string title, string message)
+        {
+            var dialog = new ContentDialog
+            {
+                XamlRoot = Content.XamlRoot,
+                RequestedTheme = ThemeHelper.ActualTheme,
+                Title = title,
+                Content = message,
+                CloseButtonText = "确定"
+            };
+
+            await dialog.ShowAsync();
         }
     }
 }

--- a/Views/ManageSubscriptionsDialog.xaml.cs
+++ b/Views/ManageSubscriptionsDialog.xaml.cs
@@ -1,9 +1,6 @@
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using XrayUI.Models;
-using XrayUI.ViewModels;
 
 namespace XrayUI.Views
 {

--- a/Views/PersonalizeControl.xaml.cs
+++ b/Views/PersonalizeControl.xaml.cs
@@ -11,7 +11,7 @@ namespace XrayUI.Views
             this.InitializeComponent();
         }
 
-        private async void ExportPresetButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        private async void ExportPresetButton_Click(object sender, RoutedEventArgs e)
         {
             try
             {

--- a/Views/ServerListControl.xaml.cs
+++ b/Views/ServerListControl.xaml.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Linq;
-using CommunityToolkit.Mvvm.Input;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Windows.Foundation;

--- a/XrayUI-dev.csproj
+++ b/XrayUI-dev.csproj
@@ -14,6 +14,7 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <WindowsPackageType>None</WindowsPackageType>
+    <RemoveUnusedWindowsMlNativeAssetsFromPublish>true</RemoveUnusedWindowsMlNativeAssetsFromPublish>
   </PropertyGroup>
 
 
@@ -30,8 +31,8 @@
   <ItemGroup>
     <Compile Remove="XrayUI.Updater\**" />
     <Content Remove="XrayUI.Updater\**" />
-    <None    Remove="XrayUI.Updater\**" />
-    <Page    Remove="XrayUI.Updater\**" />
+    <None Remove="XrayUI.Updater\**" />
+    <Page Remove="XrayUI.Updater\**" />
     <ApplicationDefinition Remove="XrayUI.Updater\**" />
   </ItemGroup>
 
@@ -66,8 +67,8 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.2.251219" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260416003" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
     <PackageReference Include="WinUIEx" Version="2.9.0" />
   </ItemGroup>
 
@@ -99,6 +100,17 @@
     </Content>
   </ItemGroup>
 
+  <!-- Windows App SDK 2.x brings Windows ML as a transitive component. XrayUI does
+       not use local ML inference, so keep those native runtime DLLs out of publish
+       folders even when publishing to a custom output path. -->
+  <Target Name="CleanUnusedWindowsMlNativeAssetsFromPublish" AfterTargets="Publish;PublishUpdaterAlongside" Condition="'$(RemoveUnusedWindowsMlNativeAssetsFromPublish)' == 'true'">
+    <ItemGroup>
+      <_UnusedWindowsMlNativeAsset Include="$(PublishDir)DirectML.dll;$(PublishDir)onnxruntime.dll;$(PublishDir)Microsoft.Windows.AI.MachineLearning.dll" />
+      <_ExistingUnusedWindowsMlNativeAsset Include="@(_UnusedWindowsMlNativeAsset)" Condition="Exists('%(_UnusedWindowsMlNativeAsset.Identity)')" />
+    </ItemGroup>
+    <Delete Files="@(_ExistingUnusedWindowsMlNativeAsset)" />
+  </Target>
+
   <!-- Auto-publish the standalone Updater alongside the main app on local
        `dotnet publish`, so testing the in-app upgrade flow doesn't require
        running two commands. CI bypasses this with -p:BuildingForCI=true
@@ -110,7 +122,7 @@
     <PropertyGroup>
       <UpdaterStagingDir>$(IntermediateOutputPath)updater-publish\</UpdaterStagingDir>
     </PropertyGroup>
-    <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)XrayUI.Updater\XrayUI.Updater.csproj&quot; -c $(Configuration) -r $(RuntimeIdentifier) -p:SelfContained=true -p:PublishAot=true -p:PublishTrimmed=true -p:PublishSingleFile=false -p:Version=$(Version) -o &quot;$(UpdaterStagingDir)&quot;"
+    <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)XrayUI.Updater\XrayUI.Updater.csproj&quot; -c $(Configuration) -r $(RuntimeIdentifier) -p:SelfContained=true -p:PublishAot=true -p:PublishTrimmed=true -p:PublishSingleFile=false -p:Version=$(Version) -o &quot;$(UpdaterStagingDir)&quot;" 
           EnvironmentVariables="DOTNET_CLI_UI_LANGUAGE=en" />
     <Copy SourceFiles="$(UpdaterStagingDir)XrayUI.Updater.exe"
           DestinationFolder="$(PublishDir)" />

--- a/XrayUI-dev.csproj
+++ b/XrayUI-dev.csproj
@@ -25,6 +25,16 @@
     <Content Remove="Assets\rules\geosite.dat" />
   </ItemGroup>
 
+  <!-- The standalone Updater lives in a sibling project; exclude it from the main app's
+       default file globs so we don't double-include its sources / Program.cs entry point. -->
+  <ItemGroup>
+    <Compile Remove="XrayUI.Updater\**" />
+    <Content Remove="XrayUI.Updater\**" />
+    <None    Remove="XrayUI.Updater\**" />
+    <Page    Remove="XrayUI.Updater\**" />
+    <ApplicationDefinition Remove="XrayUI.Updater\**" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Include="Assets\engine\xray.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -78,10 +88,33 @@
     <ApplicationIcon>Assets\Icons\output.ico</ApplicationIcon>
   </PropertyGroup>
 
+  <!-- Version: defaults for local builds; CI overrides via -p:Version=<tag> -->
+  <PropertyGroup>
+    <Version Condition="'$(Version)' == ''">0.0.0-dev</Version>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Update="Assets\Icons\output.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  
+
+  <!-- Auto-publish the standalone Updater alongside the main app on local
+       `dotnet publish`, so testing the in-app upgrade flow doesn't require
+       running two commands. CI bypasses this with -p:BuildingForCI=true
+       (it publishes the updater explicitly to keep step logs separated).
+       Skipped when no RID is set (e.g. plain `dotnet build`) since the
+       Exec would otherwise emit a malformed `-r` flag. -->
+  <Target Name="PublishUpdaterAlongside" AfterTargets="Publish"
+          Condition="'$(BuildingForCI)' != 'true' and '$(RuntimeIdentifier)' != ''">
+    <PropertyGroup>
+      <UpdaterStagingDir>$(IntermediateOutputPath)updater-publish\</UpdaterStagingDir>
+    </PropertyGroup>
+    <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)XrayUI.Updater\XrayUI.Updater.csproj&quot; -c $(Configuration) -r $(RuntimeIdentifier) -p:SelfContained=true -p:PublishAot=true -p:PublishTrimmed=true -p:PublishSingleFile=false -p:Version=$(Version) -o &quot;$(UpdaterStagingDir)&quot;"
+          EnvironmentVariables="DOTNET_CLI_UI_LANGUAGE=en" />
+    <Copy SourceFiles="$(UpdaterStagingDir)XrayUI.Updater.exe"
+          DestinationFolder="$(PublishDir)" />
+    <Message Text="Bundled XrayUI.Updater.exe into $(PublishDir)" Importance="high" />
+  </Target>
+
 </Project>

--- a/XrayUI-dev.slnx
+++ b/XrayUI-dev.slnx
@@ -10,4 +10,5 @@
     <Platform Solution="*|x86" Project="x86" />
     <Deploy />
   </Project>
+  <Project Path="XrayUI.Updater/XrayUI.Updater.csproj" />
 </Solution>

--- a/XrayUI.Updater/Program.cs
+++ b/XrayUI.Updater/Program.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Security.Principal;
+using System.Threading;
+
+namespace XrayUI.Updater;
+
+internal static class Program
+{
+    private const string ParentPidArg    = "--parent-pid=";
+    private const string ExtractedDirArg = "--extracted-dir=";
+    private const string InstallDirArg   = "--install-dir=";
+    private const string LaunchAfterArg  = "--launch-after=";
+    private const string ElevatedFlag    = "--elevated";
+
+    private const int CopyRetryCount     = 5;
+    private const int CopyRetryDelayMs   = 200;
+    private const int ParentExitTimeoutMs = 15_000;
+
+    private static StreamWriter? _log;
+
+    private static int Main(string[] args)
+    {
+        try
+        {
+            int? parentPid = null;
+            string? extractedDir = null, installDir = null, launchAfter = null;
+            var elevated = false;
+
+            foreach (var a in args)
+            {
+                if (a.StartsWith(ParentPidArg, StringComparison.OrdinalIgnoreCase))
+                    parentPid = int.TryParse(a[ParentPidArg.Length..], out var p) ? p : null;
+                else if (a.StartsWith(ExtractedDirArg, StringComparison.OrdinalIgnoreCase))
+                    extractedDir = a[ExtractedDirArg.Length..];
+                else if (a.StartsWith(InstallDirArg, StringComparison.OrdinalIgnoreCase))
+                    installDir = a[InstallDirArg.Length..];
+                else if (a.StartsWith(LaunchAfterArg, StringComparison.OrdinalIgnoreCase))
+                    launchAfter = a[LaunchAfterArg.Length..];
+                else if (string.Equals(a, ElevatedFlag, StringComparison.OrdinalIgnoreCase))
+                    elevated = true;
+            }
+
+            if (parentPid is null || string.IsNullOrEmpty(extractedDir) ||
+                string.IsNullOrEmpty(installDir) || string.IsNullOrEmpty(launchAfter))
+            {
+                Console.Error.WriteLine("Usage: XrayUI.Updater --parent-pid=N --extracted-dir=PATH --install-dir=PATH --launch-after=NAME [--elevated]");
+                return 2;
+            }
+
+            OpenLog(installDir);
+            Log($"Updater started. parent={parentPid}, elevated={elevated}");
+            Log($"  extracted-dir = {extractedDir}");
+            Log($"  install-dir   = {installDir}");
+            Log($"  launch-after  = {launchAfter}");
+
+            WaitForParentExit(parentPid.Value);
+
+            if (!TryEnsureWritable(installDir))
+            {
+                if (!elevated)
+                {
+                    Log("Install dir not writable; relaunching elevated…");
+                    RelaunchElevated(args);
+                    return 0;
+                }
+                Log("Install dir still not writable after elevation. Aborting.");
+                return 3;
+            }
+
+            CopyOverwrite(extractedDir, installDir);
+            Log("Copy complete.");
+
+            var newExe = Path.Combine(installDir, launchAfter);
+            if (!File.Exists(newExe))
+            {
+                Log($"New app exe not found after update: {newExe}. Aborting launch.");
+                return 4;
+            }
+
+            // Launch the new app unelevated. Even if we elevated to do the file
+            // overwrite, the app itself should run under the user's normal token.
+            try
+            {
+                LaunchApp(newExe, installDir);
+                Log("New app launched.");
+            }
+            catch (Exception ex)
+            {
+                Log($"Failed to launch new app: {ex}");
+                return 5;
+            }
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            try { Log($"Fatal: {ex}"); } catch { }
+            return 1;
+        }
+        finally
+        {
+            try { _log?.Flush(); _log?.Dispose(); } catch { }
+        }
+    }
+
+    private static void WaitForParentExit(int pid)
+    {
+        try
+        {
+            using var parent = Process.GetProcessById(pid);
+            if (!parent.WaitForExit(ParentExitTimeoutMs))
+            {
+                Log($"Parent {pid} did not exit within {ParentExitTimeoutMs} ms; continuing anyway.");
+            }
+        }
+        catch (ArgumentException)
+        {
+            // Process already gone — that's fine.
+        }
+        catch (Exception ex)
+        {
+            Log($"WaitForParentExit error: {ex.Message}");
+        }
+    }
+
+    private static bool TryEnsureWritable(string installDir)
+    {
+        try
+        {
+            var probe = Path.Combine(installDir, ".xrayui-write-test");
+            File.WriteAllText(probe, string.Empty);
+            File.Delete(probe);
+            return true;
+        }
+        catch (UnauthorizedAccessException ex) { Log($"Write probe denied: {ex.Message}"); return false; }
+        catch (IOException ex)                 { Log($"Write probe IO error: {ex.Message}"); return false; }
+    }
+
+    private static void RelaunchElevated(string[] originalArgs)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName        = Environment.ProcessPath ?? "XrayUI.Updater.exe",
+            UseShellExecute = true,
+            Verb            = "runas",
+        };
+        foreach (var a in originalArgs) psi.ArgumentList.Add(a);
+        psi.ArgumentList.Add(ElevatedFlag);
+        Process.Start(psi);
+    }
+
+    private static void CopyOverwrite(string source, string dest)
+    {
+        Directory.CreateDirectory(dest);
+
+        var copied = 0;
+        string? currentFile = null;
+        try
+        {
+            foreach (var srcFile in Directory.EnumerateFiles(source, "*", SearchOption.AllDirectories))
+            {
+                currentFile = Path.GetRelativePath(source, srcFile);
+                var dstFile = Path.Combine(dest, currentFile);
+                var dstDir  = Path.GetDirectoryName(dstFile);
+                if (!string.IsNullOrEmpty(dstDir))
+                    Directory.CreateDirectory(dstDir);
+
+                CopyWithRetry(srcFile, dstFile);
+                copied++;
+            }
+            Log($"Copied {copied} files into {dest}");
+        }
+        catch (Exception ex)
+        {
+            // We deliberately do NOT auto-rollback: it would require pre-copying every
+            // existing file to a backup location (~doubling the disk footprint of the
+            // upgrade) and most failures here are transient/permission issues that
+            // re-running the updater (or a manual extract) can resolve. Surface a
+            // detailed log so the user can see exactly what to retry.
+            Log($"Copy aborted after {copied} files. Failed on '{currentFile}': {ex.Message}");
+            throw;
+        }
+    }
+
+    private static void CopyWithRetry(string src, string dst)
+    {
+        for (var attempt = 0; attempt < CopyRetryCount; attempt++)
+        {
+            try
+            {
+                File.Copy(src, dst, overwrite: true);
+                return;
+            }
+            catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException)
+                                    && attempt < CopyRetryCount - 1)
+            {
+                Log($"Copy retry {attempt + 1}/{CopyRetryCount} for {dst}: {ex.Message}");
+                Thread.Sleep(CopyRetryDelayMs);
+            }
+        }
+        // Final attempt without catching — let it throw to abort the update.
+        File.Copy(src, dst, overwrite: true);
+    }
+
+    private static void LaunchApp(string exePath, string workingDirectory)
+    {
+        if (IsElevated())
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName        = "explorer.exe",
+                    Arguments       = QuoteForCommandLine(exePath),
+                    UseShellExecute = true,
+                });
+                return;
+            }
+            catch (Exception ex)
+            {
+                Log($"Unelevated launch via Explorer failed: {ex.Message}");
+            }
+        }
+
+        Process.Start(new ProcessStartInfo
+        {
+            FileName         = exePath,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute  = true,
+        });
+    }
+
+    private static bool IsElevated()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+        return new WindowsPrincipal(identity).IsInRole(WindowsBuiltInRole.Administrator);
+    }
+
+    private static string QuoteForCommandLine(string value) =>
+        "\"" + value.Replace("\"", "\\\"") + "\"";
+
+    private static void OpenLog(string installDir)
+    {
+        try
+        {
+            var logRoot = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "XrayUI", "Updates");
+            Directory.CreateDirectory(logRoot);
+            var path = Path.Combine(logRoot, "updater.log");
+            _log = new StreamWriter(new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read))
+            {
+                AutoFlush = true,
+            };
+        }
+        catch
+        {
+            _log = null; // logging is best-effort
+        }
+    }
+
+    private static void Log(string msg)
+    {
+        var line = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] {msg}";
+        try { _log?.WriteLine(line); } catch { }
+        try { Console.WriteLine(line); } catch { }
+    }
+}

--- a/XrayUI.Updater/Program.cs
+++ b/XrayUI.Updater/Program.cs
@@ -79,6 +79,8 @@ internal static class Program
                 return 4;
             }
 
+            CleanupLargeStagingDirs(extractedDir);
+
             // Launch the new app unelevated. Even if we elevated to do the file
             // overwrite, the app itself should run under the user's normal token.
             try
@@ -202,6 +204,32 @@ internal static class Program
         }
         // Final attempt without catching — let it throw to abort the update.
         File.Copy(src, dst, overwrite: true);
+    }
+
+    private static void CleanupLargeStagingDirs(string extractedDir)
+    {
+        var stageRoot = Directory.GetParent(extractedDir)?.FullName;
+        if (string.IsNullOrEmpty(stageRoot))
+            return;
+
+        DeleteDirectoryBestEffort(Path.Combine(stageRoot, "download"));
+        DeleteDirectoryBestEffort(extractedDir);
+    }
+
+    private static void DeleteDirectoryBestEffort(string path)
+    {
+        try
+        {
+            if (!Directory.Exists(path))
+                return;
+
+            Directory.Delete(path, recursive: true);
+            Log($"Deleted staging directory: {path}");
+        }
+        catch (Exception ex)
+        {
+            Log($"Could not delete staging directory '{path}': {ex.Message}");
+        }
     }
 
     private static void LaunchApp(string exePath, string workingDirectory)

--- a/XrayUI.Updater/XrayUI.Updater.csproj
+++ b/XrayUI.Updater/XrayUI.Updater.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>XrayUI.Updater</RootNamespace>
+    <AssemblyName>XrayUI.Updater</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Version Condition="'$(Version)' == ''">0.0.0-dev</Version>
+  </PropertyGroup>
+</Project>

--- a/XrayUI.Updater/app.manifest
+++ b/XrayUI.Updater/app.manifest
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="XrayUI.Updater"/>
+
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- Run unprivileged by default. We test write access at runtime and
+             relaunch ourselves with verb="runas" only when the install dir
+             actually requires admin rights. -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
## Summary
- **In-app auto-update**: new `XrayUI.Updater` standalone project + `UpdateService` for self-update flow; release workflow updated to publish update artifacts. Local `dotnet publish` now auto-bundles `XrayUI.Updater.exe` via a `PublishUpdaterAlongside` target (CI publishes it explicitly with `-p:BuildingForCI=true`)
- **Log IP masking**: configurable IP masking in logs via new `LogMaskAddress` / `FinalmaskJson`, surfaced in LogWindow + persisted in AppSettings
- **Windows App SDK 2.0** upgrade — bumped `Microsoft.WindowsAppSDK` 1.8 → 2.0.1, `SDK.BuildTools` to 10.0.28000.1839
  - SDK 2.x pulls in **Windows ML** as a transitive native component. Since XrayUI doesn't do local ML inference, AOT publish now strips `DirectML.dll`, `onnxruntime.dll`, and `Microsoft.Windows.AI.MachineLearning.dll` via a `CleanUnusedWindowsMlNativeAssetsFromPublish` target (gated on `RemoveUnusedWindowsMlNativeAssetsFromPublish=true`). Keeps publish size lean
  - Excluded `XrayUI.Updater\**` from the main app's default file globs to avoid double-including its sources
- Remove warm-up step for TUN mode
- Misc cleanup (redundant usings, small fixes)

## Notable files
- `XrayUI.Updater/` — new standalone updater project (~300 LOC)
- `Services/UpdateService.cs` + `IUpdateService.cs` + `Models/UpdateInfo.cs`
- `Services/LogMaskAddress.cs` + `FinalmaskJson.cs`
- `Helpers/AppPaths.cs` + `AppVersion.cs`
- `XrayUI-dev.csproj` — SDK 2.0 bump, ML DLL stripping target, updater bundling target
- `.github/workflows/release.yml` — updater artifact publishing

## Test plan
- [x] Trigger in-app update from an older version → updater launches, replaces binary, restarts
- [x] Enable log IP masking → verify IPs in LogWindow are masked per `Finalmask` config
- [x] TUN mode connect/disconnect still works without warm-up
- [ ] Settings round-trip for new AppSettings fields