### PR TITLE
feat: add proxy chain and SOCKS protocol support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ Generated\ Files/
 # Claude / AI
 .claude/
 /CLAUDE.md
+/BuildAndRun.ps1

--- a/Models/ServerEntry.cs
+++ b/Models/ServerEntry.cs
@@ -15,6 +15,7 @@ namespace XrayUI.Models
             Host = string.Empty;
             Protocol = string.Empty;
             Encryption = string.Empty;
+            Username = string.Empty;
             Password = string.Empty;
             Uuid = string.Empty;
             Network = "tcp";
@@ -31,6 +32,8 @@ namespace XrayUI.Models
             Flow = string.Empty;
             VlessEncryption = string.Empty;
             Finalmask = string.Empty;
+            ChainEntryServerId = string.Empty;
+            ChainExitServerId = string.Empty;
         }
 
         /// <summary>ID of the subscription this node was imported from; empty = manually added.</summary>
@@ -46,9 +49,10 @@ namespace XrayUI.Models
         [ObservableProperty]
         public partial int Port { get; set; }
 
-        /// <summary>ss | vmess | vless | hysteria2 | trojan</summary>
+        /// <summary>ss | vmess | vless | hysteria2 | trojan | socks | chain</summary>
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(DisplayProtocol))]
+        [NotifyPropertyChangedFor(nameof(IsChain))]
         public partial string Protocol { get; set; }
 
         /// <summary>Cipher for ss; "TLS" or "Reality" label for vless/vmess/hysteria2</summary>
@@ -62,6 +66,9 @@ namespace XrayUI.Models
         public partial bool IsFavorite { get; set; }
 
         // Auth
+        [ObservableProperty]
+        public partial string Username { get; set; }
+
         [ObservableProperty]
         public partial string Password { get; set; }
 
@@ -124,6 +131,13 @@ namespace XrayUI.Models
         [ObservableProperty]
         public partial string Finalmask { get; set; }
 
+        // Proxy chain
+        [ObservableProperty]
+        public partial string ChainEntryServerId { get; set; }
+
+        [ObservableProperty]
+        public partial string ChainExitServerId { get; set; }
+
         public string Id
         {
             get => _id;
@@ -138,8 +152,13 @@ namespace XrayUI.Models
             "vless" => "VLESS",
             "hysteria2" => "Hysteria 2",
             "trojan" => "Trojan",
+            "socks" => "SOCKS",
+            "chain" => "ProxyChain",
             _ => Protocol ?? string.Empty
         };
+
+        [JsonIgnore]
+        public bool IsChain => string.Equals(Protocol, "chain", System.StringComparison.OrdinalIgnoreCase);
 
         public void RefreshProtocolColor() => OnPropertyChanged(nameof(Protocol));
     }

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using System.ComponentModel;
+using System.Collections.Generic;
 using Windows.ApplicationModel.DataTransfer;
 using XrayUI.Helpers;
 using XrayUI.Models;
@@ -118,7 +119,7 @@ namespace XrayUI.Services
                 SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline
             };
             var cmbProtocol = new ComboBox { Header = "协议", MinWidth = 200 };
-            foreach (var p in new[] { "ss", "vmess", "vless", "hysteria2", "trojan" })
+            foreach (var p in new[] { "ss", "vmess", "vless", "hysteria2", "trojan", "socks" })
                 cmbProtocol.Items.Add(p);
             cmbProtocol.SelectedItem = existing?.Protocol?.ToLower() ?? "ss";
 
@@ -132,6 +133,7 @@ namespace XrayUI.Services
             if (existing?.Encryption is { Length: > 0 } existingEnc && !cmbEncryption.Items.Contains(existingEnc))
                 cmbEncryption.Items.Add(existingEnc);
             cmbEncryption.SelectedItem = existing?.Encryption ?? "aes-128-gcm";
+            var txtUsername = new TextBox { Header = "用户名 (SOCKS)", Text = existing?.Username ?? string.Empty };
             var txtPassword = new PasswordBox { Header = "密码", Password = existing?.Password ?? string.Empty };
             var txtUuid = new TextBox { Header = "UUID (VMess / VLESS)", Text = existing?.Uuid ?? string.Empty };
             var numAlterId = new NumberBox
@@ -191,6 +193,7 @@ namespace XrayUI.Services
 
             // Row containers for conditional visibility
             var rowEncryption = Wrap(cmbEncryption);
+            var rowUsername = Wrap(txtUsername);
             var rowPassword = Wrap(txtPassword);
             var rowUuid = Wrap(txtUuid);
             var rowAlterId = Wrap(numAlterId);
@@ -219,18 +222,21 @@ namespace XrayUI.Services
                 bool isVless = proto == "vless";
                 bool isHysteria2 = proto == "hysteria2";
                 bool isTrojan = proto == "trojan";
-                bool hasWs = !isHysteria2 && net == "ws";
-                bool hasXhttp = !isHysteria2 && net == "xhttp";
-                bool hasGrpc = !isHysteria2 && net == "grpc";
-                bool hasTls = !isHysteria2 && (sec == "tls" || sec == "reality");
-                bool hasReality = !isHysteria2 && sec == "reality";
+                bool isSocks = proto == "socks";
+                bool isStandardTransport = !isHysteria2 && !isSocks;
+                bool hasWs = isStandardTransport && net == "ws";
+                bool hasXhttp = isStandardTransport && net == "xhttp";
+                bool hasGrpc = isStandardTransport && net == "grpc";
+                bool hasTls = isStandardTransport && (sec == "tls" || sec == "reality");
+                bool hasReality = isStandardTransport && sec == "reality";
                 bool hasEch = isVless && sec == "tls";
 
-                cmbNetwork.Visibility = isHysteria2 ? Visibility.Collapsed : Visibility.Visible;
-                cmbSecurity.Visibility = isHysteria2 ? Visibility.Collapsed : Visibility.Visible;
+                cmbNetwork.Visibility = isStandardTransport ? Visibility.Visible : Visibility.Collapsed;
+                cmbSecurity.Visibility = isStandardTransport ? Visibility.Visible : Visibility.Collapsed;
 
                 rowEncryption.Visibility = isSs ? Visibility.Visible : Visibility.Collapsed;
-                rowPassword.Visibility = (isSs || isHysteria2 || isTrojan)
+                rowUsername.Visibility = isSocks ? Visibility.Visible : Visibility.Collapsed;
+                rowPassword.Visibility = (isSs || isHysteria2 || isTrojan || isSocks)
                     ? Visibility.Visible
                     : Visibility.Collapsed;
                 rowUuid.Visibility = (isVmess || isVless) ? Visibility.Visible : Visibility.Collapsed;
