### PR TITLE
VLESS post-quantum encryption + WinML asset-trim refactor

### DIFF
--- a/Models/ServerEntry.cs
+++ b/Models/ServerEntry.cs
@@ -27,6 +27,7 @@ namespace XrayUI.Models
             ShortId = string.Empty;
             SpiderX = string.Empty;
             Flow = string.Empty;
+            VlessEncryption = string.Empty;
             Finalmask = string.Empty;
         }
 
@@ -104,6 +105,10 @@ namespace XrayUI.Models
         /// <summary>VLESS flow: "xtls-rprx-vision" or empty string.</summary>
         [ObservableProperty]
         public partial string Flow { get; set; }
+
+        /// <summary>VLESS user-level encryption (Xray PR #5067 PQ encryption, e.g. "mlkem768x25519plus...."). Empty = "none".</summary>
+        [ObservableProperty]
+        public partial string VlessEncryption { get; set; }
 
         /// <summary>Raw Xray streamSettings.finalmask JSON, shared as the "fm" URI parameter.</summary>
         [ObservableProperty]

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -146,6 +146,13 @@ namespace XrayUI.Services
             var txtSid  = new TextBox { Header = "ShortId (Reality)", Text = existing?.ShortId ?? string.Empty };
             var txtSpx  = new TextBox { Header = "SpiderX (Reality)", Text = existing?.SpiderX ?? string.Empty };
             var txtFlow = new TextBox { Header = "Flow (VLESS)", PlaceholderText = "xtls-rprx-vision 或留空", Text = existing?.Flow ?? string.Empty };
+            var txtVlessEncryption = new TextBox
+            {
+                Header = "VLESS encryption (PQ)",
+                PlaceholderText = "留空 = none;或 mlkem768x25519plus.native.0rtt....",
+                Text = existing?.VlessEncryption ?? string.Empty,
+                TextWrapping = TextWrapping.Wrap
+            };
             var txtFinalmask = new TextBox
             {
                 Header = "Finalmask (JSON)",
@@ -169,6 +176,7 @@ namespace XrayUI.Services
             var rowSid        = Wrap(txtSid);
             var rowSpx        = Wrap(txtSpx);
             var rowFlow       = Wrap(txtFlow);
+            var rowVlessEncryption = Wrap(txtVlessEncryption);
             var rowFinalmask  = Wrap(txtFinalmask);
 
             void UpdateVisibility()
@@ -205,6 +213,7 @@ namespace XrayUI.Services
                 rowSid       .Visibility = hasReality                 ? Visibility.Visible : Visibility.Collapsed;
                 rowSpx       .Visibility = hasReality                 ? Visibility.Visible : Visibility.Collapsed;
                 rowFlow      .Visibility = isVless                    ? Visibility.Visible : Visibility.Collapsed;
+                rowVlessEncryption.Visibility = isVless               ? Visibility.Visible : Visibility.Collapsed;
             }
 
             cmbProtocol.SelectionChanged += (_, _) =>
@@ -230,7 +239,7 @@ namespace XrayUI.Services
                     txtName, txtHost, numPort, cmbProtocol,
                     rowEncryption, rowPassword, rowUuid, rowAlterId,
                     cmbNetwork, rowPath, rowWsHost,
-                    cmbSecurity, rowSni, rowFp, rowAllowInsecure, rowPk, rowSid, rowSpx, rowFlow,
+                    cmbSecurity, rowSni, rowFp, rowAllowInsecure, rowPk, rowSid, rowSpx, rowFlow, rowVlessEncryption,
                     rowFinalmask
                 }
             };
@@ -272,6 +281,7 @@ namespace XrayUI.Services
             entry.ShortId     = txtSid.Text.Trim();
             entry.SpiderX     = txtSpx.Text.Trim();
             entry.Flow        = txtFlow.Text.Trim();
+            entry.VlessEncryption = txtVlessEncryption.Text.Trim();
             entry.Finalmask   = FinalmaskJson.NormalizeForStorage(txtFinalmask.Text);
 
             if (entry.Protocol == "hysteria2")

--- a/Services/NodeLinkParser.cs
+++ b/Services/NodeLinkParser.cs
@@ -231,6 +231,7 @@ namespace XrayUI.Services
                 var path     = Q(query, "path") ?? Q(query, "serviceName") ?? string.Empty;
                 var wsHost   = Q(query, "host", string.Empty) ?? string.Empty;
                 var flow     = Q(query, "flow", string.Empty) ?? string.Empty;
+                var vlessEncryption = Q(query, "encryption", string.Empty) ?? string.Empty;
                 var finalmask = FinalmaskJson.NormalizeForStorage(Q(query, "fm"));
                 var allowInsecure = IsTruthy(Q(query, "allowInsecure")) || IsTruthy(Q(query, "insecure"));
 
@@ -252,6 +253,7 @@ namespace XrayUI.Services
                     Path        = path,
                     WsHost      = wsHost,
                     Flow        = flow,
