### PR TITLE
feat(vless): support ECH (Encrypted Client Hello) for VLESS+TLS

### DIFF
--- a/Models/ServerEntry.cs
+++ b/Models/ServerEntry.cs
@@ -23,6 +23,8 @@ namespace XrayUI.Models
             Security = string.Empty;
             Sni = string.Empty;
             Fingerprint = string.Empty;
+            EchConfigList = string.Empty;
+            EchForceQuery = string.Empty;
             PublicKey = string.Empty;
             ShortId = string.Empty;
             SpiderX = string.Empty;
@@ -91,6 +93,14 @@ namespace XrayUI.Models
 
         [ObservableProperty]
         public partial bool AllowInsecure { get; set; }
+
+        /// <summary>Client-side TLS ECH config list. Empty = disabled.</summary>
+        [ObservableProperty]
+        public partial string EchConfigList { get; set; }
+
+        /// <summary>ECH force query mode: "half", "full", or empty/none.</summary>
+        [ObservableProperty]
+        public partial string EchForceQuery { get; set; }
 
         // VLESS Reality
         [ObservableProperty]

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -142,6 +142,20 @@ namespace XrayUI.Services
             var txtSni  = new TextBox { Header = "SNI", Text = existing?.Sni ?? string.Empty };
             var txtFp   = new TextBox { Header = "指纹 (uTLS)", Text = existing?.Fingerprint ?? string.Empty };
             var chkAllowInsecure = new CheckBox { Content = "允许不安全连接（跳过证书校验）", IsChecked = existing?.AllowInsecure ?? false };
+            var txtEchConfigList = new TextBox
+            {
+                Header = "ECH ConfigList",
+                PlaceholderText = "例如 udp://1.1.1.1 或服务端生成的 ECHConfig",
+                Text = existing?.EchConfigList ?? string.Empty,
+                TextWrapping = TextWrapping.Wrap
+            };
+            var cmbEchForceQuery = new ComboBox { Header = "ECH Force Query", MinWidth = 200 };
+            foreach (var q in new[] { EchSettings.None, EchSettings.Half, EchSettings.Full })
+                cmbEchForceQuery.Items.Add(q);
+            var existingEchForceQuery = EchSettings.NormalizeForceQuery(existing?.EchForceQuery);
+            cmbEchForceQuery.SelectedItem = string.IsNullOrEmpty(existingEchForceQuery)
+                ? EchSettings.None
+                : existingEchForceQuery;
             var txtPk   = new TextBox { Header = "PublicKey (Reality)", Text = existing?.PublicKey ?? string.Empty };
             var txtSid  = new TextBox { Header = "ShortId (Reality)", Text = existing?.ShortId ?? string.Empty };
             var txtSpx  = new TextBox { Header = "SpiderX (Reality)", Text = existing?.SpiderX ?? string.Empty };
@@ -172,6 +186,8 @@ namespace XrayUI.Services
             var rowSni        = Wrap(txtSni);
             var rowFp         = Wrap(txtFp);
             var rowAllowInsecure = Wrap(chkAllowInsecure);
+            var rowEchConfigList = Wrap(txtEchConfigList);
+            var rowEchForceQuery = Wrap(cmbEchForceQuery);
             var rowPk         = Wrap(txtPk);
             var rowSid        = Wrap(txtSid);
             var rowSpx        = Wrap(txtSpx);
@@ -195,6 +211,7 @@ namespace XrayUI.Services
                 bool hasGrpc     = !isHysteria2 && net == "grpc";
                 bool hasTls      = !isHysteria2 && (sec == "tls" || sec == "reality");
                 bool hasReality  = !isHysteria2 && sec == "reality";
+                bool hasEch      = isVless && sec == "tls";
 
                 cmbNetwork .Visibility = isHysteria2                 ? Visibility.Collapsed : Visibility.Visible;
                 cmbSecurity.Visibility = isHysteria2                 ? Visibility.Collapsed : Visibility.Visible;
@@ -209,6 +226,8 @@ namespace XrayUI.Services
                 rowSni       .Visibility = (hasTls || isHysteria2)    ? Visibility.Visible : Visibility.Collapsed;
                 rowFp        .Visibility = hasTls                     ? Visibility.Visible : Visibility.Collapsed;
                 rowAllowInsecure.Visibility = (hasTls || isHysteria2) ? Visibility.Visible : Visibility.Collapsed;
+                rowEchConfigList.Visibility = hasEch                  ? Visibility.Visible : Visibility.Collapsed;
+                rowEchForceQuery.Visibility = hasEch                  ? Visibility.Visible : Visibility.Collapsed;
                 rowPk        .Visibility = hasReality                 ? Visibility.Visible : Visibility.Collapsed;
                 rowSid       .Visibility = hasReality                 ? Visibility.Visible : Visibility.Collapsed;
                 rowSpx       .Visibility = hasReality                 ? Visibility.Visible : Visibility.Collapsed;