@@ -270,7 +276,7 @@ namespace XrayUI.Services
                 Children =
                 {
                     txtName, txtHost, numPort, cmbProtocol,
-                    rowEncryption, rowPassword, rowUuid, rowAlterId,
+                    rowEncryption, rowUsername, rowPassword, rowUuid, rowAlterId,
                     cmbNetwork, rowPath, rowWsHost,
                     cmbSecurity, rowSni, rowFp, rowAllowInsecure, rowEchConfigList, rowEchForceQuery,
                     rowPk, rowSid, rowSpx, rowFlow, rowVlessEncryption,
@@ -301,6 +307,7 @@ namespace XrayUI.Services
             entry.Port = (int)numPort.Value;
             entry.Protocol = cmbProtocol.SelectedItem?.ToString() ?? "ss";
             entry.Encryption = cmbEncryption.SelectedItem?.ToString() ?? string.Empty;
+            entry.Username = txtUsername.Text.Trim();
             entry.Password = txtPassword.Password.Trim();
             entry.Uuid = txtUuid.Text.Trim();
             entry.AlterId = (int)numAlterId.Value;
@@ -324,6 +331,31 @@ namespace XrayUI.Services
             {
                 entry.Security = "tls";
             }
+            else if (entry.Protocol == "socks")
+            {
+                entry.Network = "tcp";
+                entry.Security = "none";
+                entry.Encryption = string.Empty;
+                entry.Uuid = string.Empty;
+                entry.AlterId = 0;
+                entry.Path = string.Empty;
+                entry.WsHost = string.Empty;
+                entry.Sni = string.Empty;
+                entry.Fingerprint = string.Empty;
+                entry.AllowInsecure = false;
+                entry.EchConfigList = string.Empty;
+                entry.EchForceQuery = string.Empty;
+                entry.PublicKey = string.Empty;
+                entry.ShortId = string.Empty;
+                entry.SpiderX = string.Empty;
+                entry.Flow = string.Empty;
+                entry.VlessEncryption = string.Empty;
+                entry.Finalmask = string.Empty;
+            }
+            else
+            {
+                entry.Username = string.Empty;
+            }
 
             if (!string.Equals(entry.Protocol, "vless", StringComparison.OrdinalIgnoreCase)
                 || !string.Equals(entry.Security, "tls", StringComparison.OrdinalIgnoreCase)
@@ -333,7 +365,7 @@ namespace XrayUI.Services
                 entry.EchForceQuery = string.Empty;
             }
 
-            if (entry.Protocol != "ss")
+            if (entry.Protocol != "ss" && entry.Protocol != "socks")
             {
                 entry.Encryption = entry.Security == "reality" ? "Reality"
                     : entry.Security == "tls" ? "TLS"
@@ -341,6 +373,32 @@ namespace XrayUI.Services
             }
 
             return entry;
+        }
+
+        public async Task<ServerEntry?> ShowChainProxyDialogAsync(
+            IEnumerable<ServerEntry> servers,
+            ServerEntry? existing = null)
+        {
+            var content = new AddChainProxyDialog(servers, existing);
+            ServerEntry? saved = null;
+
+            var dialog = CreateDialog();
+            dialog.Title = existing is null ? "链式代理" : "编辑链式代理";
+            dialog.PrimaryButtonText = "保存";
+            dialog.CloseButtonText = "取消";
+            dialog.DefaultButton = ContentDialogButton.Primary;
+            dialog.Content = content;
+
+            dialog.PrimaryButtonClick += (_, args) =>
+            {
+                if (content.TryCreateOrUpdate(out saved))
+                    return;
+
+                args.Cancel = true;
+            };
+
+            var result = await dialog.ShowAsync();
+            return result == ContentDialogResult.Primary ? saved : null;
         }
 
         // ── Edit local port ───────────────────────────────────────────────────

--- a/Services/IDialogService.cs
+++ b/Services/IDialogService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using XrayUI.Models;
@@ -10,6 +11,7 @@ namespace XrayUI.Services
         Task<string?> ShowImportLinkDialogAsync();
         Task<SubscriptionEntry?> ShowSubscriptionsDialogAsync(ManageSubscriptionsViewModel vm);
         Task<ServerEntry?> ShowEditServerDialogAsync(ServerEntry? existing);
+        Task<ServerEntry?> ShowChainProxyDialogAsync(IEnumerable<ServerEntry> servers, ServerEntry? existing = null);
         Task<int?> ShowEditPortDialogAsync(int currentPort);
         Task ShowErrorAsync(string title, string message, XamlRoot? xamlRoot = null);
         Task<bool> ShowConfirmationAsync(string title, string message, string confirmText = "确定", string cancelText = "取消", bool isDanger = false);

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using XrayUI.Models;
@@ -13,20 +14,28 @@ namespace XrayUI.Services
     public static class XrayConfigBuilder
     {
         private const string DefaultLogLevel = "info";
+        private const string ProxyOutboundTag = "proxy";
+        private const string DirectOutboundTag = "direct";
+        private const string BlockOutboundTag = "block";
+        private const string ChainEntryOutboundTag = "chain-entry";
 
         private static readonly JsonSerializerOptions JsonOpts = new()
         {
             WriteIndented = true
         };
 
-        public static string Build(ServerEntry server, AppSettings settings, string? tunOutboundInterfaceName = null)
+        public static string Build(
+            ServerEntry server,
+            AppSettings settings,
+            string? tunOutboundInterfaceName = null,
+            IEnumerable<ServerEntry>? availableServers = null)
         {
             var config = new JsonObject
             {
                 ["log"] = BuildLog(settings),
                 ["dns"] = BuildDns(settings),
                 ["inbounds"] = BuildInbounds(settings),
-                ["outbounds"] = BuildOutbounds(server, settings, tunOutboundInterfaceName),
+                ["outbounds"] = BuildOutbounds(server, settings, tunOutboundInterfaceName, availableServers),
                 ["routing"] = BuildRouting(settings)
             };
 
@@ -125,19 +134,35 @@ namespace XrayUI.Services
             };
         }
 