+                    VlessEncryption = vlessEncryption == "none" ? string.Empty : vlessEncryption,
                     Finalmask   = finalmask,
                     Encryption  = security == "reality" ? "Reality"
                                 : security == "tls"     ? "TLS"

--- a/Services/NodeLinkSerializer.cs
+++ b/Services/NodeLinkSerializer.cs
@@ -127,6 +127,10 @@ namespace XrayUI.Services
             if (network == "ws" || network == "xhttp")
                 AppendIfNotEmpty(sb, "host", s.WsHost);
 
+            // VLESS-level encryption (Xray PR #5067). Always emit, matching v2rayN parity & spec.
+            var vlessEnc = string.IsNullOrEmpty(s.VlessEncryption) ? "none" : s.VlessEncryption;
+            AppendParam(sb, "encryption", vlessEnc, first: false);
+
             // VLESS flow (xtls-rprx-vision etc.)
             AppendIfNotEmpty(sb, "flow", s.Flow);
             AppendIfNotEmpty(sb, "fm", FinalmaskJson.NormalizeForShare(s.Finalmask));

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -233,7 +233,7 @@ namespace XrayUI.Services
             var user = new JsonObject
             {
                 ["id"] = server.Uuid,
-                ["encryption"] = "none"
+                ["encryption"] = string.IsNullOrEmpty(server.VlessEncryption) ? "none" : server.VlessEncryption
             };
 
             if (!string.IsNullOrWhiteSpace(server.Flow))

--- a/ViewModels/ServerDetailViewModel.cs
+++ b/ViewModels/ServerDetailViewModel.cs
@@ -97,6 +97,15 @@ namespace XrayUI.ViewModels
 
         public string SelectedEncryption => SelectedServer?.Encryption ?? "-";
 
+        public string SelectedVlessEncryption
+            => string.IsNullOrEmpty(SelectedServer?.VlessEncryption) ? string.Empty : SelectedServer.VlessEncryption;
+
+        public Visibility VlessEncryptionVisibility
+            => string.Equals(SelectedServer?.Protocol, "vless", StringComparison.OrdinalIgnoreCase)
+               && !string.IsNullOrEmpty(SelectedServer?.VlessEncryption)
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+
         public string SelectedShareLink
             => SelectedServer is null ? string.Empty : (NodeLinkSerializer.ToLink(SelectedServer) ?? string.Empty);
 
@@ -244,9 +253,15 @@ namespace XrayUI.ViewModels
                     OnPropertyChanged(nameof(SelectedProtocol));
                     OnPropertyChanged(nameof(SelectedSecurityLabel));
                     OnPropertyChanged(nameof(SelectedTransport));
+                    OnPropertyChanged(nameof(VlessEncryptionVisibility));
                     break;
                 case nameof(ServerEntry.Encryption):
                     OnPropertyChanged(nameof(SelectedEncryption));
+                    break;
+                case nameof(ServerEntry.VlessEncryption):
+                    OnPropertyChanged(nameof(SelectedVlessEncryption));
+                    OnPropertyChanged(nameof(VlessEncryptionVisibility));
+                    OnPropertyChanged(nameof(SelectedShareLink));
                     break;
                 case nameof(ServerEntry.Network):
                     OnPropertyChanged(nameof(SelectedTransport));
@@ -268,6 +283,8 @@ namespace XrayUI.ViewModels
             OnPropertyChanged(nameof(SelectedProtocol));
             OnPropertyChanged(nameof(SelectedSecurityLabel));
             OnPropertyChanged(nameof(SelectedEncryption));
+            OnPropertyChanged(nameof(SelectedVlessEncryption));
+            OnPropertyChanged(nameof(VlessEncryptionVisibility));
             OnPropertyChanged(nameof(SelectedTransport));
             OnPropertyChanged(nameof(SelectedShareLink));
             OnPropertyChanged(nameof(CanTestLatency));

--- a/Views/ServerDetailControl.xaml
+++ b/Views/ServerDetailControl.xaml
@@ -58,6 +58,7 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
 
                             <!-- Row 0: 名称 -->
@@ -127,6 +128,21 @@
                                        Grid.Column="1"
                                        Text="{x:Bind ViewModel.SelectedTransport, Mode=OneWay}"
                                        FontSize="16" />
+
+                            <!-- Row 6: VLESS encryption (PQ) — VLESS only, hidden if empty -->
+                            <TextBlock Grid.Row="6"
+                                       Grid.Column="0"
+                                       Text="加密(PQ)"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       VerticalAlignment="Center"
+                                       Visibility="{x:Bind ViewModel.VlessEncryptionVisibility, Mode=OneWay}" />
+                            <TextBlock Grid.Row="6"
+                                       Grid.Column="1"
+                                       Text="{x:Bind ViewModel.SelectedVlessEncryption, Mode=OneWay}"
+                                       ToolTipService.ToolTip="{x:Bind ViewModel.SelectedVlessEncryption, Mode=OneWay}"
+                                       FontSize="13"
+                                       TextTrimming="CharacterEllipsis"
+                                       Visibility="{x:Bind ViewModel.VlessEncryptionVisibility, Mode=OneWay}" />
                         </Grid>
 
                         <!-- AI 服务监测区 -->

