### PR TITLE
Add server favorites, detail display toggles, and update progress UI

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -21,11 +21,10 @@
             <converters:ProtocolToBrushConverter x:Key="ProtocolToBrushConverter" />
 
             <!-- State indicator brush palette (AI unlock status) -->
-            <SolidColorBrush x:Key="StateNeutralBrush" Color="#787A82" />
+            <SolidColorBrush x:Key="StateNeutralBrush" Color="{ThemeResource SystemFillColorNeutral}" />
             <SolidColorBrush x:Key="StateSuccessBrush" Color="#48C78E" />
             <SolidColorBrush x:Key="StateErrorBrush"   Color="#EF4444" />
 
-            <SolidColorBrush x:Key="FavoriteBrush" Color="#FF69B4" />
 
             <!-- Danger button brush palette -->
             <SolidColorBrush x:Key="DangerAccentButtonForeground" Color="White" />

--- a/App.xaml
+++ b/App.xaml
@@ -25,6 +25,8 @@
             <SolidColorBrush x:Key="StateSuccessBrush" Color="#48C78E" />
             <SolidColorBrush x:Key="StateErrorBrush"   Color="#EF4444" />
 
+            <SolidColorBrush x:Key="FavoriteBrush" Color="#FF69B4" />
+
             <!-- Danger button brush palette -->
             <SolidColorBrush x:Key="DangerAccentButtonForeground" Color="White" />
             <SolidColorBrush x:Key="DangerAccentButtonForegroundPointerOver" Color="White" />

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -31,6 +31,8 @@ namespace XrayUI.Models
         public string? ColorVmess     { get; set; }
         public string? ColorHysteria2 { get; set; }
         public string? ColorFallback  { get; set; }
+        public bool ShowLatencyInDetails { get; set; } = true;
+        public bool ShowAiUnlockInDetails { get; set; } = true;
 
         // ── Custom routing rules ──────────────────────────────────────────────
         /// <summary>User-defined routing rules. Applied only when RoutingMode == "smart".</summary>

--- a/Models/ServerEntry.cs
+++ b/Models/ServerEntry.cs
@@ -55,6 +55,9 @@ namespace XrayUI.Models
         [ObservableProperty]
         public partial bool IsActive { get; set; }
 
+        [ObservableProperty]
+        public partial bool IsFavorite { get; set; }
+
         // Auth
         [ObservableProperty]
         public partial string Password { get; set; }

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -447,6 +447,101 @@ namespace XrayUI.Services
             if (cts.IsCancellationRequested) throw new OperationCanceledException(cts.Token);
         }
 
+        public async Task ShowProgressBarDialogAsync(string title, Func<IProgress<ProgressDialogUpdate>, CancellationToken, Task> work, XamlRoot? xamlRoot = null)
+        {
+            using var cts = new CancellationTokenSource();
+
+            var statusText = new TextBlock
+            {
+                Text         = "正在准备…",
+                TextWrapping = TextWrapping.Wrap,
+                MaxWidth     = 320,
+                HorizontalAlignment = HorizontalAlignment.Center,
+            };
+
+            var progressBar = new ProgressBar
+            {
+                IsIndeterminate = true,
+                Minimum         = 0,
+                Maximum         = 100,
+                Width           = 320,
+            };
+
+            var dialog = CreateDialog(xamlRoot);
+            dialog.Title           = title;
+            dialog.CloseButtonText = "取消";
+            dialog.Content = new StackPanel
+            {
+                Spacing             = 12,
+                MinWidth            = 320,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Children            = { progressBar, statusText }
+            };
+
+            var progress = new Progress<ProgressDialogUpdate>(update =>
+            {
+                statusText.Text = update.Message;
+
+                if (update.Percent.HasValue)
+                {
+                    progressBar.IsIndeterminate = false;
+                    progressBar.Value = Math.Clamp(update.Percent.Value, 0, 100);
+                }
+                else
+                {
+                    progressBar.IsIndeterminate = true;
+                }
+            });
+
+            Exception? error   = null;
+            int workFinished = 0;
+
+            dialog.Opened += (_, _) =>
+            {
+                if (Volatile.Read(ref workFinished) == 1)
+                {
+                    try { dialog.Hide(); } catch { }
+                }
+            };
+
+            var workTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await work(progress, cts.Token);
+                }
+                catch (OperationCanceledException) when (cts.IsCancellationRequested)
+                {
+                    // Real user cancel — swallow here, we rethrow a fresh OCE below based on cts state.
+                    // Any *other* OperationCanceledException (e.g. HttpClient.Timeout throwing
+                    // TaskCanceledException with its own internal token) must not be swallowed —
+                    // it falls through to the generic catch so the caller can surface the failure.
+                }
+                catch (Exception ex)
+                {
+                    error = ex;
+                }
+                finally
+                {
+                    Volatile.Write(ref workFinished, 1);
+                    dialog.DispatcherQueue.TryEnqueue(() =>
+                    {
+                        try { dialog.Hide(); } catch { }
+                    });
+                }
+            });
+
+            await dialog.ShowAsync();
+
+            // If the dialog closed because the user clicked Cancel (work still running), signal it.
+            if (Volatile.Read(ref workFinished) == 0) cts.Cancel();
+
+            await workTask;
+
+            if (error != null) throw error;
+            if (cts.IsCancellationRequested) throw new OperationCanceledException(cts.Token);
+        }
+
         // ── Share link ────────────────────────────────────────────────────────
 
         public async Task ShowShareLinkDialogAsync(string serverName, string link)