-        private static JsonArray BuildOutbounds(ServerEntry server, AppSettings settings, string? tunOutboundInterfaceName)
+        private static JsonArray BuildOutbounds(
+            ServerEntry server,
+            AppSettings settings,
+            string? tunOutboundInterfaceName,
+            IEnumerable<ServerEntry>? availableServers)
         {
-            var proxy = BuildProxyOutbound(server);
+            var list = new JsonArray();
+
+            if (server.IsChain)
+            {
+                var (entryServer, exitServer) = ResolveChainServers(server, availableServers);
+                var proxy = BuildProxyOutbound(exitServer, ProxyOutboundTag);
+                var chainEntry = BuildProxyOutbound(entryServer, ChainEntryOutboundTag);
+                ApplyProxySettings(proxy, ChainEntryOutboundTag);
+                AddNode(list, proxy);
+                AddNode(list, chainEntry);
+            }
+            else
+            {
+                AddNode(list, BuildProxyOutbound(server, ProxyOutboundTag));
+            }
 
             var direct = new JsonObject
             {
-                ["tag"] = "direct",
+                ["tag"] = DirectOutboundTag,
                 ["protocol"] = "freedom",
                 ["settings"] = new JsonObject()
             };
 
-            var list = new JsonArray();
-            AddNode(list, proxy);
             AddNode(list, direct);
 
             // block outbound is needed by:
@@ -148,13 +173,13 @@ namespace XrayUI.Services
                 && settings.CustomRules is { } rules
                 && rules.Any(r => r.IsEnabled
                                   && !string.IsNullOrWhiteSpace(r.Match)
-                                  && r.OutboundTag == "block");
+                                  && r.OutboundTag == BlockOutboundTag);
 
             if (settings.IsTunMode || customRulesUseBlock)
             {
                 AddNode(list, new JsonObject
                 {
-                    ["tag"] = "block",
+                    ["tag"] = BlockOutboundTag,
                     ["protocol"] = "blackhole",
                     ["settings"] = new JsonObject()
                 });
@@ -178,12 +203,52 @@ namespace XrayUI.Services
                 foreach (var outbound in list.OfType<JsonObject>())
                 {
                     var tag = outbound["tag"]?.GetValue<string>();
-                    if (tag is "proxy" or "direct")
+                    if (tag is ProxyOutboundTag or DirectOutboundTag or ChainEntryOutboundTag)
                         ApplyOutboundInterface(outbound, tunOutboundInterfaceName);
                 }
             }
 
             return list;
+        }
+
+        private static (ServerEntry entryServer, ServerEntry exitServer) ResolveChainServers(
+            ServerEntry chain,
+            IEnumerable<ServerEntry>? availableServers)
+        {
+            if (availableServers is null)
+            {
+                throw new InvalidOperationException("链式代理需要服务器列表才能解析入口和出口节点。");
+            }
+
+            ServerEntry? entryServer = null;
+            ServerEntry? exitServer = null;
+            foreach (var s in availableServers)
+            {
+                if (entryServer is null && s.Id == chain.ChainEntryServerId) entryServer = s;
+                if (exitServer is null && s.Id == chain.ChainExitServerId) exitServer = s;
+                if (entryServer is not null && exitServer is not null) break;
+            }
+
+            if (entryServer is null || exitServer is null)
+            {
+                throw new InvalidOperationException("链式代理引用的入口或出口节点不存在，请重新编辑该链式代理。");
+            }
+
+            if (entryServer.IsChain || exitServer.IsChain)
+            {
+                throw new InvalidOperationException("链式代理不能嵌套链式代理，请重新选择入口和出口节点。");
+            }
+
+            return (entryServer, exitServer);
+        }
+
+        private static void ApplyProxySettings(JsonObject outbound, string tag)
+        {
+            outbound["proxySettings"] = new JsonObject
+            {
+                ["tag"] = tag,
+                ["transportLayer"] = true
+            };
         }
 
         private static void ApplyOutboundInterface(JsonObject outbound, string interfaceName)
@@ -205,19 +270,20 @@ namespace XrayUI.Services
             sockopt["interface"] = interfaceName;
         }
 
-        private static JsonObject BuildProxyOutbound(ServerEntry server)
+        private static JsonObject BuildProxyOutbound(ServerEntry server, string tag)
         {
             return server.Protocol.ToLowerInvariant() switch
             {
-                "vmess" => BuildVmessOutbound(server),
-                "vless" => BuildVlessOutbound(server),
-                "hysteria2" => BuildHysteria2Outbound(server),
-                "trojan" => BuildTrojanOutbound(server),
-                _ => BuildSsOutbound(server)
+                "vmess" => BuildVmessOutbound(server, tag),
+                "vless" => BuildVlessOutbound(server, tag),
+                "hysteria2" => BuildHysteria2Outbound(server, tag),
+                "trojan" => BuildTrojanOutbound(server, tag),
+                "socks" => BuildSocksOutbound(server, tag),
+                _ => BuildSsOutbound(server, tag)
             };
         }
 
