### PR TITLE
feat: DNS settings dialog, FakeDNS, and process-based routing rules

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -23,7 +23,7 @@
             <!-- State indicator brush palette (AI unlock status) -->
             <SolidColorBrush x:Key="StateNeutralBrush" Color="{ThemeResource SystemFillColorNeutral}" />
             <SolidColorBrush x:Key="StateSuccessBrush" Color="#48C78E" />
-            <SolidColorBrush x:Key="StateErrorBrush"   Color="#EF4444" />
+            <SolidColorBrush x:Key="StateErrorBrush"   Color="{ThemeResource SystemFillColorCritical}" />
 
 
             <!-- Danger button brush palette -->

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -34,6 +34,17 @@ namespace XrayUI.Models
         public bool ShowLatencyInDetails { get; set; } = true;
         public bool ShowAiUnlockInDetails { get; set; } = true;
 
+        // ── DNS ───────────────────────────────────────────────────────────────
+        /// <summary>直连 DNS，用于国内域名 (geosite:cn)。null = 按 TUN 模式自动选取默认值。</summary>
+        public string? DirectDnsServer { get; set; }
+        /// <summary>代理 DNS，用于境外域名，经代理出站解析。null = 使用默认 8.8.8.8。</summary>
+        public string? ProxyDnsServer { get; set; }
+        /// <summary>Values from <see cref="XrayUI.Services.DnsQueryStrategy"/>.</summary>
+        public string DnsQueryStrategy { get; set; } = "UseIPv4";
+        public bool DnsCacheEnabled { get; set; } = true;
+        /// <summary>Enable xray FakeDNS. Only takes effect when IsTunMode is true.</summary>
+        public bool FakeDnsEnabled { get; set; } = false;
+
         // ── Custom routing rules ──────────────────────────────────────────────
         /// <summary>User-defined routing rules. Applied only when RoutingMode == "smart".</summary>
         public List<CustomRoutingRule>? CustomRules { get; set; }

