### PR TITLE
[codex] Add multi-select server deletion

### DIFF
--- a/Services/XrayService.cs
+++ b/Services/XrayService.cs
@@ -23,7 +23,9 @@ namespace XrayUI.Services
         private const int LogBufferMax = 500;
 
         private Process? _process;
-        private readonly StringBuilder _startupLog = new();
+        private StringBuilder _startupLog = new();
+        private bool _collectStartupLog;
+        private readonly Lock _startupLogLock = new();
 
         // Fixed-size ring buffer: O(1) append + oldest-drop, no array shifting.
         private readonly string[] _logBuffer = new string[LogBufferMax];
@@ -90,6 +92,50 @@ namespace XrayUI.Services
             LogReceived?.Invoke(this, line);
         }
 
+        private void BeginStartupLogCapture()
+        {
+            lock (_startupLogLock)
+            {
+                _startupLog = new StringBuilder();
+                _collectStartupLog = true;
+            }
+        }
+
+        private void AppendStartupLog(string line)
+        {
+            lock (_startupLogLock)
+            {
+                if (!_collectStartupLog)
+                {
+                    return;
+                }
+
+                _startupLog.AppendLine(line);
+            }
+        }
+
+        private string StopStartupLogCaptureAndRead()
+        {
+            lock (_startupLogLock)
+            {
+                _collectStartupLog = false;
+                var text = _startupLog.Length > 0
+                    ? _startupLog.ToString().Trim()
+                    : string.Empty;
+                _startupLog = new StringBuilder();
+                return text;
+            }
+        }
+
+        private void StopStartupLogCapture()
+        {
+            lock (_startupLogLock)
+            {
+                _collectStartupLog = false;
+                _startupLog = new StringBuilder();
+            }
+        }
+
         public async Task<bool> StartAsync(string configJson)
         {
             if (IsRunning)
@@ -98,7 +144,6 @@ namespace XrayUI.Services
             }
 
             LastError = string.Empty;
-            _startupLog.Clear();
 
             if (!File.Exists(ExePath))
             {
@@ -129,23 +174,20 @@ namespace XrayUI.Services
                 _process.OutputDataReceived += (_, e) =>
                 {
                     if (e.Data is null) return;
-                    _startupLog.AppendLine(e.Data);
+                    AppendStartupLog(e.Data);
                     AppendLog(e.Data);
                 };
 
                 _process.ErrorDataReceived += (_, e) =>
                 {
                     if (e.Data is null) return;
-                    _startupLog.AppendLine(e.Data);
+                    AppendStartupLog(e.Data);
                     AppendLog(e.Data);
                 };
 
-                _process.Exited += (_, _) =>
-                {
-                    AppendLog("[xray 进程已退出]");
-                    RunningChanged?.Invoke(this, false);
-                };
+                _process.Exited += OnProcessExited;
 
+                BeginStartupLogCapture();
                 _process.Start();
                 _process.BeginOutputReadLine();
                 _process.BeginErrorReadLine();
@@ -157,18 +199,21 @@ namespace XrayUI.Services
 
                 if (_process.HasExited)
                 {
-                    LastError = _startupLog.Length > 0
-                        ? _startupLog.ToString().Trim()
+                    var startupLog = StopStartupLogCaptureAndRead();
+                    LastError = startupLog.Length > 0
+                        ? startupLog
                         : $"xray 立即退出（退出码 {_process.ExitCode}）";
                     AppendLog("[错误] 启动失败：" + LastError);
                     return false;
                 }
 
+                StopStartupLogCapture();
                 RunningChanged?.Invoke(this, true);
                 return true;
             }
             catch (Exception ex)
             {
+                StopStartupLogCapture();
                 LastError = ex.Message;
                 AppendLog("[异常] " + ex.Message);
                 return false;
@@ -181,6 +226,8 @@ namespace XrayUI.Services
             {
                 return;
             }
+
+            _process.Exited -= OnProcessExited;
 
             try
             {
@@ -212,6 +259,7 @@ namespace XrayUI.Services
                 return;
             }
 
+            process.Exited -= OnProcessExited;
             _process = null;
 
             try
@@ -231,6 +279,12 @@ namespace XrayUI.Services
             }
 
             AppendLog("[shutdown] xray stopped");