-        private static JsonObject BuildSsOutbound(ServerEntry server)
+        private static JsonObject BuildSsOutbound(ServerEntry server, string tag)
         {
             var servers = new JsonArray();
             AddNode(servers, new JsonObject
@@ -230,7 +296,7 @@ namespace XrayUI.Services
 
             var outbound = new JsonObject
             {
-                ["tag"] = "proxy",
+                ["tag"] = tag,
                 ["protocol"] = "shadowsocks",
                 ["settings"] = new JsonObject
                 {
@@ -246,7 +312,7 @@ namespace XrayUI.Services
             return outbound;
         }
 
-        private static JsonObject BuildVmessOutbound(ServerEntry server)
+        private static JsonObject BuildVmessOutbound(ServerEntry server, string tag)
         {
             var users = new JsonArray();
             AddNode(users, new JsonObject
@@ -266,7 +332,7 @@ namespace XrayUI.Services
 
             return new JsonObject
             {
-                ["tag"] = "proxy",
+                ["tag"] = tag,
                 ["protocol"] = "vmess",
                 ["settings"] = new JsonObject
                 {
@@ -276,7 +342,7 @@ namespace XrayUI.Services
             };
         }
 
-        private static JsonObject BuildVlessOutbound(ServerEntry server)
+        private static JsonObject BuildVlessOutbound(ServerEntry server, string tag)
         {
             var user = new JsonObject
             {
@@ -302,7 +368,7 @@ namespace XrayUI.Services
 
             return new JsonObject
             {
-                ["tag"] = "proxy",
+                ["tag"] = tag,
                 ["protocol"] = "vless",
                 ["settings"] = new JsonObject
                 {
@@ -312,7 +378,7 @@ namespace XrayUI.Services
             };
         }
 
-        private static JsonObject BuildHysteria2Outbound(ServerEntry server)
+        private static JsonObject BuildHysteria2Outbound(ServerEntry server, string tag)
         {
             var sni = string.IsNullOrWhiteSpace(server.Sni) ? server.Host : server.Sni;
 
@@ -335,7 +401,7 @@ namespace XrayUI.Services
 
             return new JsonObject
             {
-                ["tag"] = "proxy",
+                ["tag"] = tag,
                 ["protocol"] = "hysteria",
                 ["settings"] = new JsonObject
                 {
@@ -347,11 +413,11 @@ namespace XrayUI.Services
             };
         }
 
-        private static JsonObject BuildTrojanOutbound(ServerEntry server)
+        private static JsonObject BuildTrojanOutbound(ServerEntry server, string tag)
         {
             return new JsonObject
             {
-                ["tag"] = "proxy",
+                ["tag"] = tag,
                 ["protocol"] = "trojan",
                 ["settings"] = new JsonObject
                 {
@@ -360,6 +426,40 @@ namespace XrayUI.Services
                     ["password"] = server.Password
                 },
                 ["streamSettings"] = BuildStreamSettings(server)
+            };
+        }
+
+        private static JsonObject BuildSocksOutbound(ServerEntry server, string tag)
+        {
+            var serverObject = new JsonObject
+            {
+                ["address"] = server.Host,
+                ["port"] = server.Port,
+            };
+
+            if (!string.IsNullOrWhiteSpace(server.Username)
+                || !string.IsNullOrWhiteSpace(server.Password))
+            {
+                var users = new JsonArray();
+                AddNode(users, new JsonObject
+                {
+                    ["user"] = server.Username,
+                    ["pass"] = server.Password,
+                });
+                serverObject["users"] = users;
+            }
+
+            var servers = new JsonArray();
+            AddNode(servers, serverObject);
+
+            return new JsonObject
+            {
+                ["tag"] = tag,
+                ["protocol"] = "socks",
+                ["settings"] = new JsonObject
+                {
+                    ["servers"] = servers
+                }
             };
         }
 
@@ -498,14 +598,14 @@ namespace XrayUI.Services
                 AddNode(rules, new JsonObject
                 {
                     ["type"] = "field",
-                    ["outboundTag"] = "direct",
+                    ["outboundTag"] = DirectOutboundTag,
                     ["process"] = CreateStringArray("self/", "xray/")
                 });
 
                 AddNode(rules, new JsonObject
                 {
                     ["type"] = "field",
-                    ["outboundTag"] = "block",
+                    ["outboundTag"] = BlockOutboundTag,
                     ["network"] = "udp",
                     ["port"] = "443"
                 });
@@ -516,7 +616,7 @@ namespace XrayUI.Services
                 AddNode(rules, new JsonObject
                 {
                     ["type"] = "field",
-                    ["outboundTag"] = "proxy",
+                    ["outboundTag"] = ProxyOutboundTag,
                     ["network"] = "tcp,udp"
                 });
 
@@ -554,7 +654,7 @@ namespace XrayUI.Services
             AddNode(rules, new JsonObject
             {
                 ["type"] = "field",
-                ["outboundTag"] = "proxy",
+                ["outboundTag"] = ProxyOutboundTag,
                 ["domain"] = CreateStringArray(
 					"geosite:google"
 				)
@@ -562,19 +662,19 @@ namespace XrayUI.Services
             AddNode(rules, new JsonObject
             {
                 ["type"] = "field",
-                ["outboundTag"] = "direct",
+                ["outboundTag"] = DirectOutboundTag,
                 ["domain"] = CreateStringArray("geosite:cn", "geosite:private")
             });
             AddNode(rules, new JsonObject
             {
                 ["type"] = "field",
-                ["outboundTag"] = "direct",
+                ["outboundTag"] = DirectOutboundTag,
                 ["ip"] = CreateStringArray("geoip:cn", "geoip:private")
             });
             AddNode(rules, new JsonObject
             {
                 ["type"] = "field",
-                ["outboundTag"] = "proxy",
+                ["outboundTag"] = ProxyOutboundTag,
                 ["network"] = "tcp,udp"
             });
 

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using XrayUI.Helpers;
@@ -39,6 +40,10 @@ namespace XrayUI.ViewModels
 
         public Func<ServerEntry?> GetSelectedServer { get; set; } = () => null;
 
+        public Func<IEnumerable<ServerEntry>> GetAllServers { get; set; } = () => Array.Empty<ServerEntry>();
+
+        public Func<bool> CanStartSelectedServer { get; set; } = () => false;
+
         // Snapshot of the server xray is actually running with, so reapply restarts
         // against the live session rather than whatever is now selected in the list.
         private ServerEntry? _activeServer;
@@ -61,6 +66,7 @@ namespace XrayUI.ViewModels
                     OnPropertyChanged(nameof(IsModeToggleEnabled));
                     OnPropertyChanged(nameof(IsTunToggleEnabled));
                     OnPropertyChanged(nameof(IsNotReapplying));
+                    NotifyStartStopStateChanged();
                     OnPropertyChanged(nameof(StatusText));
                 }
             }
@@ -69,6 +75,14 @@ namespace XrayUI.ViewModels
         /// <summary>Inverse of <see cref="IsReapplying"/> for x:Bind IsEnabled targets
         /// (x:Bind doesn't support expression negation).</summary>
         public bool IsNotReapplying => !_isReapplying;
+
+        public bool CanStartStop => !IsReapplying && (IsRunning || CanStartSelectedServer());
+
+        public void NotifyStartStopStateChanged()
+        {
+            OnPropertyChanged(nameof(CanStartStop));
+            StartStopCommand.NotifyCanExecuteChanged();
+        }
 
         public event EventHandler? ShowLogsRequested;
         public event EventHandler? ShowPersonalizeRequested;
@@ -128,14 +142,15 @@ namespace XrayUI.ViewModels
             OnPropertyChanged(nameof(StatusText));
             OnPropertyChanged(nameof(IsModeToggleEnabled));
             OnPropertyChanged(nameof(IsTunToggleEnabled));
+            NotifyStartStopStateChanged();
         }
 
         // ── Start / Stop ──────────────────────────────────────────────────────
 
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanStartStop))]
         private async Task StartStop()
         {
-            if (IsReapplying) return;
+            if (!CanStartStop) return;
 
             try
             {
@@ -228,7 +243,7 @@ namespace XrayUI.ViewModels
                 await CleanupPersistedTunRoutesAsync(appSettings);
             }
 
-            var configJson = XrayConfigBuilder.Build(server, appSettings, tunOutboundInterfaceName);
+            var configJson = XrayConfigBuilder.Build(server, appSettings, tunOutboundInterfaceName, GetAllServers());
             var ok = await _xray.StartAsync(configJson);
 
             if (!ok)
@@ -309,7 +324,7 @@ namespace XrayUI.ViewModels
                     settings.IsTunMode             = IsTunMode;
                     settings.IsSystemProxyEnabled  = _isSystemProxyEnabled;
 
-                    var cfg = XrayConfigBuilder.Build(activeServer, settings);
+                    var cfg = XrayConfigBuilder.Build(activeServer, settings, availableServers: GetAllServers());
 
                     var ok = await _xray.StartAsync(cfg);
                     if (!ok)

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -78,6 +78,9 @@ namespace XrayUI.ViewModels
 
             // Wire ControlPanel so it knows the current selected server
             ControlPanel.GetSelectedServer = () => ServerList.SelectedServer;
+            ControlPanel.GetAllServers = () => ServerList.Servers;
+            ControlPanel.CanStartSelectedServer = () => ServerList.CanRunSelectedServer;
+            ServerDetail.GetAllServers = () => ServerList.Servers;
 
             ServerList.PropertyChanged   += OnServerListPropertyChanged;
             ControlPanel.PropertyChanged += OnControlPanelPropertyChanged;
@@ -187,6 +190,7 @@ namespace XrayUI.ViewModels
 
             if (target is null) return;
             ServerList.SelectedServer = target;
+            if (!ControlPanel.StartStopCommand.CanExecute(null)) return;
             await ControlPanel.StartStopCommand.ExecuteAsync(null);
         }
 
@@ -197,6 +201,7 @@ namespace XrayUI.ViewModels
             return ControlPanel.IsRunning
                 && !ControlPanel.IsReapplying
                 && ServerList.SelectedServer is not null
+                && ServerList.CanRunSelectedServer
                 && !ReferenceEquals(ServerList.SelectedServer, _activeServer);
         }
 
@@ -243,6 +248,12 @@ namespace XrayUI.ViewModels
             {
                 ServerDetail.SelectedServer = ServerList.SelectedServer;
                 OnPropertyChanged(nameof(ActiveServerName));
+                ControlPanel.NotifyStartStopStateChanged();
+                SwitchToSelectedServerCommand.NotifyCanExecuteChanged();
+            }
+            else if (e.PropertyName == nameof(ServerListViewModel.CanRunSelectedServer))
+            {
+                ControlPanel.NotifyStartStopStateChanged();
                 SwitchToSelectedServerCommand.NotifyCanExecuteChanged();
             }
         }

--- a/ViewModels/ServerDetailViewModel.cs
+++ b/ViewModels/ServerDetailViewModel.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Media;
@@ -38,6 +40,11 @@ namespace XrayUI.ViewModels
             _aiUnlockCheck = aiUnlockCheck;
             ResetAiUnlockDisplay();
         }
+
+        public Func<IEnumerable<ServerEntry>> GetAllServers { get; set; } = () => Array.Empty<ServerEntry>();
+
+        private ServerEntry? ResolveChainServer(string id)
+            => string.IsNullOrEmpty(id) ? null : GetAllServers().FirstOrDefault(s => s.Id == id);
 
         public ServerEntry? SelectedServer
         {
@@ -84,18 +91,54 @@ namespace XrayUI.ViewModels
 
         public string SelectedName => SelectedServer?.Name ?? "未选择服务器";
 
-        public string SelectedHost => SelectedServer?.Host ?? "-";
+        public string SelectedHostLabel
+            => SelectedServer?.IsChain == true ? "入口" : "地址";
 
-        public string SelectedPort => SelectedServer?.Port.ToString() ?? "-";
+        public string SelectedHost
+            => SelectedServer?.IsChain == true
+                ? ResolveChainServer(SelectedServer.ChainEntryServerId)?.Name ?? "(入口节点缺失)"
+                : SelectedServer?.Host ?? "-";
+
+        public string SelectedPortLabel
+            => SelectedServer?.IsChain == true ? "出口" : "端口";
+
+        public string SelectedPort
+            => SelectedServer?.IsChain == true
+                ? ResolveChainServer(SelectedServer.ChainExitServerId)?.Name ?? "(出口节点缺失)"
+                : SelectedServer?.Port.ToString() ?? "-";
 
         public string SelectedProtocol => SelectedServer?.DisplayProtocol ?? "-";
 
         public string SelectedSecurityLabel
-            => string.Equals(SelectedServer?.Protocol, "ss", StringComparison.OrdinalIgnoreCase)
-                ? "加密"
-                : "安全";
+            => (SelectedServer?.Protocol?.ToLowerInvariant()) switch
+            {
+                "ss" => "加密",
+                "socks" => "认证",
+                "chain" => "链路",
+                _ => "安全"
+            };
 
-        public string SelectedEncryption => SelectedServer?.Encryption ?? "-";
+        public string SelectedEncryption
+        {
+            get
+            {
+                if (SelectedServer is null) return "-";
+                switch (SelectedServer.Protocol?.ToLowerInvariant())
+                {
+                    case "socks":
+                        return string.IsNullOrWhiteSpace(SelectedServer.Username)
+                               && string.IsNullOrWhiteSpace(SelectedServer.Password)
+                            ? "无认证"
+                            : "用户名/密码";
+                    case "chain":
+                        var entry = ResolveChainServer(SelectedServer.ChainEntryServerId)?.DisplayProtocol ?? "?";
+                        var exit = ResolveChainServer(SelectedServer.ChainExitServerId)?.DisplayProtocol ?? "?";
+                        return $"{entry} -> {exit}";
+                    default:
+                        return SelectedServer.Encryption ?? "-";
+                }
+            }
+        }
 
         public string SelectedShareLink
             => SelectedServer is null ? string.Empty : (NodeLinkSerializer.ToLink(SelectedServer) ?? string.Empty);
@@ -123,6 +166,9 @@ namespace XrayUI.ViewModels
                 };
             }
         }