--- a/XrayUI-dev.csproj
+++ b/XrayUI-dev.csproj
@@ -14,7 +14,6 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <WindowsPackageType>None</WindowsPackageType>
-    <RemoveUnusedWindowsMlNativeAssetsFromPublish>true</RemoveUnusedWindowsMlNativeAssetsFromPublish>
   </PropertyGroup>
 
 
@@ -69,6 +68,18 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.2.251219" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
+    <!-- Promote these two transitive deps of WindowsAppSDK to direct references so we can
+         strip their runtime assets (DirectML.dll / onnxruntime.dll / Microsoft.Windows.AI.MachineLearning.dll).
+         IncludeAssets=compile keeps the reference assemblies for compile-time use; PrivateAssets=all
+         prevents them from flowing to consumers. -->
+    <PackageReference Include="Microsoft.WindowsAppSDK.AI" Version="*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>compile</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Windows.AI.MachineLearning" Version="*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>compile</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="WinUIEx" Version="2.9.0" />
   </ItemGroup>
 
@@ -99,17 +110,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-
-  <!-- Windows App SDK 2.x brings Windows ML as a transitive component. XrayUI does
-       not use local ML inference, so keep those native runtime DLLs out of publish
-       folders even when publishing to a custom output path. -->
-  <Target Name="CleanUnusedWindowsMlNativeAssetsFromPublish" AfterTargets="Publish;PublishUpdaterAlongside" Condition="'$(RemoveUnusedWindowsMlNativeAssetsFromPublish)' == 'true'">
-    <ItemGroup>
-      <_UnusedWindowsMlNativeAsset Include="$(PublishDir)DirectML.dll;$(PublishDir)onnxruntime.dll;$(PublishDir)Microsoft.Windows.AI.MachineLearning.dll" />
-      <_ExistingUnusedWindowsMlNativeAsset Include="@(_UnusedWindowsMlNativeAsset)" Condition="Exists('%(_UnusedWindowsMlNativeAsset.Identity)')" />
-    </ItemGroup>
-    <Delete Files="@(_ExistingUnusedWindowsMlNativeAsset)" />
-  </Target>
 
   <!-- Auto-publish the standalone Updater alongside the main app on local
        `dotnet publish`, so testing the in-app upgrade flow doesn't require


### PR DESCRIPTION
## Summary

Two unrelated changes bundled in this PR (one commit each):

1. **`feat(vless)`** — Add support for VLESS user-level encryption (Xray PR #5067, post-quantum / `mlkem768x25519plus.*` keys). Threaded through ServerEntry, parser, serializer, xray config, edit dialog, and detail view. Empty/`none` keeps the previous behavior, so existing nodes are unaffected.
2. **`build`** — Replace the post-publish `<Delete>` target for Windows ML native DLLs with `PrivateAssets=all` + `IncludeAssets=compile` on the AI/ML package references. MSBuild now drops `DirectML.dll`, `onnxruntime.dll`, and `Microsoft.Windows.AI.MachineLearning.dll` from publish naturally, no custom target needed.

## Why

VLESS PQ encryption: Xray-core has shipped support behind PR #5067, so share links from v2rayN-style clients increasingly carry `?encryption=mlkem768x25519plus.*`. Without this patch, the parser drops the param and the resulting xray config emits `"encryption":"none"` regardless, making PQ-keyed nodes unconnectable.

WinML refactor: the existing `Delete` target ran post-publish and only when the project property was set, which made it fragile under `dotnet publish` from CI vs locally. `PrivateAssets`/`IncludeAssets` is the supported MSBuild contract for "use the ref assemblies, don't ship the runtime."

## Reviewer notes

- The new `Microsoft.WindowsAppSDK.AI` and `Microsoft.Windows.AI.MachineLearning` references use `Version=\"*\"` (latest matching). Worth confirming whether the team prefers a pinned version.
- VLESS `encryption=` is now always emitted in serialized share links (even as `none`) to match v2rayN parity. Round-trip parse → serialize → parse should be stable.
- VLESS encryption strings can be very long; the edit dialog textbox uses `TextWrapping.Wrap`, the detail view row uses `TextTrimming.CharacterEllipsis` with full text in the tooltip.

## Test plan

- [ ] Paste a VLESS share link with `?encryption=mlkem768x25519plus.native.0rtt....` — node imports with the value populated; share-link round-trip preserves it.
- [ ] Existing VLESS nodes (no `encryption` field, or `=none`) — `VlessEncryption` stays empty, xray config emits `"encryption":"none"`, no behavior change.
- [ ] Non-VLESS nodes — VLESS encryption row hidden in detail view; edit dialog field hidden.
- [ ] `dotnet publish -c Release -r win-x64 -p:Platform=x64 -p:SelfContained=true -p:PublishAot=true ...` — verify `DirectML.dll`, `onnxruntime.dll`, `Microsoft.Windows.AI.MachineLearning.dll` are NOT present in the publish folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)