### PR TITLE
feat(xray): kill orphan xray.exe with Windows Job Object

### DIFF
--- a/Services/XrayService.cs
+++ b/Services/XrayService.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace XrayUI.Services
 {
-    public class XrayService
+    public partial class XrayService
     {
         private static readonly string ExePath = Path.Combine(
             AppContext.BaseDirectory, "Assets", "engine", "xray.exe");
@@ -24,6 +24,13 @@ namespace XrayUI.Services
         private const int LogBufferMax = 500;
 
         private Process? _process;
+
+        // Kernel-level safety net: xray.exe is assigned to this Job Object with
+        // KillOnJobClose, so if the UI process dies any way (taskkill /F, AV
+        // crash, OOM), the kernel kills xray.exe synchronously. Lifetime = this
+        // XrayService instance; reused across Start/Stop cycles.
+        private IntPtr _jobHandle = IntPtr.Zero;
+
         private StringBuilder _startupLog = new();
         private bool _collectStartupLog;
         private readonly Lock _startupLogLock = new();
@@ -193,6 +200,7 @@ namespace XrayUI.Services
 
                 BeginStartupLogCapture();
                 _process.Start();
+                AttachToJobObject(_process);
                 _process.BeginOutputReadLine();
                 _process.BeginErrorReadLine();
 
@@ -327,6 +335,119 @@ namespace XrayUI.Services
         {
             AppendLog("[xray 进程已退出]");
             RunningChanged?.Invoke(this, false);
+        }
+
+        // ─────────── Job Object: orphan-xray safety net ───────────
+
+        private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
+        private const int JobObjectExtendedLimitInformation = 9;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+        {
+            public long PerProcessUserTimeLimit;
+            public long PerJobUserTimeLimit;
+            public uint LimitFlags;
+            public UIntPtr MinimumWorkingSetSize;
+            public UIntPtr MaximumWorkingSetSize;
+            public uint ActiveProcessLimit;
+            public UIntPtr Affinity;
+            public uint PriorityClass;
+            public uint SchedulingClass;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct IO_COUNTERS
+        {
+            public ulong ReadOperationCount;
+            public ulong WriteOperationCount;
+            public ulong OtherOperationCount;
+            public ulong ReadTransferCount;
+            public ulong WriteTransferCount;
+            public ulong OtherTransferCount;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+            public IO_COUNTERS IoInfo;
+            public UIntPtr ProcessMemoryLimit;
+            public UIntPtr JobMemoryLimit;
+            public UIntPtr PeakProcessMemoryUsed;
+            public UIntPtr PeakJobMemoryUsed;
+        }
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        private static partial IntPtr CreateJobObjectW(IntPtr lpJobAttributes, IntPtr lpName);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool SetInformationJobObject(
+            IntPtr hJob, int jobObjectInfoClass, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool CloseHandle(IntPtr hObject);
+
+        private void AttachToJobObject(Process process)
+        {
+            try
+            {
+                if (_jobHandle == IntPtr.Zero)
+                {
+                    _jobHandle = CreateKillOnCloseJob();
+                    if (_jobHandle == IntPtr.Zero)
+                    {
+                        AppendLog($"[警告] CreateJobObject 失败 (err={Marshal.GetLastWin32Error()})，孤儿进程兜底已禁用");
+                        return;
+                    }
+                }
+
+                if (!AssignProcessToJobObject(_jobHandle, process.Handle))
+                {
+                    AppendLog($"[警告] AssignProcessToJobObject 失败 (err={Marshal.GetLastWin32Error()})，孤儿进程兜底未生效");
+                }
+            }
+            catch (Exception ex)
+            {
+                AppendLog($"[警告] Job Object 绑定异常：{ex.Message}");
+            }
+        }
+
+        private static IntPtr CreateKillOnCloseJob()
+        {
+            var handle = CreateJobObjectW(IntPtr.Zero, IntPtr.Zero);
+            if (handle == IntPtr.Zero) return IntPtr.Zero;
+
+            var info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+            {
+                BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
+                {
+                    LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+                }
+            };
+
+            int size = Marshal.SizeOf<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>();
+            IntPtr buf = Marshal.AllocHGlobal(size);
+            try
+            {
+                Marshal.StructureToPtr(info, buf, fDeleteOld: false);
+                if (!SetInformationJobObject(handle, JobObjectExtendedLimitInformation, buf, (uint)size))
+                {
+                    _ = CloseHandle(handle);
+                    return IntPtr.Zero;
+                }
+                return handle;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buf);
+            }
         }
     }
 }

--- a/Views/ManageSubscriptionsDialog.xaml
+++ b/Views/ManageSubscriptionsDialog.xaml
@@ -52,7 +52,7 @@
             <TextBox Header="备注名称（可选）"
                      PlaceholderText="留空则使用链接域名"
                      Text="{x:Bind ViewModel.SubscriptionName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            <TextBlock Text="将自动拉取并导入订阅中的全部节点"
+            <TextBlock Text="将自动解析并导入该订阅中的全部节点"
                        FontSize="12"
                        Opacity="0.65" />
         </StackPanel>


### PR DESCRIPTION
## Summary
- Adds a Windows Job Object (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) around `xray.exe` so the kernel tears it down with the UI process even on hard kills (`taskkill /F`, AV crash, OOM) where `WM_ENDSESSION` doesn't fire.
- Small copy tweak in the subscription dialog hint.

## Why
The existing cleanup paths only cover orderly shutdowns:

| Path | Trigger | Covers |
|---|---|---|
| `Kill(entireProcessTree)` in `StopAsync` | User clicks Stop | ✅ |
| `StopForShutdown` via `WM_ENDSESSION` | Logoff / shutdown | ✅ |
| _(nothing)_ | UI killed with `taskkill /F`, crash, OOM | ❌ |

The last row is the gap. An orphaned `xray.exe` keeps SOCKS / HTTP / mixed ports bound and (in TUN mode) the wintun interface up, so the next XrayUI launch fails with `address already in use` or a stale TUN device.

A Job Object is the kernel's purpose-built tool for this: when the parent's last handle to the Job closes (which happens unconditionally on parent termination — graceful or not), the kernel kills every process in the Job.

## Implementation notes
- `XrayService` is now `partial` — required by the `[LibraryImport]` source generator. It does NOT cross the WinRT ABI (not a converter / VM / UserControl), so this is independent of the CsWinRT partial rule.
- One Job handle is held on the `XrayService` instance and reused across Start/Stop cycles — recreated only if creation initially fails.
- `AttachToJobObject` is best-effort: any failure (CreateJobObject, AssignProcessToJobObject) logs a `[警告]` line via the existing log buffer and returns. The start path itself never aborts because of the safety net.
- All Win32 P/Invoke goes through `[LibraryImport]` for AOT-safe source-generated marshalling. The struct layouts (`JOBOBJECT_BASIC_LIMIT_INFORMATION` / `IO_COUNTERS` / `JOBOBJECT_EXTENDED_LIMIT_INFORMATION`) are blittable so `Marshal.SizeOf<T>` + `Marshal.StructureToPtr` are safe under NativeAOT.
- Existing `Kill(entireProcessTree)` and `StopForShutdown` paths are untouched — the Job is purely additive.

## Test plan
- [x] Normal connect / disconnect: `xray.exe` starts and stops as before; logs show `[启动]` and `[已停止]`.
- [x] Multiple Start/Stop cycles: Job is reused (no `[警告] CreateJobObject 失败` on subsequent starts).
- [x] **Core scenario**: connect with `xray.exe` running, then `taskkill /F /IM XrayUI-dev.exe`. `xray.exe` should disappear in ProcessExplorer within ~100ms — port stays free for the next launch.
- [x] Reverse-control: temporarily comment out the `AttachToJobObject(_process);` call and repeat the taskkill — `xray.exe` should now linger as an orphan, proving the Job is what's doing the work.
- [x] Logoff / shutdown: still cleaned up via existing `WM_ENDSESSION` path; no regression.
- [x] Release AOT publish (`dotnet publish ... -p:PublishAot=true ...` per CLAUDE.md): launch and confirm no `[警告] CreateJobObject 失败` log (would indicate P/Invoke broke under AOT).