+
+        public Visibility SelectedTransportVisibility
+            => SelectedServer?.IsChain == true ? Visibility.Collapsed : Visibility.Visible;
 
         public string LatencyText
         {
@@ -231,22 +277,40 @@ namespace XrayUI.ViewModels
                     OnPropertyChanged(nameof(SelectedName));
                     break;
                 case nameof(ServerEntry.Host):
+                    OnPropertyChanged(nameof(SelectedHostLabel));
                     OnPropertyChanged(nameof(SelectedHost));
                     CancelPendingLatencyTest();
                     ResetLatencyDisplay();
                     break;
                 case nameof(ServerEntry.Port):
+                    OnPropertyChanged(nameof(SelectedPortLabel));
                     OnPropertyChanged(nameof(SelectedPort));
                     CancelPendingLatencyTest();
                     ResetLatencyDisplay();
                     break;
                 case nameof(ServerEntry.Protocol):
                     OnPropertyChanged(nameof(SelectedProtocol));
+                    OnPropertyChanged(nameof(SelectedHostLabel));
+                    OnPropertyChanged(nameof(SelectedHost));
+                    OnPropertyChanged(nameof(SelectedPortLabel));
+                    OnPropertyChanged(nameof(SelectedPort));
                     OnPropertyChanged(nameof(SelectedSecurityLabel));
                     OnPropertyChanged(nameof(SelectedTransport));
+                    OnPropertyChanged(nameof(SelectedTransportVisibility));
                     OnPropertyChanged(nameof(SelectedShareLink));
                     break;
                 case nameof(ServerEntry.Encryption):
+                case nameof(ServerEntry.Username):
+                case nameof(ServerEntry.Password):
+                    OnPropertyChanged(nameof(SelectedEncryption));
+                    OnPropertyChanged(nameof(SelectedShareLink));
+                    break;
+                case nameof(ServerEntry.ChainEntryServerId):
+                    OnPropertyChanged(nameof(SelectedHost));
+                    OnPropertyChanged(nameof(SelectedEncryption));
+                    break;
+                case nameof(ServerEntry.ChainExitServerId):
+                    OnPropertyChanged(nameof(SelectedPort));
                     OnPropertyChanged(nameof(SelectedEncryption));
                     break;
                 case nameof(ServerEntry.Security):
@@ -270,12 +334,15 @@ namespace XrayUI.ViewModels
         private void NotifySelectedServerFieldsChanged()
         {
             OnPropertyChanged(nameof(SelectedName));
+            OnPropertyChanged(nameof(SelectedHostLabel));
             OnPropertyChanged(nameof(SelectedHost));
+            OnPropertyChanged(nameof(SelectedPortLabel));
             OnPropertyChanged(nameof(SelectedPort));
             OnPropertyChanged(nameof(SelectedProtocol));
             OnPropertyChanged(nameof(SelectedSecurityLabel));
             OnPropertyChanged(nameof(SelectedEncryption));
             OnPropertyChanged(nameof(SelectedTransport));
+            OnPropertyChanged(nameof(SelectedTransportVisibility));
             OnPropertyChanged(nameof(SelectedShareLink));
             OnPropertyChanged(nameof(CanTestLatency));
             TestLatencyCommand.NotifyCanExecuteChanged();

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -24,11 +24,6 @@ namespace XrayUI.ViewModels
 
     public partial class ServerListViewModel : ObservableObject, IDisposable
     {
-        private static readonly HttpClient Http = new()
-        {
-            Timeout = TimeSpan.FromSeconds(15)
-        };
-
         private const string AllChipKey            = "__all__";
         private const string UngroupedChipKey      = "__ungrouped__";
         private const string FavoritesChipKey      = "__favorites__";
@@ -37,6 +32,16 @@ namespace XrayUI.ViewModels
         private const string FavoritesName         = "收藏列表";
         private const string UnnamedSubLabel       = "(未命名订阅)";
         private const string OrphanSubLabel        = "(已删除订阅)";
+        private const string SubscriptionUserAgent = "v2rayN/7.0";
+
+        private static readonly HttpClient Http = CreateSubscriptionHttpClient();
+
+        private static HttpClient CreateSubscriptionHttpClient()
+        {
+            var client = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(SubscriptionUserAgent);
+            return client;
+        }
 
         private readonly IDialogService  _dialogs;
         private readonly SettingsService _settings;
@@ -93,7 +98,10 @@ namespace XrayUI.ViewModels
                 if (_servers != null)
                     _servers.CollectionChanged -= OnServersCollectionChanged;
                 if (SetProperty(ref _servers, value) && _servers != null)
+                {
                     _servers.CollectionChanged += OnServersCollectionChanged;
+                    NotifySelectedServerRunStateChanged();
+                }
             }
         }
 
@@ -248,6 +256,29 @@ namespace XrayUI.ViewModels
 
         public bool CanRemoveSelectedServer => SelectedServerCount > 0 && !HasLockedSelectedServer;
 
+        public bool CanRunSelectedServer => CanRunServer(SelectedServer);
+
+        public bool CanRunServer(ServerEntry? server)
+        {
+            if (server is null) return false;
+            if (!server.IsChain) return true;
+
+            return IsResolvableChainEndpoint(server.ChainEntryServerId)
+                   && IsResolvableChainEndpoint(server.ChainExitServerId)
+                   && !string.Equals(
+                       server.ChainEntryServerId,
+                       server.ChainExitServerId,
+                       StringComparison.Ordinal);
+        }
+
+        private bool IsResolvableChainEndpoint(string serverId)
+        {
+            return !string.IsNullOrWhiteSpace(serverId)
+                   && Servers.Any(server =>
+                       !server.IsChain
+                       && string.Equals(server.Id, serverId, StringComparison.Ordinal));
+        }
+
         private List<ServerEntry> GetSelectedServersSnapshot() => _selectedServers.Count > 0
             ? _selectedServers.ToList()
             : SelectedServer is null ? new List<ServerEntry>() : new List<ServerEntry> { SelectedServer };
@@ -353,6 +384,7 @@ namespace XrayUI.ViewModels
             {
                 _suppressRebuild = false;
                 if (rebuild) RebuildAll();
+                NotifySelectedServerRunStateChanged();
             }
         }
 