@@ -239,7 +258,8 @@ namespace XrayUI.Services
                     txtName, txtHost, numPort, cmbProtocol,
                     rowEncryption, rowPassword, rowUuid, rowAlterId,
                     cmbNetwork, rowPath, rowWsHost,
-                    cmbSecurity, rowSni, rowFp, rowAllowInsecure, rowPk, rowSid, rowSpx, rowFlow, rowVlessEncryption,
+                    cmbSecurity, rowSni, rowFp, rowAllowInsecure, rowEchConfigList, rowEchForceQuery,
+                    rowPk, rowSid, rowSpx, rowFlow, rowVlessEncryption,
                     rowFinalmask
                 }
             };
@@ -277,6 +297,8 @@ namespace XrayUI.Services
             entry.Sni         = txtSni.Text.Trim();
             entry.Fingerprint = txtFp.Text.Trim();
             entry.AllowInsecure = chkAllowInsecure.IsChecked == true;
+            entry.EchConfigList = txtEchConfigList.Text.Trim();
+            entry.EchForceQuery = EchSettings.NormalizeForceQuery(cmbEchForceQuery.SelectedItem?.ToString());
             entry.PublicKey   = txtPk.Text.Trim();
             entry.ShortId     = txtSid.Text.Trim();
             entry.SpiderX     = txtSpx.Text.Trim();
@@ -287,6 +309,14 @@ namespace XrayUI.Services
             if (entry.Protocol == "hysteria2")
             {
                 entry.Security = "tls";
+            }
+
+            if (!string.Equals(entry.Protocol, "vless", StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(entry.Security, "tls", StringComparison.OrdinalIgnoreCase)
+                || string.IsNullOrWhiteSpace(entry.EchConfigList))
+            {
+                entry.EchConfigList = string.Empty;
+                entry.EchForceQuery = string.Empty;
             }
 
             if (entry.Protocol != "ss")

--- a/Services/EchSettings.cs
+++ b/Services/EchSettings.cs
@@ -1,0 +1,23 @@
+namespace XrayUI.Services
+{
+    /// <summary>
+    /// Shared constants and normalization for VLESS+TLS Encrypted Client Hello (ECH) settings.
+    /// Used by parser, serializer, config builder, dialog, and detail view.
+    /// </summary>
+    internal static class EchSettings
+    {
+        public const string None = "none";
+        public const string Half = "half";
+        public const string Full = "full";
+
+        /// <summary>
+        /// Returns "half"/"full" if value matches (after trim + lower-invariant); otherwise empty.
+        /// "none" maps to empty since the model stores absence as empty string.
+        /// </summary>
+        public static string NormalizeForceQuery(string? value)
+        {
+            value = value?.Trim().ToLowerInvariant();
+            return value is Half or Full ? value : string.Empty;
+        }
+    }
+}

--- a/Services/NodeLinkParser.cs
+++ b/Services/NodeLinkParser.cs
@@ -232,6 +232,9 @@ namespace XrayUI.Services
                 var wsHost   = Q(query, "host", string.Empty) ?? string.Empty;
                 var flow     = Q(query, "flow", string.Empty) ?? string.Empty;
                 var vlessEncryption = Q(query, "encryption", string.Empty) ?? string.Empty;
+                var echConfigList = Q(query, "echConfigList") ?? Q(query, "ech") ?? string.Empty;
+                var echForceQuery = EchSettings.NormalizeForceQuery(
+                    Q(query, "echForceQuery") ?? Q(query, "echfq"));
                 var finalmask = FinalmaskJson.NormalizeForStorage(Q(query, "fm"));
                 var allowInsecure = IsTruthy(Q(query, "allowInsecure")) || IsTruthy(Q(query, "insecure"));
 
@@ -247,6 +250,8 @@ namespace XrayUI.Services
                     Sni         = sni,
                     Fingerprint = fp,
                     AllowInsecure = allowInsecure,
+                    EchConfigList = echConfigList,
+                    EchForceQuery = echForceQuery,
                     PublicKey   = pk,
                     ShortId     = sid,
                     SpiderX     = spx,

--- a/Services/NodeLinkSerializer.cs
+++ b/Services/NodeLinkSerializer.cs
@@ -112,6 +112,12 @@ namespace XrayUI.Services
                     AppendParam(sb, "allowInsecure", "1", first: false);
             }
 