--- a/Models/CustomRoutingRule.cs
+++ b/Models/CustomRoutingRule.cs
@@ -4,10 +4,10 @@ namespace XrayUI.Models
 {
     public class CustomRoutingRule
     {
-        /// <summary>"domain" | "ip"</summary>
+        /// <summary>"domain" | "ip" | "process"</summary>
         public string Type { get; set; } = "domain";
 
-        /// <summary>youtube.com / 192.168.0.0/16 / geosite:cn / geoip:cn</summary>
+        /// <summary>youtube.com / 192.168.0.0/16 / geosite:cn / geoip:cn / chrome.exe / C:\Games\xxx.exe</summary>
         public string Match { get; set; } = "";
 
         /// <summary>"proxy" | "direct" | "block"</summary>
@@ -17,8 +17,9 @@ namespace XrayUI.Models
 
         // Helpers for x:Bind (OneTime) inside DataTemplate.
         // Visibility is computed directly to avoid converter lookups in a Window root.
-        [JsonIgnore] public Visibility DomainVisibility => Type == "domain" ? Visibility.Visible : Visibility.Collapsed;
-        [JsonIgnore] public Visibility IpVisibility     => Type == "ip"     ? Visibility.Visible : Visibility.Collapsed;
+        [JsonIgnore] public Visibility DomainVisibility  => Type == "domain"  ? Visibility.Visible : Visibility.Collapsed;
+        [JsonIgnore] public Visibility IpVisibility      => Type == "ip"      ? Visibility.Visible : Visibility.Collapsed;
+        [JsonIgnore] public Visibility ProcessVisibility => Type == "process" ? Visibility.Visible : Visibility.Collapsed;
 
         public CustomRoutingRule Clone() => new()
         {

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -31,28 +31,28 @@ namespace XrayUI.Services
             var textBox = new TextBox
             {
                 PlaceholderText = "粘贴节点链接（支持多协议）",
-                AcceptsReturn   = true,
-                Width           = 360,
-                Height          = 148,
-                TextWrapping    = TextWrapping.Wrap,
+                AcceptsReturn = true,
+                Width = 360,
+                Height = 148,
+                TextWrapping = TextWrapping.Wrap,
                 VerticalAlignment = VerticalAlignment.Top,
                 VerticalContentAlignment = VerticalAlignment.Top
             };
 
             var dialog = CreateDialog();
-            dialog.Title             = "导入节点链接";
+            dialog.Title = "导入节点链接";
             dialog.PrimaryButtonText = "确定";
-            dialog.CloseButtonText   = "取消";
-            dialog.DefaultButton     = ContentDialogButton.Primary;
+            dialog.CloseButtonText = "取消";
+            dialog.DefaultButton = ContentDialogButton.Primary;
             dialog.Content = new StackPanel
             {
-                Width    = 300,
-                Spacing  = 12,
+                Width = 300,
+                Spacing = 12,
                 Children =
                 {
                     new TextBlock
                     {
-                        Text    = "支持常见协议链接",
+                        Text = "支持常见协议链接",
                         Opacity = 0.65,
                     },
                     textBox
@@ -65,7 +65,7 @@ namespace XrayUI.Services
             var text = textBox.Text?.Trim();
             return string.IsNullOrEmpty(text) ? null : text;
         }
-  
+
         // ── Subscriptions ─────────────────────────────────────────────────────
 
         public async Task<SubscriptionEntry?> ShowSubscriptionsDialogAsync(ManageSubscriptionsViewModel vm)
@@ -77,16 +77,16 @@ namespace XrayUI.Services
             {
                 if (vm.IsAddPage)
                 {
-                    dialog.PrimaryButtonText      = "添加";
-                    dialog.CloseButtonText        = "取消";
-                    dialog.DefaultButton          = ContentDialogButton.Primary;
+                    dialog.PrimaryButtonText = "添加";
+                    dialog.CloseButtonText = "取消";
+                    dialog.DefaultButton = ContentDialogButton.Primary;
                     dialog.IsPrimaryButtonEnabled = vm.CanAddSubscription;
                     return;
                 }
 
-                dialog.PrimaryButtonText      = string.Empty;
-                dialog.CloseButtonText        = "完成";
-                dialog.DefaultButton          = ContentDialogButton.Close;
+                dialog.PrimaryButtonText = string.Empty;
+                dialog.CloseButtonText = "完成";
+                dialog.DefaultButton = ContentDialogButton.Close;
                 dialog.IsPrimaryButtonEnabled = false;
             }
 
@@ -110,38 +110,48 @@ namespace XrayUI.Services
         public async Task<ServerEntry?> ShowEditServerDialogAsync(ServerEntry? existing)
         {
             // ── Controls ──────────────────────────────────────────────────────
-            var txtName     = new TextBox { Header = "名称", Text = existing?.Name ?? string.Empty, MinWidth = 420 };
-            var txtHost     = new TextBox { Header = "地址 / 域名", Text = existing?.Host ?? string.Empty };
-            var numPort     = new NumberBox { Header = "端口", Value = existing?.Port ?? 443, Minimum = 1, Maximum = 65535, SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline };
-            var cmbProtocol = new ComboBox  { Header = "协议", MinWidth = 200 };
+            var txtName = new TextBox { Header = "名称", Text = existing?.Name ?? string.Empty, MinWidth = 420 };
+            var txtHost = new TextBox { Header = "地址 / 域名", Text = existing?.Host ?? string.Empty };
+            var numPort = new NumberBox
+            {
+                Header = "端口", Value = existing?.Port ?? 443, Minimum = 1, Maximum = 65535,
+                SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline
+            };
+            var cmbProtocol = new ComboBox { Header = "协议", MinWidth = 200 };
             foreach (var p in new[] { "ss", "vmess", "vless", "hysteria2", "trojan" })
                 cmbProtocol.Items.Add(p);
             cmbProtocol.SelectedItem = existing?.Protocol?.ToLower() ?? "ss";
 
             var cmbEncryption = new ComboBox { Header = "加密方式 (SS)", MinWidth = 200 };
-            foreach (var m in new[] { "aes-128-gcm", "aes-256-gcm", "chacha20-ietf-poly1305", "2022-blake3-aes-128-gcm", "2022-blake3-aes-256-gcm", "2022-blake3-chacha20-poly1305" })
+            foreach (var m in new[]
+                     {
+                         "aes-128-gcm", "aes-256-gcm", "chacha20-ietf-poly1305", "2022-blake3-aes-128-gcm",
+                         "2022-blake3-aes-256-gcm", "2022-blake3-chacha20-poly1305"
+                     })
                 cmbEncryption.Items.Add(m);
             if (existing?.Encryption is { Length: > 0 } existingEnc && !cmbEncryption.Items.Contains(existingEnc))
                 cmbEncryption.Items.Add(existingEnc);
             cmbEncryption.SelectedItem = existing?.Encryption ?? "aes-128-gcm";
-            var txtPassword   = new PasswordBox { Header = "密码", Password = existing?.Password ?? string.Empty };
-            var txtUuid       = new TextBox { Header = "UUID (VMess / VLESS)", Text = existing?.Uuid ?? string.Empty };
-            var numAlterId    = new NumberBox { Header = "AlterId (VMess)", Value = existing?.AlterId ?? 0, Minimum = 0, Maximum = 65535 };
-            var cmbNetwork    = new ComboBox { Header = "传输协议", MinWidth = 200 };
+            var txtPassword = new PasswordBox { Header = "密码", Password = existing?.Password ?? string.Empty };
+            var txtUuid = new TextBox { Header = "UUID (VMess / VLESS)", Text = existing?.Uuid ?? string.Empty };
+            var numAlterId = new NumberBox
+                { Header = "AlterId (VMess)", Value = existing?.AlterId ?? 0, Minimum = 0, Maximum = 65535 };
+            var cmbNetwork = new ComboBox { Header = "传输协议", MinWidth = 200 };
             foreach (var n in new[] { "tcp", "ws", "grpc", "xhttp" })
                 cmbNetwork.Items.Add(n);
             cmbNetwork.SelectedItem = existing?.Network ?? "tcp";
 
-            var txtPath     = new TextBox { Header = "路径 (WS/gRPC/XHTTP)", Text = existing?.Path ?? string.Empty };
-            var txtWsHost   = new TextBox { Header = "Host 头 (WS/XHTTP)", Text = existing?.WsHost ?? string.Empty };
+            var txtPath = new TextBox { Header = "路径 (WS/gRPC/XHTTP)", Text = existing?.Path ?? string.Empty };
+            var txtWsHost = new TextBox { Header = "Host 头 (WS/XHTTP)", Text = existing?.WsHost ?? string.Empty };
             var cmbSecurity = new ComboBox { Header = "安全", MinWidth = 200 };
             foreach (var s in new[] { "none", "tls", "reality" })
                 cmbSecurity.Items.Add(s);
             cmbSecurity.SelectedItem = existing?.Security ?? "none";
 
-            var txtSni  = new TextBox { Header = "SNI", Text = existing?.Sni ?? string.Empty };
-            var txtFp   = new TextBox { Header = "指纹 (uTLS)", Text = existing?.Fingerprint ?? string.Empty };
-            var chkAllowInsecure = new CheckBox { Content = "允许不安全连接（跳过证书校验）", IsChecked = existing?.AllowInsecure ?? false };
+            var txtSni = new TextBox { Header = "SNI", Text = existing?.Sni ?? string.Empty };
+            var txtFp = new TextBox { Header = "指纹 (uTLS)", Text = existing?.Fingerprint ?? string.Empty };
+            var chkAllowInsecure = new CheckBox
+                { Content = "允许不安全连接（跳过证书校验）", IsChecked = existing?.AllowInsecure ?? false };
             var txtEchConfigList = new TextBox
             {
                 Header = "ECH ConfigList",
@@ -156,10 +166,13 @@ namespace XrayUI.Services
             cmbEchForceQuery.SelectedItem = string.IsNullOrEmpty(existingEchForceQuery)
                 ? EchSettings.None
                 : existingEchForceQuery;
-            var txtPk   = new TextBox { Header = "PublicKey (Reality)", Text = existing?.PublicKey ?? string.Empty };
-            var txtSid  = new TextBox { Header = "ShortId (Reality)", Text = existing?.ShortId ?? string.Empty };
-            var txtSpx  = new TextBox { Header = "SpiderX (Reality)", Text = existing?.SpiderX ?? string.Empty };
-            var txtFlow = new TextBox { Header = "Flow (VLESS)", PlaceholderText = "xtls-rprx-vision 或留空", Text = existing?.Flow ?? string.Empty };
+            var txtPk = new TextBox { Header = "PublicKey (Reality)", Text = existing?.PublicKey ?? string.Empty };
+            var txtSid = new TextBox { Header = "ShortId (Reality)", Text = existing?.ShortId ?? string.Empty };
+            var txtSpx = new TextBox { Header = "SpiderX (Reality)", Text = existing?.SpiderX ?? string.Empty };
+            var txtFlow = new TextBox
+            {
+                Header = "Flow (VLESS)", PlaceholderText = "xtls-rprx-vision 或留空", Text = existing?.Flow ?? string.Empty
+            };
             var txtVlessEncryption = new TextBox
             {
                 Header = "VLESS encryption (PQ)",
@@ -178,61 +191,62 @@ namespace XrayUI.Services
 
             // Row containers for conditional visibility
             var rowEncryption = Wrap(cmbEncryption);
-            var rowPassword   = Wrap(txtPassword);
-            var rowUuid       = Wrap(txtUuid);
-            var rowAlterId    = Wrap(numAlterId);
-            var rowPath       = Wrap(txtPath);
-            var rowWsHost     = Wrap(txtWsHost);
-            var rowSni        = Wrap(txtSni);
-            var rowFp         = Wrap(txtFp);
+            var rowPassword = Wrap(txtPassword);
+            var rowUuid = Wrap(txtUuid);
+            var rowAlterId = Wrap(numAlterId);
+            var rowPath = Wrap(txtPath);
+            var rowWsHost = Wrap(txtWsHost);
+            var rowSni = Wrap(txtSni);
+            var rowFp = Wrap(txtFp);
             var rowAllowInsecure = Wrap(chkAllowInsecure);
             var rowEchConfigList = Wrap(txtEchConfigList);
             var rowEchForceQuery = Wrap(cmbEchForceQuery);
-            var rowPk         = Wrap(txtPk);
-            var rowSid        = Wrap(txtSid);
-            var rowSpx        = Wrap(txtSpx);
-            var rowFlow       = Wrap(txtFlow);
+            var rowPk = Wrap(txtPk);
+            var rowSid = Wrap(txtSid);
+            var rowSpx = Wrap(txtSpx);
+            var rowFlow = Wrap(txtFlow);
             var rowVlessEncryption = Wrap(txtVlessEncryption);
-            var rowFinalmask  = Wrap(txtFinalmask);
+            var rowFinalmask = Wrap(txtFinalmask);
 
             void UpdateVisibility()
             {
                 var proto = cmbProtocol.SelectedItem?.ToString() ?? "ss";
-                var net   = cmbNetwork.SelectedItem?.ToString() ?? "tcp";
-                var sec   = cmbSecurity.SelectedItem?.ToString() ?? "none";
+                var net = cmbNetwork.SelectedItem?.ToString() ?? "tcp";
+                var sec = cmbSecurity.SelectedItem?.ToString() ?? "none";
 
-                bool isSs        = proto == "ss";
-                bool isVmess     = proto == "vmess";
-                bool isVless     = proto == "vless";
+                bool isSs = proto == "ss";
+                bool isVmess = proto == "vmess";
+                bool isVless = proto == "vless";
                 bool isHysteria2 = proto == "hysteria2";
-                bool isTrojan    = proto == "trojan";
-                bool hasWs       = !isHysteria2 && net == "ws";
-                bool hasXhttp    = !isHysteria2 && net == "xhttp";
-                bool hasGrpc     = !isHysteria2 && net == "grpc";
-                bool hasTls      = !isHysteria2 && (sec == "tls" || sec == "reality");
-                bool hasReality  = !isHysteria2 && sec == "reality";
-                bool hasEch      = isVless && sec == "tls";
+                bool isTrojan = proto == "trojan";
+                bool hasWs = !isHysteria2 && net == "ws";
+                bool hasXhttp = !isHysteria2 && net == "xhttp";
+                bool hasGrpc = !isHysteria2 && net == "grpc";
+                bool hasTls = !isHysteria2 && (sec == "tls" || sec == "reality");
+                bool hasReality = !isHysteria2 && sec == "reality";
+                bool hasEch = isVless && sec == "tls";
 
-                cmbNetwork .Visibility = isHysteria2                 ? Visibility.Collapsed : Visibility.Visible;
-                cmbSecurity.Visibility = isHysteria2                 ? Visibility.Collapsed : Visibility.Visible;
+                cmbNetwork.Visibility = isHysteria2 ? Visibility.Collapsed : Visibility.Visible;
+                cmbSecurity.Visibility = isHysteria2 ? Visibility.Collapsed : Visibility.Visible;
 
-                rowEncryption.Visibility = isSs                       ? Visibility.Visible : Visibility.Collapsed;
-                rowPassword  .Visibility = (isSs || isHysteria2 || isTrojan)
-                                                                          ? Visibility.Visible : Visibility.Collapsed;
-                rowUuid      .Visibility = (isVmess || isVless)       ? Visibility.Visible : Visibility.Collapsed;
-                rowAlterId   .Visibility = isVmess                    ? Visibility.Visible : Visibility.Collapsed;
-                rowPath      .Visibility = (hasWs || hasXhttp || hasGrpc) ? Visibility.Visible : Visibility.Collapsed;
-                rowWsHost    .Visibility = (hasWs || hasXhttp)        ? Visibility.Visible : Visibility.Collapsed;
-                rowSni       .Visibility = (hasTls || isHysteria2)    ? Visibility.Visible : Visibility.Collapsed;
-                rowFp        .Visibility = hasTls                     ? Visibility.Visible : Visibility.Collapsed;
+                rowEncryption.Visibility = isSs ? Visibility.Visible : Visibility.Collapsed;
+                rowPassword.Visibility = (isSs || isHysteria2 || isTrojan)
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
+                rowUuid.Visibility = (isVmess || isVless) ? Visibility.Visible : Visibility.Collapsed;
+                rowAlterId.Visibility = isVmess ? Visibility.Visible : Visibility.Collapsed;
+                rowPath.Visibility = (hasWs || hasXhttp || hasGrpc) ? Visibility.Visible : Visibility.Collapsed;
+                rowWsHost.Visibility = (hasWs || hasXhttp) ? Visibility.Visible : Visibility.Collapsed;
+                rowSni.Visibility = (hasTls || isHysteria2) ? Visibility.Visible : Visibility.Collapsed;
+                rowFp.Visibility = hasTls ? Visibility.Visible : Visibility.Collapsed;
                 rowAllowInsecure.Visibility = (hasTls || isHysteria2) ? Visibility.Visible : Visibility.Collapsed;
-                rowEchConfigList.Visibility = hasEch                  ? Visibility.Visible : Visibility.Collapsed;
-                rowEchForceQuery.Visibility = hasEch                  ? Visibility.Visible : Visibility.Collapsed;
-                rowPk        .Visibility = hasReality                 ? Visibility.Visible : Visibility.Collapsed;
-                rowSid       .Visibility = hasReality                 ? Visibility.Visible : Visibility.Collapsed;
-                rowSpx       .Visibility = hasReality                 ? Visibility.Visible : Visibility.Collapsed;
-                rowFlow      .Visibility = isVless                    ? Visibility.Visible : Visibility.Collapsed;
-                rowVlessEncryption.Visibility = isVless               ? Visibility.Visible : Visibility.Collapsed;
+                rowEchConfigList.Visibility = hasEch ? Visibility.Visible : Visibility.Collapsed;
+                rowEchForceQuery.Visibility = hasEch ? Visibility.Visible : Visibility.Collapsed;
+                rowPk.Visibility = hasReality ? Visibility.Visible : Visibility.Collapsed;
+                rowSid.Visibility = hasReality ? Visibility.Visible : Visibility.Collapsed;
+                rowSpx.Visibility = hasReality ? Visibility.Visible : Visibility.Collapsed;
+                rowFlow.Visibility = isVless ? Visibility.Visible : Visibility.Collapsed;
+                rowVlessEncryption.Visibility = isVless ? Visibility.Visible : Visibility.Collapsed;
             }
 
             cmbProtocol.SelectionChanged += (_, _) =>
@@ -246,13 +260,13 @@ namespace XrayUI.Services
 
                 UpdateVisibility();
             };
-            cmbNetwork .SelectionChanged += (_, _) => UpdateVisibility();
+            cmbNetwork.SelectionChanged += (_, _) => UpdateVisibility();
             cmbSecurity.SelectionChanged += (_, _) => UpdateVisibility();
             UpdateVisibility();
 
             var form = new StackPanel
             {
-                Spacing  = 10,
+                Spacing = 10,
                 Children =
                 {
                     txtName, txtHost, numPort, cmbProtocol,
@@ -266,45 +280,45 @@ namespace XrayUI.Services
 
             var scrollViewer = new ScrollViewer
             {
-                Content          = form,
-                MaxHeight        = 520,
+                Content = form,
+                MaxHeight = 520,
                 VerticalScrollBarVisibility = ScrollBarVisibility.Auto
             };
 
             var dialog = CreateDialog();
-            dialog.Title             = existing == null ? "手动添加服务器" : "编辑服务器";
+            dialog.Title = existing == null ? "手动添加服务器" : "编辑服务器";
             dialog.PrimaryButtonText = "保存";
-            dialog.CloseButtonText   = "取消";
-            dialog.DefaultButton     = ContentDialogButton.Primary;
-            dialog.Content           = scrollViewer;
+            dialog.CloseButtonText = "取消";
+            dialog.DefaultButton = ContentDialogButton.Primary;
+            dialog.Content = scrollViewer;
 
             var result = await dialog.ShowAsync();
             if (result != ContentDialogResult.Primary) return null;
 
             var entry = existing ?? new ServerEntry();
-            entry.Name        = txtName.Text.Trim();
-            entry.Host        = txtHost.Text.Trim();
-            entry.Port        = (int)numPort.Value;
-            entry.Protocol    = cmbProtocol.SelectedItem?.ToString() ?? "ss";
-            entry.Encryption  = cmbEncryption.SelectedItem?.ToString() ?? string.Empty;
-            entry.Password    = txtPassword.Password.Trim();
-            entry.Uuid        = txtUuid.Text.Trim();
-            entry.AlterId     = (int)numAlterId.Value;
-            entry.Network     = cmbNetwork.SelectedItem?.ToString() ?? "tcp";
-            entry.Path        = txtPath.Text.Trim();
-            entry.WsHost      = txtWsHost.Text.Trim();
-            entry.Security    = cmbSecurity.SelectedItem?.ToString() ?? "none";
-            entry.Sni         = txtSni.Text.Trim();
+            entry.Name = txtName.Text.Trim();
+            entry.Host = txtHost.Text.Trim();
+            entry.Port = (int)numPort.Value;
+            entry.Protocol = cmbProtocol.SelectedItem?.ToString() ?? "ss";
+            entry.Encryption = cmbEncryption.SelectedItem?.ToString() ?? string.Empty;
+            entry.Password = txtPassword.Password.Trim();
+            entry.Uuid = txtUuid.Text.Trim();
+            entry.AlterId = (int)numAlterId.Value;
+            entry.Network = cmbNetwork.SelectedItem?.ToString() ?? "tcp";
+            entry.Path = txtPath.Text.Trim();
+            entry.WsHost = txtWsHost.Text.Trim();
+            entry.Security = cmbSecurity.SelectedItem?.ToString() ?? "none";
+            entry.Sni = txtSni.Text.Trim();
             entry.Fingerprint = txtFp.Text.Trim();
             entry.AllowInsecure = chkAllowInsecure.IsChecked == true;
             entry.EchConfigList = txtEchConfigList.Text.Trim();
             entry.EchForceQuery = EchSettings.NormalizeForceQuery(cmbEchForceQuery.SelectedItem?.ToString());
-            entry.PublicKey   = txtPk.Text.Trim();
-            entry.ShortId     = txtSid.Text.Trim();
-            entry.SpiderX     = txtSpx.Text.Trim();
-            entry.Flow        = txtFlow.Text.Trim();
+            entry.PublicKey = txtPk.Text.Trim();
+            entry.ShortId = txtSid.Text.Trim();
+            entry.SpiderX = txtSpx.Text.Trim();
+            entry.Flow = txtFlow.Text.Trim();
             entry.VlessEncryption = txtVlessEncryption.Text.Trim();
-            entry.Finalmask   = FinalmaskJson.NormalizeForStorage(txtFinalmask.Text);
+            entry.Finalmask = FinalmaskJson.NormalizeForStorage(txtFinalmask.Text);
 
             if (entry.Protocol == "hysteria2")
             {
@@ -322,8 +336,8 @@ namespace XrayUI.Services
             if (entry.Protocol != "ss")
             {
                 entry.Encryption = entry.Security == "reality" ? "Reality"
-                                 : entry.Security == "tls"     ? "TLS"
-                                                               : "None";
+                    : entry.Security == "tls" ? "TLS"
+                    : "None";
             }
 
             return entry;
@@ -335,28 +349,28 @@ namespace XrayUI.Services
         {
             var numBox = new NumberBox
             {
-                Header                  = "本地端口",
-                Value                   = currentPort,
-                Minimum                 = 1024,
-                Maximum                 = 65535,
+                Header = "本地端口",
+                Value = currentPort,
+                Minimum = 1024,
+                Maximum = 65535,
                 SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline,
             };
 
             var dialog = CreateDialog();
-            dialog.Title             = "编辑本地端口";
+            dialog.Title = "编辑本地端口";
             dialog.PrimaryButtonText = "确定";
-            dialog.CloseButtonText   = "取消";
-            dialog.DefaultButton     = ContentDialogButton.Primary;
-            dialog.Content           = new StackPanel
+            dialog.CloseButtonText = "取消";
+            dialog.DefaultButton = ContentDialogButton.Primary;
+            dialog.Content = new StackPanel
             {
-                Width    = 260,
-                Spacing  = 8,
+                Width = 260,
+                Spacing = 8,
                 Children =
                 {
                     numBox,
                     new TextBlock
                     {
-                        Text    = $"有效范围：{numBox.Minimum} - {numBox.Maximum}",
+                        Text = $"有效范围：{numBox.Minimum} - {numBox.Maximum}",
                         Opacity = 0.65,
                     }
                 }
@@ -370,23 +384,25 @@ namespace XrayUI.Services
 
         // ── Error ─────────────────────────────────────────────────────────────
 
-        public async Task<bool> ShowConfirmationAsync(string title, string message, string confirmText = "确定", string cancelText = "取消", bool isDanger = false)
+        public async Task<bool> ShowConfirmationAsync(string title, string message, string confirmText = "确定",
+            string cancelText = "取消", bool isDanger = false)
         {
             var content = new TextBlock
             {
-                Text        = message,
+                Text = message,
                 TextWrapping = TextWrapping.Wrap,
-                MaxWidth    = 280
+                MaxWidth = 280
             };
 
             var dialog = CreateDialog();
-            dialog.Title             = title;
-            dialog.Content           = content;
+            dialog.Title = title;
+            dialog.Content = content;
             dialog.PrimaryButtonText = confirmText;
-            dialog.CloseButtonText   = cancelText;
-            dialog.DefaultButton     = isDanger ? ContentDialogButton.None : ContentDialogButton.Primary;
+            dialog.CloseButtonText = cancelText;
+            dialog.DefaultButton = isDanger ? ContentDialogButton.None : ContentDialogButton.Primary;
 
-            if (isDanger && Application.Current.Resources.TryGetValue("DangerAccentButtonStyle", out var style) && style is Style buttonStyle)
+            if (isDanger && Application.Current.Resources.TryGetValue("DangerAccentButtonStyle", out var style) &&
+                style is Style buttonStyle)
                 dialog.PrimaryButtonStyle = buttonStyle;
 
             var result = await dialog.ShowAsync();
@@ -396,56 +412,63 @@ namespace XrayUI.Services
         public async Task ShowErrorAsync(string title, string message, XamlRoot? xamlRoot = null)
         {
             var dialog = CreateDialog(xamlRoot);
-            dialog.Title           = title;
-            dialog.Content         = message;
+            dialog.Title = title;
+            dialog.Content = message;
             dialog.CloseButtonText = "确定";
             await dialog.ShowAsync();
         }
 
         // ── Progress ──────────────────────────────────────────────────────────
 
-        public async Task ShowProgressDialogAsync(string title, Func<IProgress<string>, CancellationToken, Task> work, XamlRoot? xamlRoot = null)
+        public async Task ShowProgressDialogAsync(string title, Func<IProgress<string>, CancellationToken, Task> work,
+            XamlRoot? xamlRoot = null)
         {
             using var cts = new CancellationTokenSource();
 
             var statusText = new TextBlock
             {
-                Text         = "正在准备…",
+                Text = "正在准备…",
                 TextWrapping = TextWrapping.Wrap,
-                MaxWidth     = 320,
+                MaxWidth = 320,
                 HorizontalAlignment = HorizontalAlignment.Center,
             };
 
             var ring = new ProgressRing
             {
                 IsActive = true,
-                Width    = 36,
-                Height   = 36,
+                Width = 36,
+                Height = 36,
             };
 
             var dialog = CreateDialog(xamlRoot);
-            dialog.Title           = title;
+            dialog.Title = title;
             dialog.CloseButtonText = "取消";
             dialog.Content = new StackPanel
             {
-                Spacing             = 16,
-                MinWidth            = 320,
+                Spacing = 16,
+                MinWidth = 320,
                 HorizontalAlignment = HorizontalAlignment.Center,
-                Children            = { ring, statusText }
+                Children = { ring, statusText }
             };
 
             // Progress<T> captures the current SynchronizationContext — since we're on the UI
             // thread here, reports from the worker thread are marshalled back automatically.
             var progress = new Progress<string>(s => statusText.Text = s);
 
-            Exception? error   = null;
+            Exception? error = null;
             int workFinished = 0;
 
             dialog.Opened += (_, _) =>
             {
                 if (Volatile.Read(ref workFinished) == 1)
                 {
-                    try { dialog.Hide(); } catch { }
+                    try
+                    {
+                        dialog.Hide();
+                    }
+                    catch
+                    {
+                    }
                 }
             };
 
@@ -471,7 +494,13 @@ namespace XrayUI.Services
                     Volatile.Write(ref workFinished, 1);
                     dialog.DispatcherQueue.TryEnqueue(() =>
                     {
-                        try { dialog.Hide(); } catch { }
+                        try
+                        {
+                            dialog.Hide();
+                        }
+                        catch
+                        {
+                        }
                     });
                 }
             });
@@ -487,35 +516,36 @@ namespace XrayUI.Services
             if (cts.IsCancellationRequested) throw new OperationCanceledException(cts.Token);
         }
 
-        public async Task ShowProgressBarDialogAsync(string title, Func<IProgress<ProgressDialogUpdate>, CancellationToken, Task> work, XamlRoot? xamlRoot = null)
+        public async Task ShowProgressBarDialogAsync(string title,
+            Func<IProgress<ProgressDialogUpdate>, CancellationToken, Task> work, XamlRoot? xamlRoot = null)
         {
             using var cts = new CancellationTokenSource();
 
             var statusText = new TextBlock
             {
-                Text         = "正在准备…",
+                Text = "正在准备…",
                 TextWrapping = TextWrapping.Wrap,
-                MaxWidth     = 320,
+                MaxWidth = 320,
                 HorizontalAlignment = HorizontalAlignment.Center,
             };
 
             var progressBar = new ProgressBar
             {
                 IsIndeterminate = true,
-                Minimum         = 0,
-                Maximum         = 100,
-                Width           = 320,
+                Minimum = 0,
+                Maximum = 100,
+                Width = 320,
             };
 
             var dialog = CreateDialog(xamlRoot);
-            dialog.Title           = title;
+            dialog.Title = title;
             dialog.CloseButtonText = "取消";
             dialog.Content = new StackPanel
             {
-                Spacing             = 12,
-                MinWidth            = 320,
+                Spacing = 12,
+                MinWidth = 320,
                 HorizontalAlignment = HorizontalAlignment.Center,
-                Children            = { progressBar, statusText }
+                Children = { progressBar, statusText }
             };
 
             var progress = new Progress<ProgressDialogUpdate>(update =>
@@ -533,14 +563,20 @@ namespace XrayUI.Services
                 }
             });
 
-            Exception? error   = null;
+            Exception? error = null;
             int workFinished = 0;
 
             dialog.Opened += (_, _) =>
             {
                 if (Volatile.Read(ref workFinished) == 1)
                 {
-                    try { dialog.Hide(); } catch { }
+                    try
+                    {
+                        dialog.Hide();
+                    }
+                    catch
+                    {
+                    }
                 }
             };
 
@@ -566,7 +602,13 @@ namespace XrayUI.Services
                     Volatile.Write(ref workFinished, 1);
                     dialog.DispatcherQueue.TryEnqueue(() =>
                     {
-                        try { dialog.Hide(); } catch { }
+                        try
+                        {
+                            dialog.Hide();
+                        }
+                        catch
+                        {
+                        }
                     });
                 }
             });
@@ -591,11 +633,11 @@ namespace XrayUI.Services
             // ── X close button ────────────────────────────────────────────────
             var closeBtn = new Button
             {
-                Content           = "\uE711",
-                FontFamily        = new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons"),
-                Width             = 32,
-                Height            = 32,
-                Padding           = new Thickness(0),
+                Content = "\uE711",
+                FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons"),
+                Width = 32,
+                Height = 32,
+                Padding = new Thickness(0),
                 VerticalAlignment = VerticalAlignment.Center,
             };
             if (Application.Current.Resources.TryGetValue("SubtleButtonStyle", out var subtleStyle))
@@ -608,22 +650,22 @@ namespace XrayUI.Services
             header.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
             var titleText = new TextBlock
             {
-                Text              = "分享节点",
-                FontSize          = 20,
-                FontWeight        = Microsoft.UI.Text.FontWeights.SemiBold,
+                Text = "分享节点",
+                FontSize = 20,
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
                 VerticalAlignment = VerticalAlignment.Center,
             };
             Grid.SetColumn(titleText, 0);
-            Grid.SetColumn(closeBtn,  1);
+            Grid.SetColumn(closeBtn, 1);
             header.Children.Add(titleText);
             header.Children.Add(closeBtn);
 
             // ── Link box ──────────────────────────────────────────────────────
             var linkBox = new TextBox
             {
-                Text          = link,
-                IsReadOnly    = true,
-                TextWrapping  = TextWrapping.Wrap,
+                Text = link,
+                IsReadOnly = true,
+                TextWrapping = TextWrapping.Wrap,
                 AcceptsReturn = false,
             };
 
@@ -631,12 +673,12 @@ namespace XrayUI.Services
             // ── Name row (server name + animated copy icon button) ────────────
             var nameCopyBtn = new Button
             {
-                Content           = "\uE8C8",
-                FontFamily        = new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons"),
-                Width             = 28,
-                Height            = 28,
-                Padding           = new Thickness(0),
-                FontSize          = 14,
+                Content = "\uE8C8",
+                FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons"),
+                Width = 28,
+                Height = 28,
+                Padding = new Thickness(0),
+                FontSize = 14,
                 VerticalAlignment = VerticalAlignment.Center,
             };
             if (Application.Current.Resources.TryGetValue("SubtleButtonStyle", out var subtleStyle2))
@@ -658,13 +700,13 @@ namespace XrayUI.Services
             nameRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
             var nameText = new TextBlock
             {
-                Text              = serverName,
-                FontSize          = 12,
-                Opacity           = 0.65,
-                TextWrapping      = TextWrapping.Wrap,
+                Text = serverName,
+                FontSize = 12,
+                Opacity = 0.65,
+                TextWrapping = TextWrapping.Wrap,
                 VerticalAlignment = VerticalAlignment.Center,
             };
-            Grid.SetColumn(nameText,    0);
+            Grid.SetColumn(nameText, 0);
             Grid.SetColumn(nameCopyBtn, 1);
             nameRow.Children.Add(nameText);
             nameRow.Children.Add(nameCopyBtn);
@@ -673,7 +715,7 @@ namespace XrayUI.Services
             //              no CloseButtonText → bottom bar hidden
             dialog.Content = new StackPanel
             {
-                Width   = 360,
+                Width = 360,
                 Spacing = 12,
                 Children =
                 {
@@ -688,20 +730,21 @@ namespace XrayUI.Services
 
         // ── Startup ───────────────────────────────────────────────────────────
 
-        public async Task<(bool enabled, bool autoConnect)?> ShowStartupDialogAsync(bool currentEnabled, bool currentAutoConnect)
+        public async Task<(bool enabled, bool autoConnect)?> ShowStartupDialogAsync(bool currentEnabled,
+            bool currentAutoConnect)
         {
             var toggle = new ToggleSwitch
             {
-                IsOn       = currentEnabled,
-                OnContent  = "开",
+                IsOn = currentEnabled,
+                OnContent = "开",
                 OffContent = "关",
-                MinWidth   = 0,
-                Margin     = new Thickness(0),
+                MinWidth = 0,
+                Margin = new Thickness(0),
             };
 
             var toggleLabel = new TextBlock
             {
-                Text              = "开机自动启动",
+                Text = "开机自动启动",
                 VerticalAlignment = VerticalAlignment.Center,
             };
 
@@ -709,29 +752,29 @@ namespace XrayUI.Services
             toggleRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
             toggleRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
             Grid.SetColumn(toggleLabel, 0);
-            Grid.SetColumn(toggle,      1);
+            Grid.SetColumn(toggle, 1);
             toggleRow.Children.Add(toggleLabel);
             toggleRow.Children.Add(toggle);
 
             var checkBox = new CheckBox
             {
-                Content   = "自动连接上次节点",
+                Content = "自动连接上次节点",
                 IsChecked = currentAutoConnect,
                 IsEnabled = currentEnabled,
-                Margin    = new Thickness(16, 0, 0, 0),
+                Margin = new Thickness(16, 0, 0, 0),
             };
 
             toggle.Toggled += (_, _) => checkBox.IsEnabled = toggle.IsOn;
 
             var dialog = CreateDialog();
-            dialog.Title             = "开机启动";
+            dialog.Title = "开机启动";
             dialog.PrimaryButtonText = "确认";
-            dialog.CloseButtonText   = "取消";
-            dialog.DefaultButton     = ContentDialogButton.Primary;
+            dialog.CloseButtonText = "取消";
+            dialog.DefaultButton = ContentDialogButton.Primary;
             dialog.Content = new StackPanel
             {
-                Width    = 260,
-                Spacing  = 12,
+                Width = 260,
+                Spacing = 12,
                 Children = { toggleRow, checkBox },
             };
 
@@ -739,6 +782,188 @@ namespace XrayUI.Services
             if (result != ContentDialogResult.Primary) return null;
 
             return (toggle.IsOn, checkBox.IsChecked == true);
+        }
+
+        // ── DNS settings ──────────────────────────────────────────────────────
+
+        public async Task<bool> ShowDnsSettingsDialogAsync(AppSettings settings, bool isTunMode)
+        {
+            var directBox = new TextBox
+            {
+                Text = settings.DirectDnsServer ?? string.Empty,
+                PlaceholderText = "输入 IP 或 DoH 地址 (留空为自动)",
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+            };
+            var proxyBox = new TextBox
+            {
+                Text = settings.ProxyDnsServer ?? string.Empty,
+                PlaceholderText = "输入 IP 或 DoH 地址 (留空为自动)",
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+            };
+
+            var directPresets = CreatePresetButtons(directBox,
+                ("阿里", "223.5.5.5"),
+                ("腾讯", "119.29.29.29"),
+                ("114", "114.114.114.114"),
+                ("DoH", "https://dns.alidns.com/dns-query"));
+
+            var proxyPresets = CreatePresetButtons(proxyBox,
+                ("谷歌", "8.8.8.8"),
+                ("CF", "1.1.1.1"),
+                ("Quad9", "9.9.9.9"),
+                ("DoH", "https://cloudflare-dns.com/dns-query"));
+
+            var strategyCmb = new ComboBox { MinWidth = 100 };
+            foreach (var item in new[] { "仅 IPv4", "仅 IPv6", "自动" })
+                strategyCmb.Items.Add(item);
+            strategyCmb.SelectedIndex = settings.DnsQueryStrategy switch
+            {
+                DnsQueryStrategy.IPv6 => 1,
+                DnsQueryStrategy.Any => 2,
+                _ => 0,
+            };
+
+            var cacheSwitch = new ToggleSwitch
+            {
+                IsOn = settings.DnsCacheEnabled,
+                OnContent = "开",
+                OffContent = "关",
+                MinWidth = 0,
+                Margin = new Thickness(0),
+            };
+
+            var fakeDnsSwitch = new ToggleSwitch
+            {
+                IsOn = settings.FakeDnsEnabled && isTunMode,
+                IsEnabled = isTunMode,
+                OnContent = "开",
+                OffContent = "关",
+                MinWidth = 0,
+                Margin = new Thickness(0),
+            };
+
+            var fakeDnsTitleText = new TextBlock
+            {
+                Text = "FakeDNS",
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            ToolTipService.SetToolTip(fakeDnsTitleText, "仅TUN模式有效");
+
+            var fakeDnsLabel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 12,
+                VerticalAlignment = VerticalAlignment.Center,
+                Children =
+                {
+                    fakeDnsTitleText,
+                    new TextBlock
+                    {
+                        Text = "实验性",
+                        FontSize = 10,
+                        VerticalAlignment = VerticalAlignment.Center,
+                        Foreground =
+                            (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources[
+                                "SystemFillColorAttentionBrush"],
+                    },
+                },
+            };
+
+            var fakeDnsRow = new Grid { ColumnSpacing = 8 };
+            fakeDnsRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            fakeDnsRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            Grid.SetColumn(fakeDnsLabel, 0);
+            Grid.SetColumn(fakeDnsSwitch, 1);
+            fakeDnsRow.Children.Add(fakeDnsLabel);
+            fakeDnsRow.Children.Add(fakeDnsSwitch);
+
+            var strategyRow = CreateLabelRow("查询策略", strategyCmb);
+            var cacheRow = CreateLabelRow("启用 DNS 缓存", cacheSwitch);
+
+            var content = new StackPanel
+            {
+                Width = 340,
+                Spacing = 20,
+                Children =
+                {
+                    new StackPanel
+                    {
+                        Spacing = 6,
+                        Children =
+                        {
+                            new TextBlock { Text = "直连 DNS", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold },
+                            new TextBlock
+                            {
+                                Text = "用于国内域名 (geosite:cn)，走直连出站解析",
+                                FontSize = 11,
+                                Opacity = 0.6,
+                                TextWrapping = TextWrapping.Wrap,
+                                Margin = new Thickness(0, 0, 0, 4),
+                            },
+                            directBox,
+                            directPresets,
+                        }
+                    },
+                    new StackPanel
+                    {
+                        Spacing = 6,
+                        Children =
+                        {
+                            new TextBlock { Text = "代理 DNS", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold },
+                            new TextBlock
+                            {
+                                Text = "用于境外域名，经代理出站解析，防止 DNS 污染",
+                                FontSize = 11,
+                                Opacity = 0.6,
+                                TextWrapping = TextWrapping.Wrap,
+                                Margin = new Thickness(0, 0, 0, 4),
+                            },
+                            proxyBox,
+                            proxyPresets,
+                        }
+                    },
+                    new StackPanel { Spacing = 14, Children = { strategyRow, cacheRow, fakeDnsRow } },
+                }
+            };
+
+            var dialog = CreateDialog();
+            dialog.Title = "DNS 设置";
+            dialog.PrimaryButtonText = "保存";
+            dialog.SecondaryButtonText = "重置默认";
+            dialog.CloseButtonText = "取消";
+            dialog.DefaultButton = ContentDialogButton.Primary;
+            dialog.Content = content;
+
+            dialog.SecondaryButtonClick += (_, args) =>
+            {
+                args.Cancel = true;
+                directBox.Text = string.Empty;
+                proxyBox.Text = string.Empty;
+                strategyCmb.SelectedIndex = 0;
+                cacheSwitch.IsOn = true;
+                fakeDnsSwitch.IsOn = false;
+            };
+
+            var result = await dialog.ShowAsync();
+            if (result != ContentDialogResult.Primary) return false;
+
+            settings.DirectDnsServer = string.IsNullOrWhiteSpace(directBox.Text) ? null : directBox.Text.Trim();
+            settings.ProxyDnsServer = string.IsNullOrWhiteSpace(proxyBox.Text) ? null : proxyBox.Text.Trim();
+            settings.DnsQueryStrategy = strategyCmb.SelectedIndex switch
+            {
+                1 => DnsQueryStrategy.IPv6,
+                2 => DnsQueryStrategy.Any,
+                _ => DnsQueryStrategy.IPv4,
+            };
+            settings.DnsCacheEnabled = cacheSwitch.IsOn;
+            // FakeDNS only meaningful in TUN mode. Don't clobber a previously-saved value
+            // when the dialog opened in non-TUN mode (toggle was forced OFF for display).
+            if (isTunMode)
+            {
+                settings.FakeDnsEnabled = fakeDnsSwitch.IsOn;
+            }
+
+            return true;
         }
 
         // ── Helpers ───────────────────────────────────────────────────────────
@@ -750,11 +975,55 @@ namespace XrayUI.Services
         /// <param name="xamlRootOverride">If supplied, roots the dialog in this window instead of the MainWindow factory.</param>
         private ContentDialog CreateDialog(XamlRoot? xamlRootOverride = null) => new ContentDialog
         {
-            XamlRoot       = xamlRootOverride ?? XamlRoot,
+            XamlRoot = xamlRootOverride ?? XamlRoot,
             RequestedTheme = ThemeHelper.ActualTheme,
         };
 
         private static Border Wrap(FrameworkElement child) =>
             new Border { Child = child };
+
+        /// <summary>
+        /// Two-column row: stretchable label on the left, fixed-size control on the right.
+        /// </summary>
+        private static Grid CreateLabelRow(string label, FrameworkElement control)
+        {
+            var grid = new Grid { ColumnSpacing = 8 };
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            var text = new TextBlock { Text = label, VerticalAlignment = VerticalAlignment.Center };
+            Grid.SetColumn(text, 0);
+            Grid.SetColumn(control, 1);
+            grid.Children.Add(text);
+            grid.Children.Add(control);
+            return grid;
+        }
+
+        /// <summary>
+        /// Horizontal row of pill-shaped preset buttons that write their value into <paramref name="target"/>.
+        /// </summary>
+        private static StackPanel CreatePresetButtons(TextBox target, params (string label, string value)[] presets)
+        {
+            var panel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 8,
+                Margin = new Thickness(0, 2, 0, 0),
+            };
+            foreach (var (label, value) in presets)
+            {
+                var captured = value;
+                var btn = new Button
+                {
+                    Content = label,
+                    Padding = new Thickness(10, 3, 10, 3),
+                    FontSize = 11,
+                    CornerRadius = new CornerRadius(12),
+                };
+                btn.Click += (_, _) => target.Text = captured;
+                panel.Children.Add(btn);
+            }
+
+            return panel;
+        }
     }
 }

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -802,11 +802,10 @@ namespace XrayUI.Services
             };
 
             var directPresets = CreatePresetButtons(directBox,
-                ("阿里",      "223.5.5.5"),
-                ("腾讯",      "119.29.29.29"),
-                ("114",       "114.114.114.114"),
-                ("DoH",       "https://dns.alidns.com/dns-query"),
-                ("localhost", "localhost"));
+                ("阿里", "223.5.5.5"),
+                ("腾讯", "119.29.29.29"),
+                ("114",  "114.114.114.114"),
+                ("DoH",  "https://dns.alidns.com/dns-query"));
 
             var proxyPresets = CreatePresetButtons(proxyBox,
                 ("谷歌", "8.8.8.8"),

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -802,10 +802,11 @@ namespace XrayUI.Services
             };
 
             var directPresets = CreatePresetButtons(directBox,
-                ("阿里", "223.5.5.5"),
-                ("腾讯", "119.29.29.29"),
-                ("114", "114.114.114.114"),
-                ("DoH", "https://dns.alidns.com/dns-query"));
+                ("阿里",      "223.5.5.5"),
+                ("腾讯",      "119.29.29.29"),
+                ("114",       "114.114.114.114"),
+                ("DoH",       "https://dns.alidns.com/dns-query"),
+                ("localhost", "localhost"));
 
             var proxyPresets = CreatePresetButtons(proxyBox,
                 ("谷歌", "8.8.8.8"),

--- a/Services/DnsQueryStrategy.cs
+++ b/Services/DnsQueryStrategy.cs
@@ -1,0 +1,13 @@
+namespace XrayUI.Services
+{
+    /// <summary>
+    /// xray-core DNS queryStrategy values. Persisted in AppSettings.DnsQueryStrategy
+    /// and written verbatim to the xray dns config.
+    /// </summary>
+    internal static class DnsQueryStrategy
+    {
+        public const string IPv4 = "UseIPv4";
+        public const string IPv6 = "UseIPv6";
+        public const string Any  = "UseIP";
+    }
+}

--- a/Services/IDialogService.cs
+++ b/Services/IDialogService.cs
@@ -29,5 +29,14 @@ namespace XrayUI.Services
         /// </summary>
         /// <param name="xamlRoot">Override which window the dialog is rooted in. Null = MainWindow.</param>
         Task ShowProgressBarDialogAsync(string title, Func<IProgress<ProgressDialogUpdate>, CancellationToken, Task> work, XamlRoot? xamlRoot = null);
+
+        /// <summary>
+        /// Shows the DNS settings dialog. Mutates <paramref name="settings"/> in-place on save.
+        /// Returns true if the user saved, false if cancelled.
+        /// </summary>
+        /// <param name="isTunMode">Live UI TUN-mode state (not <c>settings.IsTunMode</c>, which is
+        /// the persisted runtime state and lags behind the UI toggle until the next connect).
+        /// Used to gate FakeDNS availability in the dialog.</param>
+        Task<bool> ShowDnsSettingsDialogAsync(AppSettings settings, bool isTunMode);
     }
 }

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -30,8 +30,28 @@ namespace XrayUI.Services
                 ["routing"] = BuildRouting(settings)
             };
 
