### PR TITLE
fix(ss): handle query string in share links; reject SIP003 plugin

### DIFF
--- a/Services/NodeLinkParser.cs
+++ b/Services/NodeLinkParser.cs
@@ -47,6 +47,18 @@ namespace XrayUI.Services
                     rest = rest.Substring(0, hashIdx);
                 }
 
+                // SS share links may carry a query (e.g. ?type=tcp from cross-protocol generators).
+                // We ignore unknown params, but reject SIP003 plugin links — xray-core has no
+                // SIP003 outbound, so silently dropping `plugin=...` would save an unconnectable node.
+                var queryIdx = rest.IndexOf('?');
+                if (queryIdx >= 0)
+                {
+                    var query = ParseQuery(rest.Substring(queryIdx));
+                    if (query.ContainsKey("plugin"))
+                        return null;
+                    rest = rest.Substring(0, queryIdx);
+                }
+
                 // Try SIP002: BASE64(method:password)@host:port
                 // Look for '@' that separates the base64 userinfo from host:port
                 // The base64 part must NOT contain '@' — so find last '@' and try decoding left side


### PR DESCRIPTION
## Summary

- ParseSs only stripped `#fragment`, leaving any `?query` attached to `host:port` and tripping `int.Parse` in `SplitHostPort` — so SIP002 / SS-2022 share links like `ss://...@host:port?type=tcp#name` silently failed to import with a generic "无法识别有效的节点链接" dialog.
- Strip the query before `SplitHostPort` so harmless params (`?type=tcp` etc.) no longer break parsing.
- Explicitly reject links carrying `?plugin=...`. xray-core has no SIP003 outbound, so silently dropping the plugin would save an unconnectable node — the explicit failure is preferable.

## Why

A user reported a real `2022-blake3-aes-256-gcm` share link that hit this exact path. The userinfo decoded fine, but the trailing `?type=tcp` got fed into `int.Parse("24754?type=tcp")`, the throw was caught by the outer `catch`, and the whole link returned `null`.

The plugin-rejection guard preserves the prior fail-fast behavior for plugin-based SS links — without it, those links would suddenly import as plain TCP after this patch and fail at connect time with no clear cause.

## Behavior matrix

| Link form | Before | After |
|---|---|---|
| `ss://...?type=tcp#name` | parse fail | imports correctly |
| `ss://...?plugin=v2ray-plugin;...` | parse fail | parse fail (explicit) |
| `ss://...?type=tcp&plugin=...` | parse fail | parse fail (explicit) |

## Test plan

- [x] Manually paste an SS-2022 share link with `?type=tcp` — node imports with correct host/port/method/password.
- [x] Manually paste an SS link with `?plugin=v2ray-plugin;...` — UI shows the existing parse-failure dialog.
- [x] Existing SS links without query (`ss://base64@host:port#name`) — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)