@@ -371,6 +403,7 @@ namespace XrayUI.ViewModels
             if (e.Action == NotifyCollectionChangedAction.Move) return;
 
             RebuildAll();
+            NotifySelectedServerRunStateChanged();
         }
 
         private void RebuildGroupChips()
@@ -519,10 +552,19 @@ namespace XrayUI.ViewModels
 
         private void OnSelectedItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName != nameof(ServerEntry.IsActive)) return;
-            NotifyServerActionStateChanged();
-            if (_sortMode == ServerSortMode.Active)
-                RebuildGroupedView();
+            if (e.PropertyName is nameof(ServerEntry.Protocol)
+                or nameof(ServerEntry.ChainEntryServerId)
+                or nameof(ServerEntry.ChainExitServerId))
+            {
+                NotifySelectedServerRunStateChanged();
+            }
+
+            if (e.PropertyName == nameof(ServerEntry.IsActive))
+            {
+                NotifyServerActionStateChanged();
+                if (_sortMode == ServerSortMode.Active)
+                    RebuildGroupedView();
+            }
         }
 
         private void NotifyServerActionStateChanged()
@@ -534,6 +576,12 @@ namespace XrayUI.ViewModels
             OnPropertyChanged(nameof(CanEditSelectedServer));
             OnPropertyChanged(nameof(CanRemoveSelectedServer));
             OnPropertyChanged(nameof(CanReorderInCurrentChip));