+            RunningChanged?.Invoke(this, false);
+        }
+
+        private void OnProcessExited(object? sender, EventArgs e)
+        {
+            AppendLog("[xray 进程已退出]");
             RunningChanged?.Invoke(this, false);
         }
     }

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -210,7 +210,9 @@ namespace XrayUI.ViewModels
             set
             {
                 if (SetProperty(ref _selectedServer, value))
-                    NotifyServerActionStateChanged();
+                    SetSelectedServers(value is null
+                        ? Array.Empty<ServerEntry>()
+                        : new[] { value });
             }
         }
 
@@ -230,11 +232,15 @@ namespace XrayUI.ViewModels
 
         public bool IsSelectedServerLocked => IsProxyRunning && SelectedServer?.IsActive == true;
 
-        public int SelectedServerCount => GetSelectedServersSnapshot().Count;
+        public int SelectedServerCount =>
+            _selectedServers.Count > 0 ? _selectedServers.Count : (SelectedServer is null ? 0 : 1);
 
-        public bool HasMultipleSelectedServers => SelectedServerCount > 1;
+        public bool HasMultipleSelectedServers => _selectedServers.Count > 1;
 
-        public bool HasLockedSelectedServer => IsProxyRunning && GetSelectedServersSnapshot().Any(s => s.IsActive);
+        public bool HasLockedSelectedServer => IsProxyRunning && (
+            _selectedServers.Count > 0
+                ? _selectedServers.Any(s => s.IsActive)
+                : SelectedServer?.IsActive == true);
 
         public bool CanEditSelectedServer => SelectedServer != null
             && !HasMultipleSelectedServers
@@ -927,9 +933,6 @@ namespace XrayUI.ViewModels
             }
 
             SelectedServer = nextSelected;
-            SetSelectedServers(nextSelected is null
-                ? Array.Empty<ServerEntry>()
-                : new[] { nextSelected });
 
             await SaveAsync();
         }

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -43,6 +43,7 @@ namespace XrayUI.ViewModels
         private readonly SemaphoreSlim   _settingsWriteLock = new(1, 1);
         private ObservableCollection<ServerEntry> _servers = new();
         private ServerEntry? _selectedServer;
+        private readonly List<ServerEntry> _selectedServers = new();
         private bool _isProxyRunning;
         private bool _disposed;
 
@@ -78,6 +79,10 @@ namespace XrayUI.ViewModels
             _disposed = true;
             ProtocolColorStore.ColorsChanged -= OnProtocolColorsChanged;
             _servers.CollectionChanged -= OnServersCollectionChanged;
+            foreach (var server in _selectedServers)
+            {
+                server.PropertyChanged -= OnSelectedItemPropertyChanged;
+            }
         }
 
         public ObservableCollection<ServerEntry> Servers
@@ -117,7 +122,8 @@ namespace XrayUI.ViewModels
         public bool CanReorderInCurrentChip =>
             string.IsNullOrWhiteSpace(_searchQuery)
             && _sortMode == ServerSortMode.Default
-            && VisibleServers.Count > 1;
+            && VisibleServers.Count > 1
+            && !HasMultipleSelectedServers;
 
         public ServerSortMode SortMode
         {
@@ -203,11 +209,8 @@ namespace XrayUI.ViewModels
             get => _selectedServer;
             set
             {
-                var previous = _selectedServer;
                 if (SetProperty(ref _selectedServer, value))
-                {
-                    OnSelectedServerChanged(previous, value);
-                }
+                    NotifyServerActionStateChanged();
             }
         }
 
@@ -227,13 +230,35 @@ namespace XrayUI.ViewModels
 
         public bool IsSelectedServerLocked => IsProxyRunning && SelectedServer?.IsActive == true;
 
-        public bool CanEditSelectedServer => SelectedServer != null && !IsSelectedServerLocked;
+        public int SelectedServerCount => GetSelectedServersSnapshot().Count;
 