--- a/Services/IDialogService.cs
+++ b/Services/IDialogService.cs
@@ -22,5 +22,12 @@ namespace XrayUI.Services
         /// </summary>
         /// <param name="xamlRoot">Override which window the dialog is rooted in. Null = MainWindow.</param>
         Task ShowProgressDialogAsync(string title, Func<IProgress<string>, CancellationToken, Task> work, XamlRoot? xamlRoot = null);
+
+        /// <summary>
+        /// Shows a modal dialog with a progress bar + status text while <paramref name="work"/> runs.
+        /// When progress percent is null, the progress bar is indeterminate.
+        /// </summary>
+        /// <param name="xamlRoot">Override which window the dialog is rooted in. Null = MainWindow.</param>
+        Task ShowProgressBarDialogAsync(string title, Func<IProgress<ProgressDialogUpdate>, CancellationToken, Task> work, XamlRoot? xamlRoot = null);
     }
 }

--- a/Services/IUpdateService.cs
+++ b/Services/IUpdateService.cs
@@ -28,7 +28,7 @@ namespace XrayUI.Services
         /// without touching the install dir.
         /// </summary>
         Task<UpdateStaging> DownloadVerifyAndExtractAsync(
-            UpdateInfo info, string? proxyUrl, IProgress<string> progress, CancellationToken ct);
+            UpdateInfo info, string? proxyUrl, IProgress<ProgressDialogUpdate> progress, CancellationToken ct);
 
         /// <summary>
         /// Spawns the staged updater with handoff arguments. Caller is responsible

--- a/Services/ProgressDialogUpdate.cs
+++ b/Services/ProgressDialogUpdate.cs
@@ -1,0 +1,4 @@
+namespace XrayUI.Services
+{
+    public sealed record ProgressDialogUpdate(string Message, double? Percent = null);
+}

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -84,7 +84,7 @@ namespace XrayUI.Services
         }
 
         public async Task<UpdateStaging> DownloadVerifyAndExtractAsync(
-            UpdateInfo info, string? proxyUrl, IProgress<string> progress, CancellationToken ct)
+            UpdateInfo info, string? proxyUrl, IProgress<ProgressDialogUpdate> progress, CancellationToken ct)
         {
             var stageRoot   = Path.Combine(AppPaths.UpdatesDir, info.NewVersion.ToString());
             var downloadDir = Path.Combine(stageRoot, "download");
@@ -104,7 +104,7 @@ namespace XrayUI.Services
             using var client = CreateHttpClient(proxyUrl, TimeSpan.FromMinutes(10));
 
             // ── 1. .sha256 first (small, fail-fast on bad release) ─────────────────
-            progress.Report("正在获取校验文件…");
+            progress.Report(new ProgressDialogUpdate("正在获取校验文件…"));
             string expectedHash;
             try
             {
@@ -129,7 +129,7 @@ namespace XrayUI.Services
                 throw new InvalidDataException("更新包校验失败：SHA256 与服务器公布的不一致。");
 
             // ── 4. Extract ──────────────────────────────────────────────────────────
-            progress.Report("正在解压更新包…");
+            progress.Report(new ProgressDialogUpdate("正在解压更新包…"));
             try
             {
                 ZipFile.ExtractToDirectory(zipPath, extractDir, overwriteFiles: true);
@@ -140,7 +140,7 @@ namespace XrayUI.Services
             }
 
             // ── 5. Sanity check extracted contents ──────────────────────────────────
-            progress.Report("正在验证更新包…");
+            progress.Report(new ProgressDialogUpdate("正在验证更新包…"));
 
             var newAppExe     = Path.Combine(extractDir, AppExeName);
             var newUpdaterExe = Path.Combine(extractDir, UpdaterExeName);
@@ -174,7 +174,7 @@ namespace XrayUI.Services
             var stagedRunner = Path.Combine(runnerDir, UpdaterExeName);
             File.Copy(currentUpdater, stagedRunner, overwrite: true);
 
-            progress.Report("正在准备重启…");
+            progress.Report(new ProgressDialogUpdate("正在准备重启…"));
 
             return new UpdateStaging(extractDir, stagedRunner, installDir, info.NewVersion);
         }
@@ -265,7 +265,7 @@ namespace XrayUI.Services
 
         private static async Task<string> DownloadAndHashAsync(
             HttpClient client, string url, string destPath, string displayName,
-            IProgress<string> progress, CancellationToken ct)
+            IProgress<ProgressDialogUpdate> progress, CancellationToken ct)
         {
             using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
             response.EnsureSuccessStatusCode();
@@ -302,12 +302,19 @@ namespace XrayUI.Services
             return Convert.ToHexString(hasher.GetHashAndReset()).ToLowerInvariant();
         }
 