+            NotifySelectedServerRunStateChanged();
+        }
+
+        private void NotifySelectedServerRunStateChanged()
+        {
+            OnPropertyChanged(nameof(CanRunSelectedServer));
         }
 
         // ── Import via link ───────────────────────────────────────────────────
@@ -802,6 +850,17 @@ namespace XrayUI.ViewModels
             await SaveAsync();
         }
 
+        [RelayCommand]
+        private async Task AddChainProxy()
+        {
+            var entry = await _dialogs.ShowChainProxyDialogAsync(Servers);
+            if (entry == null) return;
+
+            Servers.Add(entry);
+            SelectedServer = entry;
+            await SaveAsync();
+        }
+
         // ── Edit ──────────────────────────────────────────────────────────────
 
         [RelayCommand]
@@ -809,6 +868,15 @@ namespace XrayUI.ViewModels
         {
             if (SelectedServer is null) return;
             if (HasMultipleSelectedServers) return;
+
+            if (SelectedServer.IsChain)
+            {
+                var chainResult = await _dialogs.ShowChainProxyDialogAsync(Servers, SelectedServer);
+                if (chainResult == null) return;
+
+                await SaveAsync();
+                return;
+            }
 
             // Pass existing so dialog can pre-populate; dialog mutates and returns same ref on Primary
             var result = await _dialogs.ShowEditServerDialogAsync(SelectedServer);

--- a/Views/AddChainProxyDialog.xaml
+++ b/Views/AddChainProxyDialog.xaml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="XrayUI.Views.AddChainProxyDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:XrayUI.Models"
+    mc:Ignorable="d">
+
+    <StackPanel Spacing="16" MinWidth="340" MaxWidth="400">
+
+        <StackPanel Spacing="6">
+            <TextBlock Text="名称"
+                       FontSize="12"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+            <TextBox x:Name="NameTextBox"
+                     PlaceholderText="链式代理名称" />
+        </StackPanel>
+
+        <StackPanel Spacing="6">
+            <TextBlock Text="入口代理"
+                       FontSize="12"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+            <ComboBox x:Name="EntryComboBox"
+                      HorizontalAlignment="Stretch"
+                      PlaceholderText="选择前置节点">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate x:DataType="models:ServerEntry">
+                        <Grid ColumnSpacing="8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0"
+                                       Text="{x:Bind Name, Mode=OneWay}"
+                                       TextTrimming="CharacterEllipsis"
+                                       VerticalAlignment="Center" />
+                            <TextBlock Grid.Column="1"
+                                       Text="{x:Bind DisplayProtocol, Mode=OneWay}"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       Foreground="{x:Bind Protocol, Mode=OneWay, Converter={StaticResource ProtocolToBrushConverter}}"
+                                       VerticalAlignment="Center" />
+                        </Grid>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+        </StackPanel>
+
+        <StackPanel Spacing="6">
+            <TextBlock Text="出口代理"
+                       FontSize="12"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+            <ComboBox x:Name="ExitComboBox"
+                      HorizontalAlignment="Stretch"
+                      PlaceholderText="选择落地节点">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate x:DataType="models:ServerEntry">
+                        <Grid ColumnSpacing="8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0"
+                                       Text="{x:Bind Name, Mode=OneWay}"
+                                       TextTrimming="CharacterEllipsis"
+                                       VerticalAlignment="Center" />
+                            <TextBlock Grid.Column="1"
+                                       Text="{x:Bind DisplayProtocol, Mode=OneWay}"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       Foreground="{x:Bind Protocol, Mode=OneWay, Converter={StaticResource ProtocolToBrushConverter}}"
+                                       VerticalAlignment="Center" />
+                        </Grid>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <TextBlock Text="流量经入口代理转发，再由出口代理出站"
+                       FontSize="11"
+                       Opacity="0.6"
+                       TextWrapping="Wrap" />
+        </StackPanel>
+
+        <TextBlock x:Name="ErrorText"
+                   Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                   FontSize="11"
+                   TextWrapping="Wrap"
+                   Visibility="Collapsed" />
+
+    </StackPanel>
+</UserControl>

--- a/Views/AddChainProxyDialog.xaml.cs
+++ b/Views/AddChainProxyDialog.xaml.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Linq;
+using XrayUI.Models;
+
+namespace XrayUI.Views
+{
+    public sealed partial class AddChainProxyDialog
+    {
+        private readonly List<ServerEntry> _servers;
+        private readonly ServerEntry? _existing;
+
+        public AddChainProxyDialog(IEnumerable<ServerEntry>? servers = null, ServerEntry? existing = null)
+        {
+            this.InitializeComponent();
+            _existing = existing;
+            _servers = servers?
+                .Where(server => !server.IsChain)
+                .ToList() ?? [];
+
+            EntryComboBox.ItemsSource = _servers;
+            ExitComboBox.ItemsSource = _servers;
+
+            if (existing is not null)
+            {
+                NameTextBox.Text = existing.Name;
+                EntryComboBox.SelectedItem = _servers.FirstOrDefault(
+                    server => server.Id == existing.ChainEntryServerId);
+                ExitComboBox.SelectedItem = _servers.FirstOrDefault(
+                    server => server.Id == existing.ChainExitServerId);
+            }
+        }
+
+        public bool TryCreateOrUpdate(out ServerEntry? entry)
+        {
+            entry = null;
+            ErrorText.Visibility = Visibility.Collapsed;
+            ErrorText.Text = string.Empty;
+
+            var name = NameTextBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                ShowError("请输入链式代理名称。");
+                return false;
+            }
+
+            if (EntryComboBox.SelectedItem is not ServerEntry entryServer)
+            {
+                ShowError("请选择入口代理。");
+                return false;
+            }
+
+            if (ExitComboBox.SelectedItem is not ServerEntry exitServer)
+            {
+                ShowError("请选择出口代理。");
+                return false;
+            }
+
+            if (entryServer.Id == exitServer.Id)
+            {
+                ShowError("入口代理和出口代理不能是同一个节点。");
+                return false;
+            }
+
+            var chain = _existing ?? new ServerEntry();
+            chain.Name = name;
+            chain.SubscriptionId = string.Empty;
+            chain.Protocol = "chain";
+            // Host/Port mirror the entry server so latency probing has an endpoint.
+            chain.Host = entryServer.Host;
+            chain.Port = entryServer.Port;
+            chain.ChainEntryServerId = entryServer.Id;
+            chain.ChainExitServerId = exitServer.Id;
+
+            entry = chain;
+            return true;
+        }
+
+        private void ShowError(string message)
+        {
+            ErrorText.Text = message;
+            ErrorText.Visibility = Visibility.Visible;
+        }
+    }
+}