+            if (IsFakeDnsActive(settings))
+            {
+                var pools = new JsonArray();
+                AddNode(pools, new JsonObject
+                {
+                    ["ipPool"] = XrayConfigConstants.FakeDnsPoolV4,
+                    ["poolSize"] = 65535,
+                });
+                AddNode(pools, new JsonObject
+                {
+                    ["ipPool"] = XrayConfigConstants.FakeDnsPoolV6,
+                    ["poolSize"] = 65535,
+                });
+                config["fakedns"] = pools;
+            }
+
             return config.ToJsonString(JsonOpts);
         }
+
+        /// <summary>True when xray will be built with a fakedns pool wired to the TUN inbound.</summary>
+        private static bool IsFakeDnsActive(AppSettings settings) =>
+            settings.IsTunMode && settings.FakeDnsEnabled;
 
         private static JsonObject BuildLog(AppSettings settings)
         {
@@ -54,12 +74,12 @@ namespace XrayUI.Services
 
             if (settings.IsTunMode)
             {
-                AddNode(list, BuildTunInbound());
+                AddNode(list, BuildTunInbound(settings));
             }
 
             AddNode(list, new JsonObject
             {
-                ["tag"] = "mixed-in",
+                ["tag"] = XrayConfigConstants.MixedInboundTag,
                 ["protocol"] = "socks",
                 ["listen"] = "127.0.0.1",
                 ["port"] = settings.LocalMixedPort,
@@ -73,11 +93,25 @@ namespace XrayUI.Services
             return list;
         }
 
-        private static JsonObject BuildTunInbound()
+        private static JsonObject BuildTunInbound(AppSettings settings)
         {
+            var destOverride = settings.FakeDnsEnabled
+                ? CreateStringArray(XrayConfigConstants.FakeDnsServerTag, "http", "tls", "quic")
+                : CreateStringArray("http", "tls", "quic");
+
+            var sniffing = new JsonObject
+            {
+                ["enabled"] = true,
+                ["destOverride"] = destOverride,
+            };
+            if (settings.FakeDnsEnabled)
+            {
+                sniffing["metadataOnly"] = false;
+            }
+
             return new JsonObject
             {
-                ["tag"] = "tun-in",
+                ["tag"] = XrayConfigConstants.TunInboundTag,
                 ["protocol"] = "tun",
                 ["settings"] = new JsonObject
                 {
@@ -87,11 +121,7 @@ namespace XrayUI.Services
                     ["autoSystemRoutingTable"] = CreateStringArray("0.0.0.0/0"),
                     ["autoOutboundsInterface"] = "auto"
                 },
-                ["sniffing"] = new JsonObject
-                {
-                    ["enabled"] = true,
-                    ["destOverride"] = CreateStringArray("http", "tls", "quic")
-                }
+                ["sniffing"] = sniffing,
             };
         }
 
@@ -127,6 +157,15 @@ namespace XrayUI.Services
                     ["tag"] = "block",
                     ["protocol"] = "blackhole",
                     ["settings"] = new JsonObject()
+                });
+            }
+
+            if (IsFakeDnsActive(settings))
+            {
+                AddNode(list, new JsonObject
+                {
+                    ["tag"] = XrayConfigConstants.DnsOutboundTag,
+                    ["protocol"] = "dns",
                 });
             }
 