-        private static string FormatProgress(string name, long received, long? total)
+        private static ProgressDialogUpdate FormatProgress(string name, long received, long? total)
         {
             var mbReceived = received / 1024.0 / 1024.0;
-            return total.HasValue
-                ? $"正在下载 {name} … {mbReceived:0.0} / {total.Value / 1024.0 / 1024.0:0.0} MB"
-                : $"正在下载 {name} … {mbReceived:0.0} MB";
+            if (total is > 0)
+            {
+                var mbTotal = total.Value / 1024.0 / 1024.0;
+                var percent = received * 100.0 / total.Value;
+                return new ProgressDialogUpdate(
+                    $"正在下载 {name} … {mbReceived:0.0} / {mbTotal:0.0} MB",
+                    percent);
+            }
+
+            return new ProgressDialogUpdate($"正在下载 {name} … {mbReceived:0.0} MB");
         }
     }
 }

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -857,7 +857,7 @@ namespace XrayUI.ViewModels
             UpdateStaging? staging = null;
             try
             {
-                await _dialogs.ShowProgressDialogAsync("正在更新 XrayUI",
+                await _dialogs.ShowProgressBarDialogAsync("正在更新 XrayUI",
                     async (progress, ct) =>
                     {
                         staging = await _update.DownloadVerifyAndExtractAsync(info, proxy, progress, ct);

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -111,7 +111,8 @@ namespace XrayUI.ViewModels
             ControlPanel.IsSystemProxyEnabled  = s.IsSystemProxyEnabled;
             ControlPanel.InitializePersonalize(s);
             Personalize.LoadDisplayOptions(s);
-            ApplyDetailDisplayOptions(s.ShowLatencyInDetails, s.ShowAiUnlockInDetails);
+            ServerDetail.ShowLatencyInDetails = s.ShowLatencyInDetails;
+            ServerDetail.ShowAiUnlockInDetails = s.ShowAiUnlockInDetails;
 
             // Reconcile external state vs persisted setting (external is ground truth)
             var externalEnabled = _startupService.IsStartupEnabled();
@@ -222,12 +223,6 @@ namespace XrayUI.ViewModels
             OnPropertyChanged(nameof(MainContentVisibility));
             OnPropertyChanged(nameof(PersonalizeVisibility));
             OnPropertyChanged(nameof(BackButtonVisibility));
-        }
-
-        private void ApplyDetailDisplayOptions(bool showLatency, bool showAiUnlock)
-        {
-            ServerDetail.ShowLatencyInDetails = showLatency;
-            ServerDetail.ShowAiUnlockInDetails = showAiUnlock;
         }
 
         // ── Back navigation (TitleBar back button) ────────────────────────────

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -82,6 +82,7 @@ namespace XrayUI.ViewModels
             ServerList.PropertyChanged   += OnServerListPropertyChanged;
             ControlPanel.PropertyChanged += OnControlPanelPropertyChanged;
             ServerDetail.PropertyChanged += OnServerDetailPropertyChanged;
+            Personalize.PropertyChanged  += OnPersonalizePropertyChanged;
 
             ControlPanel.ShowPersonalizeRequested += (_, _) => OpenPersonalize();
             Personalize.CloseRequested            += (_, _) => ClosePersonalize();
@@ -109,6 +110,8 @@ namespace XrayUI.ViewModels
             ControlPanel.RoutingMode           = s.RoutingMode == "global" ? "全局路由" : "智能分流";
             ControlPanel.IsSystemProxyEnabled  = s.IsSystemProxyEnabled;
             ControlPanel.InitializePersonalize(s);
+            Personalize.LoadDisplayOptions(s);
+            ApplyDetailDisplayOptions(s.ShowLatencyInDetails, s.ShowAiUnlockInDetails);
 
             // Reconcile external state vs persisted setting (external is ground truth)
             var externalEnabled = _startupService.IsStartupEnabled();
@@ -221,6 +224,12 @@ namespace XrayUI.ViewModels
             OnPropertyChanged(nameof(BackButtonVisibility));
         }
 
+        private void ApplyDetailDisplayOptions(bool showLatency, bool showAiUnlock)
+        {
+            ServerDetail.ShowLatencyInDetails = showLatency;
+            ServerDetail.ShowAiUnlockInDetails = showAiUnlock;
+        }
+
         // ── Back navigation (TitleBar back button) ────────────────────────────
         // Discards any in-flight edits and returns to the main view without saving.
 
@@ -240,6 +249,18 @@ namespace XrayUI.ViewModels
                 ServerDetail.SelectedServer = ServerList.SelectedServer;
                 OnPropertyChanged(nameof(ActiveServerName));
                 SwitchToSelectedServerCommand.NotifyCanExecuteChanged();
+            }
+        }
+
+        private void OnPersonalizePropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(PersonalizeViewModel.ShowLatencyInDetails))
+            {
+                ServerDetail.ShowLatencyInDetails = Personalize.ShowLatencyInDetails;
+            }
+            else if (e.PropertyName == nameof(PersonalizeViewModel.ShowAiUnlockInDetails))
+            {
+                ServerDetail.ShowAiUnlockInDetails = Personalize.ShowAiUnlockInDetails;
             }
         }
 