-        public bool CanRemoveSelectedServer => SelectedServer != null && !IsSelectedServerLocked;
+        public bool HasMultipleSelectedServers => SelectedServerCount > 1;
 
-        public bool CanEditServer => CanEditSelectedServer;
+        public bool HasLockedSelectedServer => IsProxyRunning && GetSelectedServersSnapshot().Any(s => s.IsActive);
 
-        public bool CanRemoveServer => CanRemoveSelectedServer;
+        public bool CanEditSelectedServer => SelectedServer != null
+            && !HasMultipleSelectedServers
+            && !IsSelectedServerLocked;
+
+        public bool CanRemoveSelectedServer => SelectedServerCount > 0 && !HasLockedSelectedServer;
+
+        private List<ServerEntry> GetSelectedServersSnapshot() => _selectedServers.Count > 0
+            ? _selectedServers.ToList()
+            : SelectedServer is null ? new List<ServerEntry>() : new List<ServerEntry> { SelectedServer };
+
+        public void SetSelectedServers(IReadOnlyList<ServerEntry> selectedServers)
+        {
+            foreach (var server in _selectedServers)
+                server.PropertyChanged -= OnSelectedItemPropertyChanged;
+
+            _selectedServers.Clear();
+            _selectedServers.AddRange(selectedServers);
+
+            foreach (var server in _selectedServers)
+                server.PropertyChanged += OnSelectedItemPropertyChanged;
+
+            NotifyServerActionStateChanged();
+        }
 
         // ── Search ────────────────────────────────────────────────────────────
 
@@ -486,38 +511,23 @@ namespace XrayUI.ViewModels
                 : new List<SubscriptionEntry>();
         }
 
-        private void OnSelectedServerChanged(ServerEntry? previous, ServerEntry? current)
+        private void OnSelectedItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (previous is not null)
-            {
-                previous.PropertyChanged -= OnSelectedServerPropertyChanged;
-            }
-
-            if (current is not null)
-            {
-                current.PropertyChanged += OnSelectedServerPropertyChanged;
-            }
-
+            if (e.PropertyName != nameof(ServerEntry.IsActive)) return;
             NotifyServerActionStateChanged();
-        }
-
-        private void OnSelectedServerPropertyChanged(object? sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(ServerEntry.IsActive))
-            {
-                NotifyServerActionStateChanged();
-                if (_sortMode == ServerSortMode.Active)
-                    RebuildGroupedView();
-            }
+            if (_sortMode == ServerSortMode.Active)
+                RebuildGroupedView();
         }
 
         private void NotifyServerActionStateChanged()
         {
             OnPropertyChanged(nameof(IsSelectedServerLocked));
+            OnPropertyChanged(nameof(SelectedServerCount));
+            OnPropertyChanged(nameof(HasMultipleSelectedServers));
+            OnPropertyChanged(nameof(HasLockedSelectedServer));
             OnPropertyChanged(nameof(CanEditSelectedServer));
             OnPropertyChanged(nameof(CanRemoveSelectedServer));
-            OnPropertyChanged(nameof(CanEditServer));
-            OnPropertyChanged(nameof(CanRemoveServer));
+            OnPropertyChanged(nameof(CanReorderInCurrentChip));
         }
 
         // ── Import via link ───────────────────────────────────────────────────