@@ -434,6 +473,20 @@ namespace XrayUI.Services
 
             if (settings.IsTunMode)
             {
+                if (settings.FakeDnsEnabled)
+                {
+                    // Must precede the self/xray direct rule so DNS queries from tun-in get
+                    // intercepted by xray's internal DNS handler (and the fakedns pool) rather
+                    // than being forwarded upstream.
+                    AddNode(rules, new JsonObject
+                    {
+                        ["type"] = "field",
+                        ["inboundTag"] = CreateStringArray(XrayConfigConstants.TunInboundTag),
+                        ["port"] = "53",
+                        ["outboundTag"] = XrayConfigConstants.DnsOutboundTag,
+                    });
+                }
+
                 AddNode(rules, new JsonObject
                 {
                     ["type"] = "field",
@@ -479,10 +532,12 @@ namespace XrayUI.Services
                         ["type"] = "field",
                         ["outboundTag"] = rule.OutboundTag,
                     };
-                    if (rule.Type == "ip")
-                        node["ip"] = CreateStringArray(rule.Match);
-                    else
-                        node["domain"] = CreateStringArray(rule.Match);
+                    switch (rule.Type)
+                    {
+                        case "ip":      node["ip"]      = CreateStringArray(rule.Match); break;
+                        case "process": node["process"] = CreateStringArray(rule.Match); break;
+                        default:        node["domain"]  = CreateStringArray(rule.Match); break;
+                    }
 
                     AddNode(rules, node);
                 }
@@ -524,15 +579,48 @@ namespace XrayUI.Services
 
         private static JsonObject BuildDns(AppSettings settings)
         {
-            return settings.IsTunMode
-                ? new JsonObject
-                {
-                    ["servers"] = CreateStringArray("223.5.5.5", "119.29.29.29", "localhost")
-                }
-                : new JsonObject
-                {
-                    ["servers"] = CreateStringArray("8.8.8.8", "114.114.114.114", "localhost")
-                };
+            var directDns = settings.DirectDnsServer
+                ?? (settings.IsTunMode ? "223.5.5.5" : "114.114.114.114");
+            var proxyDns = settings.ProxyDnsServer ?? "8.8.8.8";
+
+            var directEntry = new JsonObject
+            {
+                ["address"]   = directDns,
+                ["domains"]   = CreateStringArray("geosite:cn"),
+                ["expectIPs"] = CreateStringArray("geoip:cn"),
+            };
+
+            var localEntry = new JsonObject
+            {
+                ["address"]      = "localhost",
+                ["domains"]      = CreateStringArray("geosite:private"),
+                ["skipFallback"] = true,
+            };
+
+            var proxyEntry = new JsonObject
+            {
+                ["address"]      = proxyDns,
+                ["skipFallback"] = true,
+            };
+
+            var servers = new JsonArray();
+            if (IsFakeDnsActive(settings))
+            {
+                // FakeDNS must be first: it answers initial client lookups with fake IPs. The
+                // real DNS entries below handle outbound-side resolution after sniffing recovers
+                // the original domain.
+                AddValue(servers, XrayConfigConstants.FakeDnsServerTag);
+            }
+            AddNode(servers, directEntry);
+            AddNode(servers, localEntry);
+            AddNode(servers, proxyEntry);
+
+            return new JsonObject
+            {
+                ["servers"]       = servers,
+                ["queryStrategy"] = settings.DnsQueryStrategy,
+                ["disableCache"]  = !settings.DnsCacheEnabled
+            };
         }
 
         private static JsonArray CreateStringArray(params string[] values)

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -171,8 +171,16 @@ namespace XrayUI.Services
 
             if (settings.IsTunMode && !string.IsNullOrWhiteSpace(tunOutboundInterfaceName))
             {
+                // sockopt.interface only matters for outbounds that actually open sockets
+                // to remote hosts. block (blackhole) drops traffic without a socket, and
+                // dns-out is xray-internal — applying the binding to them produces
+                // redundant fields in the generated config.
                 foreach (var outbound in list.OfType<JsonObject>())
-                    ApplyOutboundInterface(outbound, tunOutboundInterfaceName);
+                {
+                    var tag = outbound["tag"]?.GetValue<string>();
+                    if (tag is "proxy" or "direct")
+                        ApplyOutboundInterface(outbound, tunOutboundInterfaceName);
+                }
             }
 
             return list;

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -580,7 +580,7 @@ namespace XrayUI.Services
 
             return new JsonObject
             {
-                ["domainStrategy"] = "IPIfNonMatch",
+                ["domainStrategy"] = "AsIs",
                 ["rules"] = rules
             };
         }