--- a/ViewModels/PersonalizeViewModel.cs
+++ b/ViewModels/PersonalizeViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Windows.UI;
 using XrayUI.Helpers;
+using XrayUI.Models;
 using XrayUI.Services;
 
 namespace XrayUI.ViewModels
@@ -18,6 +19,8 @@ namespace XrayUI.ViewModels
 
         private int _selectedThemeIndex;
         private int _selectedBackdropIndex;
+        private bool _showLatencyInDetails = true;
+        private bool _showAiUnlockInDetails = true;
 
         public event EventHandler? CloseRequested;
 
@@ -125,6 +128,18 @@ namespace XrayUI.ViewModels
             }
         }
 
+        public bool ShowLatencyInDetails
+        {
+            get => _showLatencyInDetails;
+            set => SetProperty(ref _showLatencyInDetails, value);
+        }
+
+        public bool ShowAiUnlockInDetails
+        {
+            get => _showAiUnlockInDetails;
+            set => SetProperty(ref _showAiUnlockInDetails, value);
+        }
+
         // ── Commands ──────────────────────────────────────────────────────────
 
         [RelayCommand]
@@ -152,6 +167,8 @@ namespace XrayUI.ViewModels
                 _                    => "Default"
             };
             s.BackdropSetting = ThemeHelper.CurrentBackdrop;
+            s.ShowLatencyInDetails = ShowLatencyInDetails;
+            s.ShowAiUnlockInDetails = ShowAiUnlockInDetails;
             await _settings.SaveSettingsAsync(s);
             CloseRequested?.Invoke(this, EventArgs.Empty);
         }
@@ -182,6 +199,14 @@ namespace XrayUI.ViewModels
 
             _selectedBackdropIndex = ThemeHelper.CurrentBackdrop == "Acrylic" ? 1 : 0;
             OnPropertyChanged(nameof(SelectedBackdropIndex));
+        }
+
+        public void LoadDisplayOptions(AppSettings settings)
+        {
+            _showLatencyInDetails = settings.ShowLatencyInDetails;
+            _showAiUnlockInDetails = settings.ShowAiUnlockInDetails;
+            OnPropertyChanged(nameof(ShowLatencyInDetails));
+            OnPropertyChanged(nameof(ShowAiUnlockInDetails));
         }
     }
 }

--- a/ViewModels/PersonalizeViewModel.cs
+++ b/ViewModels/PersonalizeViewModel.cs
@@ -203,10 +203,8 @@ namespace XrayUI.ViewModels
 
         public void LoadDisplayOptions(AppSettings settings)
         {
-            _showLatencyInDetails = settings.ShowLatencyInDetails;
-            _showAiUnlockInDetails = settings.ShowAiUnlockInDetails;
-            OnPropertyChanged(nameof(ShowLatencyInDetails));
-            OnPropertyChanged(nameof(ShowAiUnlockInDetails));
+            ShowLatencyInDetails = settings.ShowLatencyInDetails;
+            ShowAiUnlockInDetails = settings.ShowAiUnlockInDetails;
         }
     }
 }