--- a/Views/ControlPanelControl.xaml
+++ b/Views/ControlPanelControl.xaml
@@ -127,7 +127,7 @@
                 <ToggleButton MinWidth="88"
                               Content="{x:Bind ViewModel.StartStopButtonContent, Mode=OneWay}"
                               IsChecked="{x:Bind ViewModel.StartStopButtonChecked, Mode=OneWay}"
-                              IsEnabled="{x:Bind ViewModel.IsNotReapplying, Mode=OneWay}"
+                              IsEnabled="{x:Bind ViewModel.CanStartStop, Mode=OneWay}"
                               Command="{x:Bind ViewModel.StartStopCommand}" />
                 <StackPanel Orientation="Horizontal"
                             VerticalAlignment="Center"

--- a/Views/ServerDetailControl.xaml
+++ b/Views/ServerDetailControl.xaml
@@ -84,7 +84,7 @@
                                        TextWrapping="WrapWholeWords" />
 
                             <!-- Row 2: 地址 -->
-                            <TextBlock Text="地址"
+                            <TextBlock Text="{x:Bind ViewModel.SelectedHostLabel, Mode=OneWay}"
                                        Grid.Row="2"
                                        Grid.Column="0"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -96,7 +96,7 @@
                                        TextWrapping="WrapWholeWords" />
 
                             <!-- Row 3: 端口 -->
-                            <TextBlock Text="端口"
+                            <TextBlock Text="{x:Bind ViewModel.SelectedPortLabel, Mode=OneWay}"
                                        Grid.Row="3"
                                        Grid.Column="0"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -119,11 +119,13 @@
                             <TextBlock Grid.Row="5"
                                        Grid.Column="0"
                                        Text="传输"
+                                       Visibility="{x:Bind ViewModel.SelectedTransportVisibility, Mode=OneWay}"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        VerticalAlignment="Center" />
                             <TextBlock Grid.Row="5"
                                        Grid.Column="1"
                                        Text="{x:Bind ViewModel.SelectedTransport, Mode=OneWay}"
+                                       Visibility="{x:Bind ViewModel.SelectedTransportVisibility, Mode=OneWay}"
                                        FontSize="16" />
 
 

--- a/Views/ServerListControl.xaml
+++ b/Views/ServerListControl.xaml
@@ -57,6 +57,13 @@
                                     <FontIcon Glyph="&#xE710;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
+                            <MenuFlyoutItem Text="链式代理"
+                                            Command="{x:Bind ViewModel.AddChainProxyCommand}"
+                                            FontWeight="Normal">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xEF90;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
                         </MenuFlyout>
                     </DropDownButton.Flyout>
                 </DropDownButton>
@@ -228,7 +235,8 @@
                             </Grid>
 
                             <StackPanel Orientation="Horizontal"
-                                        Spacing="8">
+                                        Spacing="8"
+                                        Visibility="{x:Bind IsChain, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
                                 <TextBlock Text="{x:Bind Host, Mode=OneWay}"
                                            FontSize="13"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -240,6 +248,11 @@
                                            FontWeight="SemiBold"
                                            Foreground="{x:Bind Protocol, Mode=OneWay, Converter={StaticResource ProtocolToBrushConverter}}" />
                             </StackPanel>
+                            <TextBlock Text="ProxyChain"
+                                       Visibility="{x:Bind IsChain, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                       FontSize="13"
+                                       FontWeight="SemiBold"
+                                       Foreground="{x:Bind Protocol, Mode=OneWay, Converter={StaticResource ProtocolToBrushConverter}}" />
                         </StackPanel>
                     </Grid>
                 </DataTemplate>


### PR DESCRIPTION
## Summary

- Introduce **proxy chain** entries that route traffic through an entry node and out an exit node, configured via a new `AddChainProxyDialog` and represented as `Protocol = "chain"` on `ServerEntry` with `ChainEntryServerId` / `ChainExitServerId` references.
- Add **SOCKS** as a first-class outbound protocol (with optional username/password auth) — useful on its own and a natural building block for chains.
- Send a `v2rayN/7.0` User-Agent on subscription fetches so providers that gate on UA return the expected base64 payload.

## Details

**Proxy chains**
- `XrayConfigBuilder.Build` now accepts `availableServers` and, for a chain server, emits two outbounds: the exit (`tag: proxy`) with `proxySettings.tag = chain-entry`, and the entry (`tag: chain-entry`). Refuses to nest chains and surfaces a clear error if either endpoint reference is missing.
- The Start button (`StartStopCommand`) is now gated by `CanStartStop` — for chains this means both endpoints must resolve to non-chain servers and be distinct. Wired through `ServerListViewModel.CanRunSelectedServer` and `ControlPanelViewModel.CanStartSelectedServer`.
- `ServerDetailViewModel` shows entry/exit node names (instead of host/port) for chains, hides the transport row, and exposes a `chain` security label with `entry -> exit` protocol summary.
- Server list rendering hides the host:port subtitle for chain rows and shows a `ProxyChain` badge instead.
- Edit flow for a chain entry opens the chain dialog instead of the standard edit dialog.

**SOCKS protocol**
- New `Username` field on `ServerEntry`; outbound emits `socks` protocol with `users[].user`/`pass` when credentials are supplied, otherwise no auth.
- The edit dialog shows a "用户名 (SOCKS)" row only for SOCKS, hides transport/security rows that don't apply, and clears unrelated fields on save.
- Detail panel shows `认证` label and either `无认证` or `用户名/密码` value.

**Other**
- `ServerListViewModel.Http` now sets `User-Agent: v2rayN/7.0` so picky subscription endpoints return the expected payload.
- `.gitignore` ignores `/BuildAndRun.ps1` (local build helper).

## Test plan

- [x] Create a SOCKS server (with and without credentials); start it and verify connectivity through the local SOCKS/HTTP inbound.
- [x] Create a chain proxy referencing two distinct non-chain servers; start it and confirm `xray_config.json` contains `chain-entry` outbound and `proxy` outbound with `proxySettings.tag = chain-entry`.
- [x] Delete one of the referenced endpoint nodes and confirm the Start button disables.
- [x] Confirm chain edit reopens the chain dialog with the existing selections.
- [x] Confirm the server-list row for a chain shows `ProxyChain` instead of host:port.
- [x] Update a subscription URL and verify the `v2rayN/7.0` User-Agent is sent.