@@ -591,29 +591,13 @@ namespace XrayUI.Services
                 ?? (settings.IsTunMode ? "223.5.5.5" : "114.114.114.114");
             var proxyDns = settings.ProxyDnsServer ?? "8.8.8.8";
 
-            // skipFallback semantics (xray-core):
-            //   1) Servers with `domains` match by domain first; if none match, xray walks
-            //      the fallback list — servers WITHOUT `skipFallback: true`.
-            //   2) directEntry / localEntry are domain-matched only; we set skipFallback so
-            //      they don't accidentally answer queries that didn't match their `domains`.
-            //   3) proxyEntry has no `domains` and no skipFallback, so it is the sole catch-all
-            //      fallback. Its address (e.g. 8.8.8.8) is non-CN, so the routing rules send
-            //      these DNS queries out via the proxy outbound — that's what realises the
-            //      "代理 DNS 用于境外域名" intent.
             var directEntry = new JsonObject
             {
                 ["address"]      = directDns,
-                ["domains"]      = CreateStringArray("geosite:cn"),
-                ["expectIPs"]    = CreateStringArray("geoip:cn"),
+                ["domains"]      = CreateStringArray("geosite:cn", "geosite:private"),
                 ["skipFallback"] = true,
             };
 
-            var localEntry = new JsonObject
-            {
-                ["address"]      = "localhost",
-                ["domains"]      = CreateStringArray("geosite:private"),
-                ["skipFallback"] = true,
-            };
 
             var proxyEntry = new JsonObject
             {
@@ -629,7 +613,6 @@ namespace XrayUI.Services
                 AddValue(servers, XrayConfigConstants.FakeDnsServerTag);
             }
             AddNode(servers, directEntry);
-            AddNode(servers, localEntry);
             AddNode(servers, proxyEntry);
 
             return new JsonObject

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -583,11 +583,21 @@ namespace XrayUI.Services
                 ?? (settings.IsTunMode ? "223.5.5.5" : "114.114.114.114");
             var proxyDns = settings.ProxyDnsServer ?? "8.8.8.8";
 
+            // skipFallback semantics (xray-core):
+            //   1) Servers with `domains` match by domain first; if none match, xray walks
+            //      the fallback list — servers WITHOUT `skipFallback: true`.
+            //   2) directEntry / localEntry are domain-matched only; we set skipFallback so
+            //      they don't accidentally answer queries that didn't match their `domains`.
+            //   3) proxyEntry has no `domains` and no skipFallback, so it is the sole catch-all
+            //      fallback. Its address (e.g. 8.8.8.8) is non-CN, so the routing rules send
+            //      these DNS queries out via the proxy outbound — that's what realises the
+            //      "代理 DNS 用于境外域名" intent.
             var directEntry = new JsonObject
             {
-                ["address"]   = directDns,
-                ["domains"]   = CreateStringArray("geosite:cn"),
-                ["expectIPs"] = CreateStringArray("geoip:cn"),
+                ["address"]      = directDns,
+                ["domains"]      = CreateStringArray("geosite:cn"),
+                ["expectIPs"]    = CreateStringArray("geoip:cn"),
+                ["skipFallback"] = true,
             };
 
             var localEntry = new JsonObject