--- a/ViewModels/ServerDetailViewModel.cs
+++ b/ViewModels/ServerDetailViewModel.cs
@@ -29,6 +29,8 @@ namespace XrayUI.ViewModels
         private SolidColorBrush _openAiStatusBrush = null!;
         private SolidColorBrush _claudeStatusBrush = null!;
         private SolidColorBrush _geminiStatusBrush = null!;
+        private bool _showLatencyInDetails = true;
+        private bool _showAiUnlockInDetails = true;
 
         public ServerDetailViewModel(LatencyProbeService latencyProbe, AiUnlockCheckService aiUnlockCheck)
         {
@@ -141,6 +143,34 @@ namespace XrayUI.ViewModels
         }
 
         public bool CanTestLatency => !IsTestingLatency && SelectedServer is not null;
+
+        public bool ShowLatencyInDetails
+        {
+            get => _showLatencyInDetails;
+            set
+            {
+                if (SetProperty(ref _showLatencyInDetails, value))
+                {
+                    OnPropertyChanged(nameof(LatencyVisibility));
+                }
+            }
+        }
+
+        public bool ShowAiUnlockInDetails
+        {
+            get => _showAiUnlockInDetails;
+            set
+            {
+                if (SetProperty(ref _showAiUnlockInDetails, value))
+                {
+                    OnPropertyChanged(nameof(AiUnlockVisibility));
+                }
+            }
+        }
+
+        public Visibility LatencyVisibility => ShowLatencyInDetails ? Visibility.Visible : Visibility.Collapsed;
+
+        public Visibility AiUnlockVisibility => ShowAiUnlockInDetails ? Visibility.Visible : Visibility.Collapsed;
 
         // ── AI Unlock indicators ──────────────────────────────────────────────
 

--- a/ViewModels/ServerGroupChip.cs
+++ b/ViewModels/ServerGroupChip.cs
@@ -7,6 +7,7 @@ namespace XrayUI.ViewModels
         public enum ChipKind
         {
             All,
+            Favorites,
             Subscription,
             Ungrouped,
         }

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -347,8 +347,10 @@ namespace XrayUI.ViewModels
             // Single pass: count servers grouped by SubscriptionId (empty/null → ungrouped bucket).
             var countsBySub = new Dictionary<string, int>(StringComparer.Ordinal);
             int ungroupedCount = 0;
+            bool hasFavorites = false;
             foreach (var s in Servers)
             {
+                hasFavorites |= s.IsFavorite;
                 if (string.IsNullOrEmpty(s.SubscriptionId))
                     ungroupedCount++;
                 else
@@ -368,7 +370,7 @@ namespace XrayUI.ViewModels
                 DisplayName = AllChipName,
             });
 