@@ -792,6 +802,7 @@ namespace XrayUI.ViewModels
         private async Task EditServer()
         {
             if (SelectedServer is null) return;
+            if (HasMultipleSelectedServers) return;
 
             // Pass existing so dialog can pre-populate; dialog mutates and returns same ref on Primary
             var result = await _dialogs.ShowEditServerDialogAsync(SelectedServer);
@@ -868,23 +879,57 @@ namespace XrayUI.ViewModels
         [RelayCommand]
         private async Task RemoveServer()
         {
-            if (SelectedServer is null) return;
+            var selectedServers = GetSelectedServersSnapshot();
+            if (selectedServers.Count == 0) return;
+            if (IsProxyRunning && selectedServers.Any(s => s.IsActive)) return;
+
+            var isBatchDelete = selectedServers.Count > 1;
+            var message = isBatchDelete
+                ? $"确定要删除当前 {selectedServers.Count} 个项目?"
+                : $"确定要删除 {selectedServers[0].Name}?";
 
             var confirmed = await _dialogs.ShowConfirmationAsync(
                 "确认删除",
-                $"确定要删除 {SelectedServer.Name}?",
+                message,
                 "删除",
                 "取消",
                 isDanger: true);
             if (!confirmed) return;
 
-            var toRemove = SelectedServer;
-            var idx      = Servers.IndexOf(toRemove);
-            Servers.Remove(toRemove);
+            ServerEntry? nextSelected;
+            if (isBatchDelete)
+            {
+                var firstVisibleIdx = selectedServers
+                    .Select(s => VisibleServers.IndexOf(s))
+                    .Where(i => i >= 0)
+                    .DefaultIfEmpty(0)
+                    .Min();
 
-            SelectedServer = Servers.Count > 0
-                ? Servers[Math.Max(0, idx - 1)]
-                : null;
+                MutateServersInBatch(() =>
+                {
+                    foreach (var server in selectedServers)
+                        Servers.Remove(server);
+                });
+
+                nextSelected = VisibleServers.Count > 0
+                    ? VisibleServers[Math.Min(firstVisibleIdx, VisibleServers.Count - 1)]
+                    : Servers.FirstOrDefault();
+            }
+            else
+            {
+                var toRemove = selectedServers[0];
+                var idx      = Servers.IndexOf(toRemove);
+                Servers.Remove(toRemove);
+
+                nextSelected = Servers.Count > 0
+                    ? Servers[Math.Max(0, idx - 1)]
+                    : null;
+            }
+
+            SelectedServer = nextSelected;
+            SetSelectedServers(nextSelected is null
+                ? Array.Empty<ServerEntry>()
+                : new[] { nextSelected });
 
             await SaveAsync();
         }

--- a/Views/ServerListControl.xaml
+++ b/Views/ServerListControl.xaml
@@ -190,7 +190,8 @@
                   CanReorderItems="{x:Bind ViewModel.CanReorderInCurrentChip, Mode=OneWay}"
                   AllowDrop="{x:Bind ViewModel.CanReorderInCurrentChip, Mode=OneWay}"
                   DragItemsCompleted="ServersListView_DragItemsCompleted"
-                  SelectionMode="Single"
+                  SelectionChanged="ServersListView_SelectionChanged"
+                  SelectionMode="Extended"
                   ScrollViewer.VerticalScrollBarVisibility="Auto">
 
             <ListView.ItemTemplate>

--- a/Views/ServerListControl.xaml.cs
+++ b/Views/ServerListControl.xaml.cs
@@ -74,6 +74,11 @@ namespace XrayUI.Views
             await ViewModel.SaveOrderAsync();
         }
 
+        private void ServersListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            ViewModel.SetSelectedServers(ServersListView.SelectedItems.OfType<ServerEntry>().ToArray());
+        }
+
         private async void ServerItem_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
         {
             if (sender is not FrameworkElement element)
@@ -95,6 +100,12 @@ namespace XrayUI.Views
 
         private void ServerItem_ContextRequested(UIElement sender, ContextRequestedEventArgs e)
         {
+            if (ViewModel.HasMultipleSelectedServers)
+            {
+                e.Handled = true;
+                return;
+            }
+
             if (sender is not FrameworkElement element)
             {
                 e.Handled = true;


### PR DESCRIPTION
## Summary

- Adds extended multi-selection support to the server list for batch deletion.
- Keeps single-selection behavior for editing, details, context menu actions, and server switching.
- Disables delete when the selection includes the active server, and disables drag reorder while multiple servers are selected.
- Includes the existing `optimise start process` commit already present on `net10`, which makes startup log capture thread-safe and avoids duplicate exit notifications during intentional stop paths.

## Impact

Users can select multiple server nodes and delete them with one confirmation dialog while active/running nodes remain protected. Single-node workflows should continue to behave as before.

## Validation

- `dotnet build --no-restore` passed with 0 warnings and 0 errors after allowing access to the local Windows SDK cache.