+            if (security == "tls" && !string.IsNullOrWhiteSpace(s.EchConfigList))
+            {
+                AppendIfNotEmpty(sb, "echConfigList", s.EchConfigList);
+                AppendIfNotEmpty(sb, "echForceQuery", EchSettings.NormalizeForceQuery(s.EchForceQuery));
+            }
+
             // Reality-only params
             if (security == "reality")
             {

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using XrayUI.Models;
@@ -334,12 +335,26 @@ namespace XrayUI.Services
             {
                 var sni = string.IsNullOrWhiteSpace(server.Sni) ? server.Host : server.Sni;
                 var fingerprint = string.IsNullOrWhiteSpace(server.Fingerprint) ? "chrome" : server.Fingerprint;
-                stream["tlsSettings"] = new JsonObject
+                var tlsSettings = new JsonObject
                 {
                     ["serverName"] = sni,
                     ["fingerprint"] = fingerprint,
                     ["allowInsecure"] = server.AllowInsecure
                 };
+
+                if (string.Equals(server.Protocol, "vless", StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrWhiteSpace(server.EchConfigList))
+                {
+                    tlsSettings["echConfigList"] = server.EchConfigList;
+
+                    var echForceQuery = EchSettings.NormalizeForceQuery(server.EchForceQuery);
+                    if (!string.IsNullOrEmpty(echForceQuery))
+                    {
+                        tlsSettings["echForceQuery"] = echForceQuery;
+                    }
+                }
+
+                stream["tlsSettings"] = tlsSettings;
             }
             else if (security == "reality")
             {

--- a/ViewModels/ServerDetailViewModel.cs
+++ b/ViewModels/ServerDetailViewModel.cs
@@ -106,6 +106,29 @@ namespace XrayUI.ViewModels
                 ? Visibility.Visible
                 : Visibility.Collapsed;
 
+        public string SelectedEch
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(SelectedServer?.EchConfigList))
+                {
+                    return string.Empty;
+                }
+
+                var echForceQuery = EchSettings.NormalizeForceQuery(SelectedServer.EchForceQuery);
+                return string.IsNullOrEmpty(echForceQuery)
+                    ? SelectedServer.EchConfigList
+                    : $"{SelectedServer.EchConfigList} ({echForceQuery})";
+            }
+        }
+
+        public Visibility EchVisibility
+            => string.Equals(SelectedServer?.Protocol, "vless", StringComparison.OrdinalIgnoreCase)
+               && string.Equals(SelectedServer?.Security, "tls", StringComparison.OrdinalIgnoreCase)
+               && !string.IsNullOrWhiteSpace(SelectedServer?.EchConfigList)
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+
         public string SelectedShareLink
             => SelectedServer is null ? string.Empty : (NodeLinkSerializer.ToLink(SelectedServer) ?? string.Empty);
 
@@ -254,13 +277,25 @@ namespace XrayUI.ViewModels
                     OnPropertyChanged(nameof(SelectedSecurityLabel));
                     OnPropertyChanged(nameof(SelectedTransport));
                     OnPropertyChanged(nameof(VlessEncryptionVisibility));
+                    OnPropertyChanged(nameof(EchVisibility));
+                    OnPropertyChanged(nameof(SelectedShareLink));
                     break;
                 case nameof(ServerEntry.Encryption):
                     OnPropertyChanged(nameof(SelectedEncryption));
                     break;
+                case nameof(ServerEntry.Security):
+                    OnPropertyChanged(nameof(EchVisibility));
+                    OnPropertyChanged(nameof(SelectedShareLink));
+                    break;
                 case nameof(ServerEntry.VlessEncryption):
                     OnPropertyChanged(nameof(SelectedVlessEncryption));
                     OnPropertyChanged(nameof(VlessEncryptionVisibility));
+                    OnPropertyChanged(nameof(SelectedShareLink));
+                    break;
+                case nameof(ServerEntry.EchConfigList):
+                case nameof(ServerEntry.EchForceQuery):
+                    OnPropertyChanged(nameof(SelectedEch));
+                    OnPropertyChanged(nameof(EchVisibility));
                     OnPropertyChanged(nameof(SelectedShareLink));
                     break;
                 case nameof(ServerEntry.Network):
@@ -285,6 +320,8 @@ namespace XrayUI.ViewModels
             OnPropertyChanged(nameof(SelectedEncryption));
             OnPropertyChanged(nameof(SelectedVlessEncryption));
             OnPropertyChanged(nameof(VlessEncryptionVisibility));
+            OnPropertyChanged(nameof(SelectedEch));
+            OnPropertyChanged(nameof(EchVisibility));
             OnPropertyChanged(nameof(SelectedTransport));
             OnPropertyChanged(nameof(SelectedShareLink));
             OnPropertyChanged(nameof(CanTestLatency));

--- a/Views/ServerDetailControl.xaml
+++ b/Views/ServerDetailControl.xaml
@@ -59,6 +59,7 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
 
                             <!-- Row 0: 名称 -->