-            if (Servers.Any(s => s.IsFavorite))
+            if (hasFavorites)
             {
                 GroupChips.Add(new ServerGroupChip
                 {
@@ -825,6 +827,7 @@ namespace XrayUI.ViewModels
             var server = SelectedServer;
             var isFavoritesChip = _selectedChip?.Kind == ServerGroupChip.ChipKind.Favorites;
             server.IsFavorite = !server.IsFavorite;
+            var justFavorited = server.IsFavorite;
 
             if (isFavoritesChip && !server.IsFavorite)
             {
@@ -834,16 +837,16 @@ namespace XrayUI.ViewModels
             }
             else
             {
-                SyncFavoritesChipPresence();
+                SyncFavoritesChipPresence(justFavorited);
             }
 
             await SaveAsync();
         }
 
-        private void SyncFavoritesChipPresence()
+        private void SyncFavoritesChipPresence(bool justFavorited)
         {
             var favoritesChip = GroupChips.FirstOrDefault(c => c.Kind == ServerGroupChip.ChipKind.Favorites);
-            var hasFavorites = Servers.Any(s => s.IsFavorite);
+            var hasFavorites = justFavorited || Servers.Any(s => s.IsFavorite);
 
             if (hasFavorites && favoritesChip == null)
             {

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -31,8 +31,10 @@ namespace XrayUI.ViewModels
 
         private const string AllChipKey            = "__all__";
         private const string UngroupedChipKey      = "__ungrouped__";
+        private const string FavoritesChipKey      = "__favorites__";
         private const string AllChipName           = "所有服务器";
         private const string UngroupedName         = "未分组";
+        private const string FavoritesName         = "收藏列表";
         private const string UnnamedSubLabel       = "(未命名订阅)";
         private const string OrphanSubLabel        = "(已删除订阅)";
 
@@ -366,6 +368,15 @@ namespace XrayUI.ViewModels
                 DisplayName = AllChipName,
             });
 
+            if (Servers.Any(s => s.IsFavorite))
+            {
+                GroupChips.Add(new ServerGroupChip
+                {
+                    Kind        = ServerGroupChip.ChipKind.Favorites,
+                    DisplayName = FavoritesName,
+                });
+            }
+
             foreach (var sub in _knownSubscriptions)
             {
                 if (string.IsNullOrEmpty(sub.Id)) continue;
@@ -423,6 +434,7 @@ namespace XrayUI.ViewModels
         {
             ServerGroupChip.ChipKind.All          => AllChipKey,
             ServerGroupChip.ChipKind.Ungrouped    => UngroupedChipKey,
+            ServerGroupChip.ChipKind.Favorites    => FavoritesChipKey,
             ServerGroupChip.ChipKind.Subscription => chip!.SubscriptionId,
             _                                     => null,
         };
@@ -443,6 +455,8 @@ namespace XrayUI.ViewModels
                     Servers.Where(s => s.SubscriptionId == (_selectedChip.SubscriptionId ?? string.Empty)),
                 ServerGroupChip.ChipKind.Ungrouped =>
                     Servers.Where(s => string.IsNullOrEmpty(s.SubscriptionId)),
+                ServerGroupChip.ChipKind.Favorites =>
+                    Servers.Where(s => s.IsFavorite),
                 _ => Servers,
             };
 
@@ -651,7 +665,10 @@ namespace XrayUI.ViewModels
                 foreach (var e in newEntries)
                 {
                     if (oldByEndpoint.TryGetValue($"{e.Protocol}://{e.Host}:{e.Port}", out var match))
+                    {
                         e.Id = match.Id;
+                        e.IsFavorite = match.IsFavorite;
+                    }
                 }
 
                 MutateServersInBatch(() =>
@@ -797,6 +814,50 @@ namespace XrayUI.ViewModels
             }
 
             await _dialogs.ShowShareLinkDialogAsync(SelectedServer.Name, link);
+        }
+
+        // ── Favorite ─────────────────────────────────────────────────────────
+
+        [RelayCommand]
+        private async Task ToggleFavorite()
+        {
+            if (SelectedServer is null) return;
+            var server = SelectedServer;
+            var isFavoritesChip = _selectedChip?.Kind == ServerGroupChip.ChipKind.Favorites;
+            server.IsFavorite = !server.IsFavorite;
+
+            if (isFavoritesChip && !server.IsFavorite)
+            {
+                RebuildAll();
+                // 当前节点已不属于收藏列表，重建后选中列表里的第一个节点。
+                SelectedServer = VisibleServers.FirstOrDefault();
+            }
+            else
+            {
+                SyncFavoritesChipPresence();
+            }
+
+            await SaveAsync();
+        }
+
+        private void SyncFavoritesChipPresence()
+        {
+            var favoritesChip = GroupChips.FirstOrDefault(c => c.Kind == ServerGroupChip.ChipKind.Favorites);
+            var hasFavorites = Servers.Any(s => s.IsFavorite);
+
+            if (hasFavorites && favoritesChip == null)
+            {
+                // RebuildGroupChips 总是把 All chip 放在 index 0，收藏紧跟其后。
+                GroupChips.Insert(1, new ServerGroupChip
+                {
+                    Kind        = ServerGroupChip.ChipKind.Favorites,
+                    DisplayName = FavoritesName,
+                });
+            }
+            else if (!hasFavorites && favoritesChip != null)
+            {
+                GroupChips.Remove(favoritesChip);
+            }
         }
 
         // ── Remove ────────────────────────────────────────────────────────────

--- a/Views/PersonalizeControl.xaml
+++ b/Views/PersonalizeControl.xaml
@@ -381,6 +381,82 @@
                 </Border>
             </StackPanel>
 
+            <!-- ── 详情设置 ────────────────────────────────────────────────── -->
+            <StackPanel Spacing="10">
+                <TextBlock Text="详情设置"
+                           FontSize="15"
+                           FontWeight="SemiBold" />
+
+                <Expander HorizontalAlignment="Stretch"
+                          HorizontalContentAlignment="Stretch"
+                          CornerRadius="{ThemeResource OverlayCornerRadius}"
+                          Background="{ThemeResource LayerFillColorDefaultBrush}"
+                          BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}">
+                    <Expander.Header>
+                        <Grid Padding="0,12" ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+
+                            <FontIcon Grid.Column="0"
+                                      Glyph="&#xE946;"
+                                      FontSize="16"
+                                      VerticalAlignment="Center"
+                                      Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+
+                            <StackPanel Grid.Column="1"
+                                        VerticalAlignment="Center"
+                                        Spacing="2">
+                                <TextBlock Text="服务器信息显示"
+                                           FontSize="14" />
+                                <TextBlock Text="选择详情卡片上的信息展示"
+                                           FontSize="12"
+                                           TextWrapping="Wrap"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                        </Grid>
+                    </Expander.Header>
+
+                <StackPanel Margin="-16,-12,-16,-12">
+                    <!-- Delay Display -->
+                    <CheckBox IsChecked="{x:Bind ViewModel.ShowLatencyInDetails, Mode=TwoWay}"
+                              HorizontalAlignment="Stretch"
+                              HorizontalContentAlignment="Stretch"
+                              Margin="42,10,16,10">
+                        <StackPanel VerticalAlignment="Center"
+                                    Spacing="2">
+                            <TextBlock Text="延迟"
+                                       FontSize="14" />
+                            <TextBlock Text="节点卡片上展示延迟"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        </StackPanel>
+                    </CheckBox>
+
+                    <Rectangle Height="1"
+                               Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
+
+                    <!-- AI Unlock Display -->
+                    <CheckBox IsChecked="{x:Bind ViewModel.ShowAiUnlockInDetails, Mode=TwoWay}"
+                              HorizontalAlignment="Stretch"
+                              HorizontalContentAlignment="Stretch"
+                              Margin="42,10,16,10">
+                        <StackPanel VerticalAlignment="Center"
+                                    Spacing="2">
+                            <TextBlock Text="AI 解锁"
+                                       FontSize="14" />
+                            <TextBlock Text="节点卡片上展示AI的解锁状态"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        </StackPanel>
+                    </CheckBox>
+                </StackPanel>
+            </Expander>
+            </StackPanel>
+
             <!-- ── 数据管理 ────────────────────────────────────────────────── -->
             <StackPanel Spacing="10">
                 <StackPanel Spacing="2">