@@ -599,8 +609,7 @@ namespace XrayUI.Services
 
             var proxyEntry = new JsonObject
             {
-                ["address"]      = proxyDns,
-                ["skipFallback"] = true,
+                ["address"] = proxyDns,
             };
 
             var servers = new JsonArray();

--- a/Services/XrayConfigConstants.cs
+++ b/Services/XrayConfigConstants.cs
@@ -1,0 +1,20 @@
+namespace XrayUI.Services
+{
+    /// <summary>
+    /// Inbound/outbound tags and well-known IP pools referenced by the xray-core JSON config.
+    /// These strings are part of the contract with xray itself (they appear in routing rules,
+    /// dns.servers entries, etc.), so changing them requires keeping every cross-reference in sync.
+    /// </summary>
+    internal static class XrayConfigConstants
+    {
+        // Inbound / outbound / DNS tags
+        public const string TunInboundTag    = "tun-in";
+        public const string MixedInboundTag  = "mixed-in";
+        public const string DnsOutboundTag   = "dns-out";
+        public const string FakeDnsServerTag = "fakedns";
+
+        // FakeDNS IP pools. 198.18.0.0/15 is RFC-2544 benchmarking space (safe to reuse).
+        public const string FakeDnsPoolV4 = "198.18.0.0/15";
+        public const string FakeDnsPoolV6 = "fc00::/18";
+    }
+}

--- a/Services/XrayService.cs
+++ b/Services/XrayService.cs
@@ -247,8 +247,37 @@ namespace XrayUI.Services
                 _process = null;
             }
 
+            FlushSystemDnsCache();
+
             AppendLog("[已停止]");
             RunningChanged?.Invoke(this, false);
+        }
+
+        /// <summary>
+        /// Best-effort `ipconfig /flushdns` to clear any cached fake IPs (198.18.0.0/15) that
+        /// might linger in the Windows resolver cache after a FakeDNS-enabled run. Harmless
+        /// when FakeDNS was not used. Runs unconditionally on every stop to keep XrayService
+        /// stateless w.r.t. last-run config.
+        /// </summary>
+        private void FlushSystemDnsCache()
+        {
+            try
+            {
+                using var p = Process.Start(new ProcessStartInfo
+                {
+                    FileName = "ipconfig",
+                    Arguments = "/flushdns",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                });
+                p?.WaitForExit(2000);
+            }
+            catch
+            {
+                // best-effort, never block stop on this
+            }
         }
 
         public void StopForShutdown()

--- a/Services/XrayService.cs
+++ b/Services/XrayService.cs
@@ -247,7 +247,7 @@ namespace XrayUI.Services
                 _process = null;
             }
 
-            FlushSystemDnsCache();
+            await FlushSystemDnsCacheAsync();
 
             AppendLog("[已停止]");
             RunningChanged?.Invoke(this, false);
@@ -259,7 +259,7 @@ namespace XrayUI.Services
         /// when FakeDNS was not used. Runs unconditionally on every stop to keep XrayService
         /// stateless w.r.t. last-run config.
         /// </summary>