@@ -137,12 +138,27 @@
                                        VerticalAlignment="Center"
                                        Visibility="{x:Bind ViewModel.VlessEncryptionVisibility, Mode=OneWay}" />
                             <TextBlock Grid.Row="6"
+                                        Grid.Column="1"
+                                        Text="{x:Bind ViewModel.SelectedVlessEncryption, Mode=OneWay}"
+                                        ToolTipService.ToolTip="{x:Bind ViewModel.SelectedVlessEncryption, Mode=OneWay}"
+                                        FontSize="13"
+                                        TextTrimming="CharacterEllipsis"
+                                        Visibility="{x:Bind ViewModel.VlessEncryptionVisibility, Mode=OneWay}" />
+
+                            <!-- Row 7: ECH - VLESS + TLS only, hidden if empty -->
+                            <TextBlock Grid.Row="7"
+                                       Grid.Column="0"
+                                       Text="ECH"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       VerticalAlignment="Center"
+                                       Visibility="{x:Bind ViewModel.EchVisibility, Mode=OneWay}" />
+                            <TextBlock Grid.Row="7"
                                        Grid.Column="1"
-                                       Text="{x:Bind ViewModel.SelectedVlessEncryption, Mode=OneWay}"
-                                       ToolTipService.ToolTip="{x:Bind ViewModel.SelectedVlessEncryption, Mode=OneWay}"
+                                       Text="{x:Bind ViewModel.SelectedEch, Mode=OneWay}"
+                                       ToolTipService.ToolTip="{x:Bind ViewModel.SelectedEch, Mode=OneWay}"
                                        FontSize="13"
                                        TextTrimming="CharacterEllipsis"
-                                       Visibility="{x:Bind ViewModel.VlessEncryptionVisibility, Mode=OneWay}" />
+                                       Visibility="{x:Bind ViewModel.EchVisibility, Mode=OneWay}" />
                         </Grid>
 
                         <!-- AI 服务监测区 -->


### PR DESCRIPTION
## Summary

Adds Encrypted Client Hello (ECH) client-side support for VLESS+TLS servers.

## What changed

- **`Models/ServerEntry.cs`** — two new `[ObservableProperty]` fields: `EchConfigList` (string, empty = ECH disabled) and `EchForceQuery` (`half`/`full`/empty).
- **`Services/EchSettings.cs`** *(new)* — shared `Half`/`Full`/`None` constants and `NormalizeForceQuery(string?)` helper. Single source of truth referenced by parser, serializer, config builder, dialog, and the detail VM.
- **`Services/NodeLinkParser.cs`** — reads `echConfigList`/`ech` and `echForceQuery`/`echfq` from VLESS share-link query parameters.
- **`Services/NodeLinkSerializer.cs`** — emits the same params when `security == tls` and `EchConfigList` is non-empty.
- **`Services/XrayConfigBuilder.cs`** — injects `echConfigList` and `echForceQuery` into the VLESS+TLS `tlsSettings` JSON object.
- **`Services/DialogService.cs`** — adds an `ECH ConfigList` text box and `ECH Force Query` combo box to the server-edit dialog, shown only when protocol is VLESS and security is TLS. Post-save scrub clears both fields when the conditions no longer hold (the dialog hides the rows but does not wipe ComboBox state on switch).
- **`ViewModels/ServerDetailViewModel.cs` / `Views/ServerDetailControl.xaml`** — new `SelectedEch` / `EchVisibility` derived properties and a row in the server detail panel.

## Notable details

- Force-query is stored as `""`/`"half"`/`"full"` — the UI's three-option combo (`none` / `half` / `full`) maps `none` ↔ empty.
- The xray config builder applies the strict guard (`Protocol == "vless" && !empty(EchConfigList)`); the dialog's post-save scrub mirrors it so persisted entries can never carry ECH state on non-VLESS servers.
- Drive-by fix: `ServerDetailViewModel.OnSelectedServerPropertyChanged` now raises `SelectedShareLink` on `Protocol` changes too — previously only the protocol-derived display fields refreshed, leaving the displayed share URI stale until another property changed.

## Test plan

- [ ] Create a new VLESS+TLS server via the edit dialog with `EchConfigList` set; confirm it shows in the detail panel and survives a round-trip through the share link.
- [ ] Toggle `Force Query` between `none`/`half`/`full`; confirm the share link's `echForceQuery` parameter updates and the detail row reflects the suffix `(half)` / `(full)`.
- [ ] Switch the protocol to vmess, save, reopen — confirm `EchConfigList` and `EchForceQuery` are cleared.
- [ ] Connect to a VLESS+TLS server with ECH configured; confirm `xray_config.json` under `%LocalAppData%\XrayUI\` has `echConfigList`/`echForceQuery` under `streamSettings.tlsSettings`.
- [ ] Paste a `vless://` link with `&echConfigList=...&echForceQuery=full` and confirm it imports correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)