--- a/Views/ServerDetailControl.xaml
+++ b/Views/ServerDetailControl.xaml
@@ -130,7 +130,9 @@
                         </Grid>
 
                         <!-- AI 服务监测区 -->
-                        <StackPanel Spacing="12" Margin="0,2,0,0" >
+                        <StackPanel Spacing="12"
+                                    Margin="0,2,0,0"
+                                    Visibility="{x:Bind ViewModel.AiUnlockVisibility, Mode=OneWay}">
                             <Grid x:Name="AIShadowCastGrid" />
                             <TextBlock Text="AI 访问解锁"
                                            FontSize="13"                                          
@@ -379,7 +381,8 @@
                         <!-- Latency row -->
                         <Grid ColumnDefinitions="*,Auto,Auto"
                               ColumnSpacing="12"
-                              VerticalAlignment="Center">
+                              VerticalAlignment="Center"
+                              Visibility="{x:Bind ViewModel.LatencyVisibility, Mode=OneWay}">
                             <TextBlock Text="网络延迟"
                                        FontSize="13"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"

--- a/Views/ServerListControl.xaml.cs
+++ b/Views/ServerListControl.xaml.cs
@@ -133,9 +133,7 @@ namespace XrayUI.Views
             editItem.Click += (_, _) => ViewModel.EditServerCommand.Execute(null);
 
             var isFavorite = ViewModel.SelectedServer?.IsFavorite == true;