-        private void FlushSystemDnsCache()
+        private async Task FlushSystemDnsCacheAsync()
         {
             try
             {
@@ -272,7 +272,10 @@ namespace XrayUI.Services
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                 });
-                p?.WaitForExit(2000);
+                if (p is null) return;
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                try { await p.WaitForExitAsync(cts.Token); }
+                catch (OperationCanceledException) { try { p.Kill(); } catch { } }
             }
             catch
             {

--- a/Services/XrayService.cs
+++ b/Services/XrayService.cs
@@ -140,7 +140,10 @@ namespace XrayUI.Services
         {
             if (IsRunning)
             {
-                await StopAsync();
+                // Restart path (e.g. ReapplyRoutingAsync): skip the DNS flush — the new xray
+                // session is about to repopulate the resolver cache anyway, and ipconfig
+                // /flushdns adds ~hundreds of ms to every routing/DNS/proxy-mode toggle.
+                await StopCoreAsync();
             }
 
             LastError = string.Empty;
@@ -222,6 +225,17 @@ namespace XrayUI.Services
 
         public async Task StopAsync()
         {
+            await StopCoreAsync();
+            await FlushSystemDnsCacheAsync();
+        }
+
+        /// <summary>
+        /// Kills the xray process and tears down state, without flushing the OS DNS cache.
+        /// Used by StartAsync on the restart path so reapply doesn't pay the ipconfig
+        /// /flushdns cost on every routing/DNS/proxy-mode toggle. No-op if not running.
+        /// </summary>
+        private async Task StopCoreAsync()
+        {
             if (_process is null)
             {
                 return;
@@ -246,8 +260,6 @@ namespace XrayUI.Services
                 _process.Dispose();
                 _process = null;
             }
-
-            await FlushSystemDnsCacheAsync();
 
             AppendLog("[已停止]");
             RunningChanged?.Invoke(this, false);

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -223,23 +223,8 @@ namespace XrayUI.ViewModels
             string? tunOutboundInterfaceName = null;
             if (IsTunMode)
             {
-                // Pre-check: wintun.dll must be present so xray can create the TUN adapter.
-                if (!_tunService.IsWintunAvailable())
-                {
-                    await _dialogs.ShowErrorAsync("TUN mode error",
-                        $"Could not find wintun.dll\nPath: {_tunService.GetExpectedWintunPath()}");
-                    return false;
-                }
-
-                tunOutboundInterfaceName = _tunService.DetectDefaultOutboundInterfaceName();
-                if (string.IsNullOrWhiteSpace(tunOutboundInterfaceName))
-                {
-                    await _dialogs.ShowErrorAsync("TUN mode error",
-                        "Could not determine the default outbound network interface. Please check that Wi-Fi/Ethernet is connected, then try TUN mode again as administrator.");
-                    return false;
-                }
-
-                SystemProxyService.ClearProxy();
+                tunOutboundInterfaceName = await RunTunPreflightAsync("TUN mode error");
+                if (tunOutboundInterfaceName is null) return false;
                 await CleanupPersistedTunRoutesAsync(appSettings);
             }
 
@@ -300,8 +285,8 @@ namespace XrayUI.ViewModels
         /// <summary>
         /// Rebuild xray config from persisted settings and restart xray. No-op if not running.
         /// Always reapplies against the live _activeServer, not the currently-selected list entry.
-        /// Not safe in TUN mode: restarting xray tears down the TUN adapter but we don't
-        /// re-invoke SetupTunRoutes, so traffic would silently fall off the tunnel.
+        /// Not used in TUN mode: changing DNS/routing there is saved and takes effect
+        /// after the user restarts the proxy session.
         /// </summary>
         public async Task ReapplyRoutingAsync()
         {
@@ -312,13 +297,20 @@ namespace XrayUI.ViewModels
             await _reapplyLock.WaitAsync();
             try
             {
-                if (!IsRunning || _activeServer is null) return;
+                var activeServer = _activeServer;
+                if (!IsRunning || activeServer is null) return;
 
                 IsReapplying = true;
                 try
                 {
                     var settings = await _settings.LoadSettingsAsync();
-                    var cfg = XrayConfigBuilder.Build(_activeServer, settings);
+                    settings.LocalMixedPort        = LocalPort;
+                    settings.RoutingMode           = RoutingMode == "智能分流" ? "smart" : "global";
+                    settings.IsTunMode             = IsTunMode;
+                    settings.IsSystemProxyEnabled  = _isSystemProxyEnabled;
+
+                    var cfg = XrayConfigBuilder.Build(activeServer, settings);
+
                     var ok = await _xray.StartAsync(cfg);
                     if (!ok)
                     {
@@ -326,7 +318,15 @@ namespace XrayUI.ViewModels
                             ? "xray 应用新配置失败，已停止。"
                             : _xray.LastError;
                         await HandleReapplyFailureAsync(detail);
+                        return;
                     }
+
+                    if (_isSystemProxyEnabled)
+                    {
+                        SystemProxyService.SetProxy("127.0.0.1", settings.LocalMixedPort);
+                    }
+
+                    IsRunning = true;
                 }
                 catch (Exception ex)
                 {
@@ -375,6 +375,32 @@ namespace XrayUI.ViewModels
         }
 
 
+
+        /// <summary>
+        /// Runs the shared TUN-mode preflight: wintun availability, outbound interface detection,
+        /// and system-proxy clearing. Returns the detected interface name, or null when a check
+        /// fails (the user has already seen an error dialog with <paramref name="errorTitle"/>).
+        /// </summary>
+        private async Task<string?> RunTunPreflightAsync(string errorTitle)
+        {
+            if (!_tunService.IsWintunAvailable())
+            {
+                await _dialogs.ShowErrorAsync(errorTitle,
+                    $"Could not find wintun.dll\nPath: {_tunService.GetExpectedWintunPath()}");
+                return null;
+            }
+
+            var iface = _tunService.DetectDefaultOutboundInterfaceName();
+            if (string.IsNullOrWhiteSpace(iface))
+            {
+                await _dialogs.ShowErrorAsync(errorTitle,
+                    "Could not determine the default outbound network interface. Please check that Wi-Fi/Ethernet is connected, then try again.");
+                return null;
+            }
+
+            SystemProxyService.ClearProxy();
+            return iface;
+        }
 
         private void CleanupTunRoutesSafely()
         {
@@ -655,6 +681,24 @@ namespace XrayUI.ViewModels
                 // When xray is stopped, null = direct connection.
                 () => _xray.IsRunning ? $"socks5://127.0.0.1:{LocalPort}" : null);
             ShowCustomRulesRequested?.Invoke(this, vm);
+        }
+
+        [RelayCommand]
+        private async Task ShowDnsSettings()
+        {
+            var s = await _settings.LoadSettingsAsync();
+            var saved = await _dialogs.ShowDnsSettingsDialogAsync(s, IsTunMode);
+            if (!saved) return;
+
+            await TrySaveSettingsAsync(s, "persist DNS settings");
+
+            if (IsRunning && IsTunMode) return;
+
+            if (IsRunning)
+            {
+                try { await ReapplyRoutingAsync(); }
+                catch (Exception ex) { Debug.WriteLine($"[ControlPanel] Reapply after DNS change failed: {ex.Message}"); }
+            }
         }
 
         // ── Routing mode ──────────────────────────────────────────────────────

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -325,8 +325,9 @@ namespace XrayUI.ViewModels
                     {
                         SystemProxyService.SetProxy("127.0.0.1", settings.LocalMixedPort);
                     }
-
-                    IsRunning = true;
+                    // IsRunning is managed manually by this VM (no subscription to
+                    // _xray.RunningChanged), and the guard at the top of this method
+                    // already proves it's true here — so no reassignment is needed.
                 }
                 catch (Exception ex)
                 {

--- a/ViewModels/ServerDetailViewModel.cs
+++ b/ViewModels/ServerDetailViewModel.cs
@@ -97,38 +97,6 @@ namespace XrayUI.ViewModels
 
         public string SelectedEncryption => SelectedServer?.Encryption ?? "-";
 
-        public string SelectedVlessEncryption
-            => string.IsNullOrEmpty(SelectedServer?.VlessEncryption) ? string.Empty : SelectedServer.VlessEncryption;
-
-        public Visibility VlessEncryptionVisibility
-            => string.Equals(SelectedServer?.Protocol, "vless", StringComparison.OrdinalIgnoreCase)
-               && !string.IsNullOrEmpty(SelectedServer?.VlessEncryption)
-                ? Visibility.Visible
-                : Visibility.Collapsed;
-
-        public string SelectedEch
-        {
-            get
-            {
-                if (string.IsNullOrWhiteSpace(SelectedServer?.EchConfigList))
-                {
-                    return string.Empty;
-                }
-
-                var echForceQuery = EchSettings.NormalizeForceQuery(SelectedServer.EchForceQuery);
-                return string.IsNullOrEmpty(echForceQuery)
-                    ? SelectedServer.EchConfigList
-                    : $"{SelectedServer.EchConfigList} ({echForceQuery})";
-            }
-        }
-
-        public Visibility EchVisibility
-            => string.Equals(SelectedServer?.Protocol, "vless", StringComparison.OrdinalIgnoreCase)
-               && string.Equals(SelectedServer?.Security, "tls", StringComparison.OrdinalIgnoreCase)
-               && !string.IsNullOrWhiteSpace(SelectedServer?.EchConfigList)
-                ? Visibility.Visible
-                : Visibility.Collapsed;
-
         public string SelectedShareLink
             => SelectedServer is null ? string.Empty : (NodeLinkSerializer.ToLink(SelectedServer) ?? string.Empty);
 
@@ -138,7 +106,7 @@ namespace XrayUI.ViewModels
             {
                 if (SelectedServer is null)
                 {
-                    return "TCP";
+                    return "-";
                 }
 
                 if (string.Equals(SelectedServer.Protocol, "hysteria2", StringComparison.OrdinalIgnoreCase))
@@ -276,26 +244,15 @@ namespace XrayUI.ViewModels
                     OnPropertyChanged(nameof(SelectedProtocol));
                     OnPropertyChanged(nameof(SelectedSecurityLabel));
                     OnPropertyChanged(nameof(SelectedTransport));
-                    OnPropertyChanged(nameof(VlessEncryptionVisibility));
-                    OnPropertyChanged(nameof(EchVisibility));
                     OnPropertyChanged(nameof(SelectedShareLink));
                     break;
                 case nameof(ServerEntry.Encryption):
                     OnPropertyChanged(nameof(SelectedEncryption));
                     break;
                 case nameof(ServerEntry.Security):
-                    OnPropertyChanged(nameof(EchVisibility));
-                    OnPropertyChanged(nameof(SelectedShareLink));
-                    break;
                 case nameof(ServerEntry.VlessEncryption):
-                    OnPropertyChanged(nameof(SelectedVlessEncryption));
-                    OnPropertyChanged(nameof(VlessEncryptionVisibility));
-                    OnPropertyChanged(nameof(SelectedShareLink));
-                    break;
                 case nameof(ServerEntry.EchConfigList):
                 case nameof(ServerEntry.EchForceQuery):
-                    OnPropertyChanged(nameof(SelectedEch));
-                    OnPropertyChanged(nameof(EchVisibility));
                     OnPropertyChanged(nameof(SelectedShareLink));
                     break;
                 case nameof(ServerEntry.Network):
@@ -318,10 +275,6 @@ namespace XrayUI.ViewModels
             OnPropertyChanged(nameof(SelectedProtocol));
             OnPropertyChanged(nameof(SelectedSecurityLabel));
             OnPropertyChanged(nameof(SelectedEncryption));
-            OnPropertyChanged(nameof(SelectedVlessEncryption));
-            OnPropertyChanged(nameof(VlessEncryptionVisibility));
-            OnPropertyChanged(nameof(SelectedEch));
-            OnPropertyChanged(nameof(EchVisibility));
             OnPropertyChanged(nameof(SelectedTransport));
             OnPropertyChanged(nameof(SelectedShareLink));
             OnPropertyChanged(nameof(CanTestLatency));

--- a/Views/AddRuleDialog.xaml
+++ b/Views/AddRuleDialog.xaml
@@ -11,7 +11,7 @@
     CloseButtonText="取消"
     DefaultButton="Primary">
 
-    <StackPanel Spacing="16" MinWidth="320">
+    <StackPanel Spacing="16" MinWidth="320" MaxWidth="380">
 
         <StackPanel Spacing="6">
             <TextBlock Text="类型"
@@ -20,8 +20,9 @@
             <ComboBox x:Name="TypeComboBox"
                       SelectedIndex="0"
                       HorizontalAlignment="Stretch">
-                <ComboBoxItem Content="域名（Domain）" Tag="domain" />
-                <ComboBoxItem Content="IP"             Tag="ip" />
+                <ComboBoxItem Content="域名（Domain）"  Tag="domain" />
+                <ComboBoxItem Content="IP"              Tag="ip" />
+                <ComboBoxItem Content="进程（Process）" Tag="process" />
             </ComboBox>
         </StackPanel>
 
@@ -31,7 +32,29 @@
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
             <TextBox x:Name="MatchTextBox"
                      PlaceholderText="youtube.com 或 geosite:cn" />
-            <TextBlock Text="支持精确匹配、regexp:、geosite:、geoip: 前缀"
+
+            <!-- Browse helpers (visible only when Type = process) -->
+            <StackPanel x:Name="BrowsePanel"
+                        Orientation="Horizontal"
+                        Spacing="8"
+                        Visibility="Collapsed">
+                <Button x:Name="BrowseButton">
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <FontIcon Glyph="&#xE8E5;" FontSize="12" />
+                        <TextBlock x:Name="BrowseButtonText" Text="浏览 exe..." />
+                    </StackPanel>
+                </Button>
+                <ComboBox x:Name="BrowseFormatComboBox"
+                          SelectedIndex="0"
+                          MinWidth="130">
+                    <ComboBoxItem Content="匹配同名进程" Tag="name" />
+                    <ComboBoxItem Content="匹配完整路径" Tag="path" />
+                    <ComboBoxItem Content="匹配整个目录" Tag="folder" />
+                </ComboBox>
+            </StackPanel>
+
+            <TextBlock x:Name="HintTextBlock"
+                       Text="支持精确匹配、regexp:、geosite: 前缀"
                        FontSize="11"
                        Opacity="0.6"
                        TextWrapping="Wrap" />

--- a/Views/AddRuleDialog.xaml
+++ b/Views/AddRuleDialog.xaml
@@ -40,7 +40,7 @@
                         Visibility="Collapsed">
                 <Button x:Name="BrowseButton">
                     <StackPanel Orientation="Horizontal" Spacing="4">
-                        <FontIcon Glyph="&#xE8E5;" FontSize="12" />
+                        <FontIcon x:Name="BrowseButtonIcon" Glyph="&#xE8E5;" FontSize="12" />
                         <TextBlock x:Name="BrowseButtonText" Text="浏览 exe..." />
                     </StackPanel>
                 </Button>

--- a/Views/AddRuleDialog.xaml.cs
+++ b/Views/AddRuleDialog.xaml.cs
@@ -1,3 +1,7 @@
+using System;
+using System.IO;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Storage.Pickers;
 using XrayUI.Helpers;
 using XrayUI.Models;
 
@@ -7,19 +11,33 @@ namespace XrayUI.Views
     {
         public CustomRoutingRule? Result { get; private set; }
 
-        public AddRuleDialog() : this(null) { }
+        private readonly IntPtr _hostHwnd;
 
-        public AddRuleDialog(CustomRoutingRule? existing)
+        public AddRuleDialog(IntPtr hostHwnd, CustomRoutingRule? existing = null)
         {
+            _hostHwnd = hostHwnd;
             this.InitializeComponent();
             this.RequestedTheme = ThemeHelper.ActualTheme;
+
+            // Wire up event handlers in code-behind (NOT via XAML markup).
+            // The XAML-compiler-generated Connect path for SelectionChanged on a
+            // ContentDialog can fail to fire under AOT in WinUI 3; explicit
+            // subscription here is the AOT-safe pattern (cf. DialogService.cs).
+            TypeComboBox.SelectionChanged         += TypeComboBox_SelectionChanged;
+            BrowseFormatComboBox.SelectionChanged += BrowseFormatComboBox_SelectionChanged;
+            BrowseButton.Click                    += BrowseButton_Click;
 
             if (existing != null)
             {
                 Title             = "编辑规则";
                 PrimaryButtonText = "保存";
 
-                TypeComboBox.SelectedIndex     = existing.Type == "ip" ? 1 : 0;
+                TypeComboBox.SelectedIndex = existing.Type switch
+                {
+                    "ip"      => 1,
+                    "process" => 2,
+                    _         => 0,
+                };
                 MatchTextBox.Text              = existing.Match;
                 OutboundComboBox.SelectedIndex = existing.OutboundTag switch
                 {
@@ -29,7 +47,117 @@ namespace XrayUI.Views
                 };
             }
 
+            // Sync BrowsePanel + placeholder + hint for the initial Type selection
+            // (SelectionChanged may not fire for SelectedIndex set above pre-load).
+            ApplyTypeUiState();
+            ApplyBrowseFormatUiState();
+
             this.PrimaryButtonClick += OnPrimaryClick;
+        }
+
+        // ── Type changes: toggle BrowsePanel, swap placeholder + hint ─────────
+
+        private void TypeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+            => ApplyTypeUiState();
+
+        private void ApplyTypeUiState()
+        {
+            var tag = GetSelectedType();
+
+            if (BrowsePanel is not null)
+                BrowsePanel.Visibility = tag == "process" ? Visibility.Visible : Visibility.Collapsed;
+
+            if (MatchTextBox is not null)
+            {
+                MatchTextBox.PlaceholderText = tag switch
+                {
+                    "ip"      => "192.168.0.0/16 或 geoip:cn",
+                    "process" => "可手填进程名 / 路径 / 文件夹，或点浏览选取",
+                    _         => "youtube.com 或 geosite:cn",
+                };
+            }
+
+            if (HintTextBlock is not null)
+            {
+                HintTextBlock.Text = tag switch
+                {
+                    "ip"      => "支持 CIDR 与 geoip: 前缀",
+                    "process" => "同名进程：匹配任意路径下的同名 exe；完整路径：只匹配此 exe；整个目录：匹配该目录下所有 exe",
+                    _         => "支持精确匹配、regexp:、geosite: 前缀",
+                };
+            }
+        }
+
+        // ── Browse format changes: swap button label between exe / folder ────
+
+        private void BrowseFormatComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+            => ApplyBrowseFormatUiState();
+
+        private void ApplyBrowseFormatUiState()
+        {
+            if (BrowseButtonText is null) return;
+            var fmt = GetSelectedBrowseFormat();
+            BrowseButtonText.Text = fmt == "folder" ? "浏览文件夹..." : "浏览 exe...";
+        }
+
+        // Native AOT can be brittle around object-valued ComboBoxItem.Tag from XAML.
+        // These lists are static, so index mapping keeps dialog state deterministic.
+        private string GetSelectedType() => TypeComboBox.SelectedIndex switch
+        {
+            1 => "ip",
+            2 => "process",
+            _ => "domain",
+        };
+
+        private string GetSelectedBrowseFormat() => BrowseFormatComboBox.SelectedIndex switch
+        {
+            1 => "path",
+            2 => "folder",
+            _ => "name",
+        };
+
+        private string GetSelectedOutboundTag() => OutboundComboBox.SelectedIndex switch
+        {
+            1 => "direct",
+            2 => "block",
+            _ => "proxy",
+        };
+
+        // ── Browse click: file picker for name/path, folder picker for folder ──
+
+        private async void BrowseButton_Click(object sender, RoutedEventArgs e)
+        {
+            var format = GetSelectedBrowseFormat();
+
+            if (format == "folder")
+            {
+                var folderPicker = new FolderPicker
+                {
+                    SuggestedStartLocation = PickerLocationId.ComputerFolder,
+                };
+                folderPicker.FileTypeFilter.Add("*");
+                WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, _hostHwnd);
+
+                var folder = await folderPicker.PickSingleFolderAsync();
+                if (folder is null) return;
+
+                // Trailing backslash makes xray treat this as a folder match for
+                // all executables under the directory.
+                MatchTextBox.Text = folder.Path.TrimEnd('\\') + "\\";
+                return;
+            }
+
+            var picker = new FileOpenPicker
+            {
+                SuggestedStartLocation = PickerLocationId.ComputerFolder,
+            };
+            picker.FileTypeFilter.Add(".exe");
+            WinRT.Interop.InitializeWithWindow.Initialize(picker, _hostHwnd);
+
+            var file = await picker.PickSingleFileAsync();
+            if (file is null) return;
+
+            MatchTextBox.Text = format == "path" ? file.Path : file.Name;
         }
 
         private void OnPrimaryClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
@@ -42,8 +170,8 @@ namespace XrayUI.Views
                 return;
             }
 
-            var typeTag     = (TypeComboBox.SelectedItem     as ComboBoxItem)?.Tag as string ?? "domain";
-            var outboundTag = (OutboundComboBox.SelectedItem as ComboBoxItem)?.Tag as string ?? "proxy";
+            var typeTag     = GetSelectedType();
+            var outboundTag = GetSelectedOutboundTag();
 
             Result = new CustomRoutingRule
             {

--- a/Views/AddRuleDialog.xaml.cs
+++ b/Views/AddRuleDialog.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Storage.Pickers;
@@ -96,8 +96,12 @@ namespace XrayUI.Views
         private void ApplyBrowseFormatUiState()
         {
             if (BrowseButtonText is null) return;
-            var fmt = GetSelectedBrowseFormat();
-            BrowseButtonText.Text = fmt == "folder" ? "浏览文件夹..." : "浏览 exe...";
+            var isFolder = GetSelectedBrowseFormat() == "folder";
+            BrowseButtonText.Text = isFolder ? "浏览文件夹..." : "浏览 exe...";
+            if (BrowseButtonIcon is not null)
+            {
+                BrowseButtonIcon.Glyph = isFolder ? "\uE8DA" : "\uE8E5";
+            }
         }
 
         // Native AOT can be brittle around object-valued ComboBoxItem.Tag from XAML.

--- a/Views/ControlPanelControl.xaml
+++ b/Views/ControlPanelControl.xaml
@@ -86,6 +86,9 @@
                                 <MenuFlyoutItem Text="自定义规则..."
                                                 IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
                                                 Command="{x:Bind ViewModel.ShowCustomRulesCommand}" />
+                                <MenuFlyoutItem Text="DNS设置"
+                                                IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
+                                                Command="{x:Bind ViewModel.ShowDnsSettingsCommand}" />
                             </MenuFlyoutSubItem>
                         </MenuFlyout>
                     </Button.Flyout>

--- a/Views/CustomRulesWindow.xaml
+++ b/Views/CustomRulesWindow.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Window x:Class="XrayUI.Views.CustomRulesWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -36,7 +36,7 @@
                         Background="Transparent"
                         BorderThickness="0"
                         VerticalAlignment="Center"
-                        ToolTipService.ToolTip="更新geoFile路由数据"
+                        ToolTipService.ToolTip="更新GeoFiles路由数据"
                         Click="UpdateGeoButton_Click">
                     <FontIcon Glyph="&#xE895;"  FontSize="14" />
                 </Button>

--- a/Views/CustomRulesWindow.xaml
+++ b/Views/CustomRulesWindow.xaml
@@ -94,7 +94,7 @@
                     <Grid ColumnDefinitions="Auto,*,Auto,Auto"
                           ColumnSpacing="12"
                           Padding="4,2">
-                        <!-- Type badge (Domain = accent, IP = success) -->
+                        <!-- Type badge (Domain = accent, IP = success, Process = caution) -->
                         <Grid Grid.Column="0" VerticalAlignment="Center">
                             <Border CornerRadius="4"
                                     Background="{ThemeResource SystemFillColorAttentionBackgroundBrush}"
@@ -113,6 +113,15 @@
                                            FontSize="11"
                                            FontWeight="SemiBold"
                                            Foreground="{ThemeResource SystemFillColorSuccessBrush}" />
+                            </Border>
+                            <Border CornerRadius="4"
+                                    Background="{ThemeResource SystemFillColorCautionBackgroundBrush}"
+                                    Padding="8,2"
+                                    Visibility="{x:Bind ProcessVisibility}">
+                                <TextBlock Text="Process"
+                                           FontSize="11"
+                                           FontWeight="SemiBold"
+                                           Foreground="{ThemeResource SystemFillColorCautionBrush}" />
                             </Border>
                         </Grid>
 

--- a/Views/CustomRulesWindow.xaml.cs
+++ b/Views/CustomRulesWindow.xaml.cs
@@ -75,7 +75,8 @@ namespace XrayUI.Views
 
         private async void OnShowAddOrEditDialogRequested(object? sender, CustomRoutingRule? existing)
         {
-            var dialog = new AddRuleDialog(existing) { XamlRoot = Content.XamlRoot };
+            var hostHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            var dialog = new AddRuleDialog(hostHwnd, existing) { XamlRoot = Content.XamlRoot };
             var result = await dialog.ShowAsync();
             if (result != ContentDialogResult.Primary || dialog.Result is null) return;
 

--- a/Views/ServerDetailControl.xaml
+++ b/Views/ServerDetailControl.xaml
@@ -25,10 +25,8 @@
                    Margin="0,0,0,16" />
 
         <StackPanel Orientation="Vertical"
-                    
                     Grid.Row="1"
-                    Spacing="8"
-                    Padding="0,0,12,80">
+                Padding="0,0,12,40"    >
 
 
             <Border 
@@ -52,8 +50,6 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
@@ -130,35 +126,7 @@
                                        Text="{x:Bind ViewModel.SelectedTransport, Mode=OneWay}"
                                        FontSize="16" />
 
-                            <!-- Row 6: VLESS encryption (PQ) — VLESS only, hidden if empty -->
-                            <TextBlock Grid.Row="6"
-                                       Grid.Column="0"
-                                       Text="加密(PQ)"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                       VerticalAlignment="Center"
-                                       Visibility="{x:Bind ViewModel.VlessEncryptionVisibility, Mode=OneWay}" />
-                            <TextBlock Grid.Row="6"
-                                        Grid.Column="1"
-                                        Text="{x:Bind ViewModel.SelectedVlessEncryption, Mode=OneWay}"
-                                        ToolTipService.ToolTip="{x:Bind ViewModel.SelectedVlessEncryption, Mode=OneWay}"
-                                        FontSize="13"
-                                        TextTrimming="CharacterEllipsis"
-                                        Visibility="{x:Bind ViewModel.VlessEncryptionVisibility, Mode=OneWay}" />
 
-                            <!-- Row 7: ECH - VLESS + TLS only, hidden if empty -->
-                            <TextBlock Grid.Row="7"
-                                       Grid.Column="0"
-                                       Text="ECH"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                       VerticalAlignment="Center"
-                                       Visibility="{x:Bind ViewModel.EchVisibility, Mode=OneWay}" />
-                            <TextBlock Grid.Row="7"
-                                       Grid.Column="1"
-                                       Text="{x:Bind ViewModel.SelectedEch, Mode=OneWay}"
-                                       ToolTipService.ToolTip="{x:Bind ViewModel.SelectedEch, Mode=OneWay}"
-                                       FontSize="13"
-                                       TextTrimming="CharacterEllipsis"
-                                       Visibility="{x:Bind ViewModel.EchVisibility, Mode=OneWay}" />
                         </Grid>
 
                         <!-- AI 服务监测区 -->


### PR DESCRIPTION
## Summary

Three independent additions plus some smaller cleanups on the `net10` branch:

- **DNS settings dialog** — split direct / proxy DNS upstreams, query strategy, cache toggle, with one-tap presets and DoH support
- **FakeDNS (experimental)** — opt-in TUN-mode-only feature with auto DNS-cache flushing on stop to mitigate the documented pollution risk
- **Process-based routing rules** — `process` type in custom rules with a built-in exe / path / folder picker

## What changed

### DNS

- `Services/DialogService.ShowDnsSettingsDialogAsync(AppSettings, bool isTunMode)` — new dialog with 直连/代理 DNS textboxes, presets (阿里/腾讯/114/谷歌/CF/Quad9 + DoH), 查询策略 (IPv4/IPv6/自动), and DNS 缓存 toggle. The `isTunMode` parameter takes the **live** UI state rather than `settings.IsTunMode` (which only catches up at Connect) so FakeDNS gating reflects what the user just toggled
- `Services/XrayConfigBuilder.BuildDns` rewritten around per-domain server entries: direct upstream filtered by `geosite:cn` + `expectIPs: geoip:cn`, localhost for `geosite:private`, proxy upstream as fallback; `queryStrategy` and `disableCache` honored from settings
- `Services/DnsQueryStrategy.cs` — new constants (`UseIPv4` / `UseIPv6` / `UseIP`) so persisted values stay in one place

### FakeDNS

- `Models/AppSettings.FakeDnsEnabled` — opt-in, default false; only acts when `IsTunMode` is also true
- `Services/XrayConfigBuilder` — emits `fakedns` pool (`198.18.0.0/15` + `fc00::/18`), prepends `"fakedns"` to `dns.servers`, adds a `dns-out` outbound + port-53 routing rule, and flips TUN inbound sniffing to `destOverride: ["fakedns", "http", "tls", "quic"]` with `metadataOnly: false`
- `Services/XrayService.FlushSystemDnsCache` — `ipconfig /flushdns` runs unconditionally on every `StopAsync` to clear cached 198.18.x.x entries (xtls docs warn fakedns can pollute local DNS, causing "无法访问网络" after Xray closes). Not called in `StopForShutdown` since the system flushes on logoff anyway
- `Services/XrayConfigConstants` — centralizes `tun-in` / `mixed-in` / `dns-out` / `fakedns` tags and the IP pools to keep cross-references in sync
- UI: an "实验性" pill using `SystemFillColorAttentionBackgroundBrush` + `SystemFillColorAttentionBrush` (theme-aware). Toggle is disabled and forced to OFF when not in TUN mode, and the save path skips writing `FakeDnsEnabled` in that case so a previously-saved value isn't clobbered

### Routing

- `Models/CustomRoutingRule` — `Type` accepts `"process"` in addition to `"domain"` / `"ip"`; new `ProcessVisibility` for x:Bind
- `Views/AddRuleDialog` — adds a 浏览 exe... helper with a format dropdown (匹配同名进程 / 匹配完整路径 / 匹配整个目录) that uses `FileOpenPicker` / `FolderPicker`. ComboBox selections are mapped by index (AOT-safe; XAML `Tag` projection is fragile under AOT)
- `Views/CustomRulesWindow` — caution-tinted "Process" badge alongside the existing Domain / IP badges
- `Services/XrayConfigBuilder.BuildRouting` — switch over `rule.Type` so process rules emit `["process"]` arrays

### Other

- `ViewModels/ControlPanelViewModel` — TUN preflight (wintun availability, default outbound interface detection, system-proxy clear) factored into `RunTunPreflightAsync` and reused from connect + reapply; `ReapplyRoutingAsync` now also refreshes the live `LocalMixedPort` / `RoutingMode` / `IsTunMode` / `IsSystemProxyEnabled` before rebuilding so a runtime change to those is honored, and re-points the WinInet system proxy to the (possibly new) `LocalMixedPort` after restart — fixes the case where changing the local port at runtime left the OS proxy pointing at the old port
- `Views/ServerDetailControl` — drops the PQ encryption and ECH info rows from the detail panel (the data is still accessible via the share link and edit dialog) so the panel stays compact; `ServerDetailViewModel` loses the now-unused properties and change notifications

## Why

- **FakeDNS:** users in TUN mode were seeing DNS queries leak around the tunnel; FakeDNS routes them through xray's internal resolver. Gated as experimental because of the documented pollution risk — auto-flushdns on stop mitigates it but isn't a perfect guarantee against per-app DNS caches
- **DNS dialog:** the previous DNS config was hard-coded (`["223.5.5.5", "119.29.29.29", "localhost"]` etc.); users couldn't switch providers, enable DoH, or toggle the cache
- **Process rules:** routing by process name was a frequently-requested addition for handling apps that don't match cleanly by domain or IP (games, native clients)

## Test plan

- [x] Build: `dotnet build -c Debug` clean (currently 0 warnings / 0 errors)
- [x] DNS dialog: open from 路由 menu, edit each field, save → values persist in `%LocalAppData%\XrayUI\settings.json`; "重置默认" clears all four controls
- [x] DNS regression (FakeDNS off): TUN-mode connect, inspect `%LocalAppData%\XrayUI\xray_config.json` — no `fakedns` field, no `dns-out`, TUN inbound `destOverride = ["http","tls","quic"]`
- [x] FakeDNS on + TUN on: config has top-level `fakedns` pool, `dns.servers[0] == "fakedns"`, `tun-in.sniffing.destOverride` contains `"fakedns"` with `metadataOnly: false`, outbounds contain `{tag:"dns-out", protocol:"dns"}`, routing has port-53 → dns-out as the first rule
- [x] FakeDNS on + TUN off: config has no fakedns-related fields (the `Build`-time guard short-circuits)
- [x] UI gating: with TUN off, FakeDNS toggle is greyed and forced OFF; switching TUN on and reopening restores the previously saved value
- [x] Pollution mitigation: stop xray after a FakeDNS session — `Get-DnsClientCache | ? IPAddress -like '198.18.*'` is empty; baidu.com / github.com resolve immediately
- [x] Process rules: add a rule with each of the three browse formats, verify the generated config has the rule under `routing.rules` with `process: [...]`
- [x] Reapply: with xray running in non-TUN mode, change Local Port at runtime and confirm xray restarts with the new config **and** the OS proxy now points at the new port (the bug this fix targets)