-            var favoriteIcon = new FontIcon { Glyph = "\uE718" };
-            if (isFavorite && Application.Current.Resources["FavoriteBrush"] is Brush favoriteBrush)
-                favoriteIcon.Foreground = favoriteBrush;
+            var favoriteIcon = isFavorite ? new FontIcon { Glyph = "\uE8D9" } : new FontIcon { Glyph = "\uE734" };
             var favoriteItem = new MenuFlyoutItem
             {
                 Text = isFavorite ? "取消收藏" : "加入收藏",

--- a/Views/ServerListControl.xaml.cs
+++ b/Views/ServerListControl.xaml.cs
@@ -131,7 +131,9 @@ namespace XrayUI.Views
             editItem.IsEnabled = ViewModel.CanEditSelectedServer;
             editItem.Click += (_, _) => ViewModel.EditServerCommand.Execute(null);
 
-            var deleteItem = CreateMenuItem("删除", "\uE74D");
+			var favoriteItem = CreateMenuItem("加入收藏", "\uE718");
+
+			var deleteItem = CreateMenuItem("删除", "\uE74D");
             deleteItem.IsEnabled = ViewModel.CanRemoveSelectedServer;
             deleteItem.Click += (_, _) => ViewModel.RemoveServerCommand.Execute(null);
 
@@ -139,6 +141,7 @@ namespace XrayUI.Views
             shareItem.Click += (_, _) => ViewModel.ShareServerCommand.Execute(null);
 
             flyout.Items.Add(editItem);
+            flyout.Items.Add(favoriteItem);
             flyout.Items.Add(deleteItem);
             flyout.Items.Add(shareItem);
 

--- a/Views/ServerListControl.xaml.cs
+++ b/Views/ServerListControl.xaml.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Windows.Foundation;
 using XrayUI.Models;
 
@@ -131,9 +132,18 @@ namespace XrayUI.Views
             editItem.IsEnabled = ViewModel.CanEditSelectedServer;
             editItem.Click += (_, _) => ViewModel.EditServerCommand.Execute(null);
 
-			var favoriteItem = CreateMenuItem("加入收藏", "\uE718");
+            var isFavorite = ViewModel.SelectedServer?.IsFavorite == true;
+            var favoriteIcon = new FontIcon { Glyph = "\uE718" };
+            if (isFavorite && Application.Current.Resources["FavoriteBrush"] is Brush favoriteBrush)
+                favoriteIcon.Foreground = favoriteBrush;
+            var favoriteItem = new MenuFlyoutItem
+            {
+                Text = isFavorite ? "取消收藏" : "加入收藏",
+                Icon = favoriteIcon,
+            };
+            favoriteItem.Click += (_, _) => ViewModel.ToggleFavoriteCommand.Execute(null);
 
-			var deleteItem = CreateMenuItem("删除", "\uE74D");
+            var deleteItem = CreateMenuItem("删除", "\uE74D");
             deleteItem.IsEnabled = ViewModel.CanRemoveSelectedServer;
             deleteItem.Click += (_, _) => ViewModel.RemoveServerCommand.Execute(null);
 

--- a/Views/ServerListControl.xaml.cs
+++ b/Views/ServerListControl.xaml.cs
@@ -133,12 +133,9 @@ namespace XrayUI.Views
             editItem.Click += (_, _) => ViewModel.EditServerCommand.Execute(null);
 
             var isFavorite = ViewModel.SelectedServer?.IsFavorite == true;
-            var favoriteIcon = isFavorite ? new FontIcon { Glyph = "\uE8D9" } : new FontIcon { Glyph = "\uE734" };
-            var favoriteItem = new MenuFlyoutItem
-            {
-                Text = isFavorite ? "取消收藏" : "加入收藏",
-                Icon = favoriteIcon,
-            };
+            var favoriteItem = CreateMenuItem(
+                isFavorite ? "取消收藏" : "加入收藏",
+                isFavorite ? "\uE8D9" : "\uE734");
             favoriteItem.Click += (_, _) => ViewModel.ToggleFavoriteCommand.Execute(null);
 
             var deleteItem = CreateMenuItem("删除", "\uE74D");


### PR DESCRIPTION
## Summary
- New **server favorites** feature: right-click → 加入收藏 / 取消收藏, with a dedicated 收藏列表 chip in the group bar (auto-shows/hides based on whether any node is favorited; favorite state preserved across subscription refreshes).
- New 详情设置 panel under Personalize: toggles to **show/hide latency and AI unlock sections** in the server detail card.
- **Progress bar** for app update flow (in-place update progress instead of opaque wait).
- Optimized `RebuildGroupChips` and `SyncFavoritesChipPresence` to avoid redundant O(N) scans.
- `StateNeutralBrush` now uses `SystemFillColorNeutral` theme resource so the AI-unlock idle dot adapts to light/dark.

## Test plan
- [x] Right-click a node → 加入收藏，verify 收藏列表 chip appears
- [x] Toggle the only favorite off, verify 收藏列表 chip auto-disappears
- [x] Refresh a subscription, verify nodes that survive keep their IsFavorite state
- [x] Personalize → 详情设置 → toggle 延迟 / AI 解锁，verify the corresponding sections in the detail card hide/show
- [x] Restart app, verify display toggles persist
- [x] Trigger an update check & install, verify the progress bar reports progress
- [x] Light / Dark theme: verify AI-unlock idle dot color adapts

🤖 Generated with [Claude Code](https://claude.com/claude-code)