### PR TITLE
Implement English language support

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -40,22 +40,26 @@ namespace XrayUI
 
         private static void ApplyPersistedLanguageOverride()
         {
+            string? language = null;
             try
             {
-                if (!File.Exists(AppPaths.SettingsJsonPath)) return;
-
-                using var stream = File.OpenRead(AppPaths.SettingsJsonPath);
-                using var doc = JsonDocument.Parse(stream);
-                if (doc.RootElement.TryGetProperty("Language", out var langElem)
-                    && langElem.ValueKind == JsonValueKind.String)
+                if (File.Exists(AppPaths.SettingsJsonPath))
                 {
-                    LanguageHelper.ApplyOverride(langElem.GetString());
+                    using var stream = File.OpenRead(AppPaths.SettingsJsonPath);
+                    using var doc = JsonDocument.Parse(stream);
+                    if (doc.RootElement.TryGetProperty("Language", out var langElem)
+                        && langElem.ValueKind == JsonValueKind.String)
+                    {
+                        language = langElem.GetString();
+                    }
                 }
             }
             catch (Exception ex)
             {
                 Debug.WriteLine($"[Language] Failed to load persisted language: {ex.Message}");
             }
+
+            LanguageHelper.ApplyOverride(language);
         }
 
         protected override async void OnLaunched(LaunchActivatedEventArgs args)

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
+using XrayUI.Helpers;
 using XrayUI.Services;
 
 namespace XrayUI
@@ -23,11 +27,35 @@ namespace XrayUI
 
         public App()
         {
+            // Must run before InitializeComponent — the XAML resource loader caches the
+            // current locale at first touch, and that happens during component init.
+            ApplyPersistedLanguageOverride();
+
             this.InitializeComponent();
 
             ConfigureProcessShutdownBehavior();
             this.UnhandledException += (_, _) => CleanupOnExit();
             AppDomain.CurrentDomain.ProcessExit += (_, _) => CleanupOnExit();
+        }
+
+        private static void ApplyPersistedLanguageOverride()
+        {
+            try
+            {
+                if (!File.Exists(AppPaths.SettingsJsonPath)) return;
+
+                using var stream = File.OpenRead(AppPaths.SettingsJsonPath);
+                using var doc = JsonDocument.Parse(stream);
+                if (doc.RootElement.TryGetProperty("Language", out var langElem)
+                    && langElem.ValueKind == JsonValueKind.String)
+                {
+                    LanguageHelper.ApplyOverride(langElem.GetString());
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[Language] Failed to load persisted language: {ex.Message}");
+            }
         }
 
         protected override async void OnLaunched(LaunchActivatedEventArgs args)
@@ -86,6 +114,45 @@ namespace XrayUI
         public void RequestShutdown(bool fastShutdown = false)
         {
             CleanupOnExit(fastShutdown);
+            Environment.Exit(0);
+        }
+
+        /// <summary>
+        /// Restart the process. xray.exe is a child process not bound to a job object, so
+        /// bare termination would leak it (and the system proxy) — and <see cref="AppInstance.Restart"/>
+        /// itself bypasses Window.Closed / ProcessExit, so cleanup must be triggered explicitly here.
+        /// </summary>
+        public static void Restart()
+        {
+            (Application.Current as App)?.CleanupOnExit(fastShutdown: true);
+
+            // Restart terminates the process on success; any synchronous return (or
+            // exception) means the platform refused — fall through to a manual relaunch.
+            try { AppInstance.Restart(string.Empty); } catch { }
+
+            var exePath = Process.GetCurrentProcess().MainModule?.FileName;
+            if (!string.IsNullOrEmpty(exePath))
+            {
+                // Let an external process wait for this one to exit before relaunching.
+                // An in-process delayed task would be killed by Environment.Exit below.
+                try
+                {
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe",
+                        Arguments = $"/c ping 127.0.0.1 -n 2 > nul & start \"\" \"{exePath}\"",
+                        WorkingDirectory = AppContext.BaseDirectory,
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        WindowStyle = ProcessWindowStyle.Hidden,
+                    });
+                }
+                catch
+                {
+                    // Worst case the user relaunches manually.
+                }
+            }
+
             Environment.Exit(0);
         }
 

--- a/Helpers/AppPaths.cs
+++ b/Helpers/AppPaths.cs
@@ -10,5 +10,7 @@ namespace XrayUI.Helpers
             "XrayUI");
 
         public static string UpdatesDir { get; } = Path.Combine(LocalAppDataDir, "Updates");
+
+        public static string SettingsJsonPath { get; } = Path.Combine(LocalAppDataDir, "settings.json");
     }
 }

--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -4,11 +4,121 @@ namespace XrayUI.Helpers;
 /// Strongly-typed accessors for resource strings. Each property is the canonical
 /// way to look up a localized string from C# — compiler catches typos, IDE
 /// supports go-to-definition. XAML still uses <c>x:Uid</c> on the same key
-/// (the resw entry key matches the property name 1:1).
+/// (the resw entry key for XAML carries a property suffix like <c>.Text</c>;
+/// the C# key here matches the bare name).
 ///
-/// Entries are added incrementally as call sites are localized. Empty for now —
-/// see commit 3 of the i18n series.
+/// Entries are added incrementally as call sites are localized.
 /// </summary>
 public static class L
 {
+    // ── Generic dialog buttons ─────────────────────────────────────────────
+    public static string Dialog_OK        => Loc.GetString("Dialog_OK");
+    public static string Dialog_Cancel    => Loc.GetString("Dialog_Cancel");
+    public static string Dialog_Save      => Loc.GetString("Dialog_Save");
+    public static string Dialog_Done      => Loc.GetString("Dialog_Done");
+    public static string Dialog_Confirm   => Loc.GetString("Dialog_Confirm");
+    public static string Dialog_Add       => Loc.GetString("Dialog_Add");
+    public static string Dialog_Delete    => Loc.GetString("Dialog_Delete");
+    public static string Dialog_Replace   => Loc.GetString("Dialog_Replace");
+    public static string Dialog_Preparing => Loc.GetString("Dialog_Preparing");
+    public static string Dialog_On        => Loc.GetString("Dialog_On");
+    public static string Dialog_Off       => Loc.GetString("Dialog_Off");
+
+    // ── Confirmation dialogs ───────────────────────────────────────────────
+    public static string Confirm_ReplaceTitle => Loc.GetString("Confirm_ReplaceTitle");
+    public static string Confirm_ReplaceMsg   => Loc.GetString("Confirm_ReplaceMsg");
+
+    // ── Import link dialog ─────────────────────────────────────────────────
+    public static string Import_Title       => Loc.GetString("Import_Title");
+    public static string Import_Placeholder => Loc.GetString("Import_Placeholder");
+    public static string Import_SupportHint => Loc.GetString("Import_SupportHint");
+
+    // ── Edit server dialog ─────────────────────────────────────────────────
+    public static string EditServer_AddTitle         => Loc.GetString("EditServer_AddTitle");
+    public static string EditServer_EditTitle        => Loc.GetString("EditServer_EditTitle");
+    public static string EditServer_Name             => Loc.GetString("EditServer_Name");
+    public static string EditServer_Address          => Loc.GetString("EditServer_Address");
+    public static string EditServer_Port             => Loc.GetString("EditServer_Port");
+    public static string EditServer_Protocol         => Loc.GetString("EditServer_Protocol");
+    public static string EditServer_Encryption       => Loc.GetString("EditServer_Encryption");
+    public static string EditServer_Password         => Loc.GetString("EditServer_Password");
+    public static string EditServer_Transport        => Loc.GetString("EditServer_Transport");
+    public static string EditServer_Path             => Loc.GetString("EditServer_Path");
+    public static string EditServer_WsHost           => Loc.GetString("EditServer_WsHost");
+    public static string EditServer_Security         => Loc.GetString("EditServer_Security");
+    public static string EditServer_Fingerprint      => Loc.GetString("EditServer_Fingerprint");
+    public static string EditServer_AllowInsecure    => Loc.GetString("EditServer_AllowInsecure");
+    public static string EditServer_FlowPlaceholder  => Loc.GetString("EditServer_FlowPlaceholder");
+
+    // ── Edit port dialog ───────────────────────────────────────────────────
+    public static string EditPort_Title  => Loc.GetString("EditPort_Title");
+    public static string EditPort_Header => Loc.GetString("EditPort_Header");
+
+    // ── TUN mode ───────────────────────────────────────────────────────────
+    public static string Tun_EnableTitle => Loc.GetString("Tun_EnableTitle");
+
+    // ── Share link dialog ──────────────────────────────────────────────────
+    public static string Share_Title    => Loc.GetString("Share_Title");
+    public static string Share_CopyLink => Loc.GetString("Share_CopyLink");
+
+    // ── Startup dialog ─────────────────────────────────────────────────────
+    public static string Startup_Title       => Loc.GetString("Startup_Title");
+    public static string Startup_AutoStart   => Loc.GetString("Startup_AutoStart");
+    public static string Startup_AutoConnect => Loc.GetString("Startup_AutoConnect");
+
+    // ── Edit server dialog (extras not in stash) ───────────────────────────
+    public static string EditServer_SocksUsername        => Loc.GetString("EditServer_SocksUsername");
+    public static string EditServer_EchPlaceholder       => Loc.GetString("EditServer_EchPlaceholder");
+    public static string EditServer_FinalmaskPlaceholder => Loc.GetString("EditServer_FinalmaskPlaceholder");
+
+    // ── Chain proxy dialog ─────────────────────────────────────────────────
+    public static string ChainProxy_AddTitle  => Loc.GetString("ChainProxy_AddTitle");
+    public static string ChainProxy_EditTitle => Loc.GetString("ChainProxy_EditTitle");
+
+    // ── MainViewModel ──────────────────────────────────────────────────────
+    public static string Main_NoSelection  => Loc.GetString("Main_NoSelection");
+    public static string Main_NotConnected => Loc.GetString("Main_NotConnected");
+
+    // ── ControlPanel ───────────────────────────────────────────────────────
+    public static string ControlPanel_Start              => Loc.GetString("ControlPanel_Start");
+    public static string ControlPanel_Stop               => Loc.GetString("ControlPanel_Stop");
+    public static string ControlPanel_StatusApplying     => Loc.GetString("ControlPanel_StatusApplying");
+    public static string ControlPanel_StatusNotRunning   => Loc.GetString("ControlPanel_StatusNotRunning");
+    public static string ControlPanel_RoutingGlobal      => Loc.GetString("ControlPanel_RoutingGlobal");
+    public static string ControlPanel_RoutingSmart       => Loc.GetString("ControlPanel_RoutingSmart");
+    public static string ControlPanel_UpdateFound        => Loc.GetString("ControlPanel_UpdateFound");
+
+    // ── Error dialogs ──────────────────────────────────────────────────────
+    public static string Error_NoServer            => Loc.GetString("Error_NoServer");
+    public static string Error_NoServerMsg         => Loc.GetString("Error_NoServerMsg");
+    public static string Error_StartFailed         => Loc.GetString("Error_StartFailed");
+    public static string Error_XrayStartFailed     => Loc.GetString("Error_XrayStartFailed");
+    public static string Error_ReapplyFailed       => Loc.GetString("Error_ReapplyFailed");
+    public static string Error_XrayReapplyFailed   => Loc.GetString("Error_XrayReapplyFailed");
+    public static string Error_UpdateFailed        => Loc.GetString("Error_UpdateFailed");
+    public static string Error_UpdaterLaunchFailed => Loc.GetString("Error_UpdaterLaunchFailed");
+
+    // ── Startup / Update / TUN ─────────────────────────────────────────────
+    public static string Startup_SetFailed => Loc.GetString("Startup_SetFailed");
+    public static string Update_Updating   => Loc.GetString("Update_Updating");
+    public static string Tun_EnableMsg     => Loc.GetString("Tun_EnableMsg");
+
+    // ── DNS settings dialog ────────────────────────────────────────────────
+    public static string Dns_DialogTitle        => Loc.GetString("Dns_DialogTitle");
+    public static string Dns_ResetDefaults      => Loc.GetString("Dns_ResetDefaults");
+    public static string Dns_ServerPlaceholder  => Loc.GetString("Dns_ServerPlaceholder");
+    public static string Dns_QueryStrategyLabel => Loc.GetString("Dns_QueryStrategyLabel");
+    public static string Dns_EnableCacheLabel   => Loc.GetString("Dns_EnableCacheLabel");
+    public static string Dns_DirectTitle        => Loc.GetString("Dns_DirectTitle");
+    public static string Dns_DirectDesc         => Loc.GetString("Dns_DirectDesc");
+    public static string Dns_ProxyTitle         => Loc.GetString("Dns_ProxyTitle");
+    public static string Dns_ProxyDesc          => Loc.GetString("Dns_ProxyDesc");
+    public static string Dns_TunOnlyHint        => Loc.GetString("Dns_TunOnlyHint");
+    public static string Dns_Experimental       => Loc.GetString("Dns_Experimental");
+    public static string Dns_Provider_Ali       => Loc.GetString("Dns_Provider_Ali");
+    public static string Dns_Provider_Tencent   => Loc.GetString("Dns_Provider_Tencent");
+    public static string Dns_Provider_Google    => Loc.GetString("Dns_Provider_Google");
+    public static string Dns_Strategy_V4Only    => Loc.GetString("Dns_Strategy_V4Only");
+    public static string Dns_Strategy_V6Only    => Loc.GetString("Dns_Strategy_V6Only");
+    public static string Dns_Strategy_Auto      => Loc.GetString("Dns_Strategy_Auto");
 }

--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -1,0 +1,14 @@
+namespace XrayUI.Helpers;
+
+/// <summary>
+/// Strongly-typed accessors for resource strings. Each property is the canonical
+/// way to look up a localized string from C# — compiler catches typos, IDE
+/// supports go-to-definition. XAML still uses <c>x:Uid</c> on the same key
+/// (the resw entry key matches the property name 1:1).
+///
+/// Entries are added incrementally as call sites are localized. Empty for now —
+/// see commit 3 of the i18n series.
+/// </summary>
+public static class L
+{
+}

--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -1,4 +1,4 @@
-namespace XrayUI.Helpers;
+﻿namespace XrayUI.Helpers;
 
 /// <summary>
 /// Strongly-typed accessors for resource strings. Each property is the canonical
@@ -80,6 +80,7 @@ public static class L
     public static string Main_NotConnected => Loc.GetString("Main_NotConnected");
 
     // ── ControlPanel ───────────────────────────────────────────────────────
+    public static string ControlPanel_Personalize        => Loc.GetString("ControlPanel_Personalize");
     public static string ControlPanel_Start              => Loc.GetString("ControlPanel_Start");
     public static string ControlPanel_Stop               => Loc.GetString("ControlPanel_Stop");
     public static string ControlPanel_StatusApplying     => Loc.GetString("ControlPanel_StatusApplying");
@@ -101,7 +102,144 @@ public static class L
     // ── Startup / Update / TUN ─────────────────────────────────────────────
     public static string Startup_SetFailed => Loc.GetString("Startup_SetFailed");
     public static string Update_Updating   => Loc.GetString("Update_Updating");
-    public static string Tun_EnableMsg     => Loc.GetString("Tun_EnableMsg");
+    public static string Tun_EnableMsg     => Loc.GetString("Tun_EnableMsg.Text");
+
+    // ── ChainProxy ─────────────────────────────────────────────────────────
+    public static string ChainProxy_NameRequired   => Loc.GetString("ChainProxy_NameRequired");
+    public static string ChainProxy_EntryRequired  => Loc.GetString("ChainProxy_EntryRequired");
+    public static string ChainProxy_ExitRequired   => Loc.GetString("ChainProxy_ExitRequired");
+    public static string ChainProxy_EntryExitSame  => Loc.GetString("ChainProxy_EntryExitSame");
+
+    // ── TUN confirmation ───────────────────────────────────────────────────
+    public static string Tun_MoreOptions        => Loc.GetString("Tun_MoreOptionsBtn.Content");
+    public static string Tun_InterfaceTooltip   => Loc.GetString("Tun_InterfaceTooltip");
+    public static string Tun_AutoInterfaceLabel => Loc.GetString("Tun_AutoInterfaceLabel");
+
+    // ── Subscription dialog ────────────────────────────────────────────────
+    public static string Subscription_DialogTitle_Add    => Loc.GetString("Subscription_DialogTitle_Add");
+    public static string Subscription_DialogTitle_Manage => Loc.GetString("Subscription_DialogTitle_Manage");
+    public static string Subscription_AddTooltip         => Loc.GetString("Subscription_AddTooltip");
+    public static string Subscription_ManageTooltip      => Loc.GetString("Subscription_ManageTooltip");
+    public static string Subscription_Refresh            => Loc.GetString("Subscription_Refresh");
+    public static string Subscription_DeleteTooltip      => Loc.GetString("Subscription_DeleteTooltip");
+    public static string Subscription_NeverUpdated       => Loc.GetString("Subscription_NeverUpdated");
+    public static string Subscription_JustNow            => Loc.GetString("Subscription_JustNow");
+
+    // ── Personalize ────────────────────────────────────────────────────────
+    public static string Personalize_ExportSuccess         => Loc.GetString("Personalize_ExportSuccess");
+    public static string Personalize_ImportFailed          => Loc.GetString("Personalize_ImportFailed");
+    public static string Personalize_ImportSuccess         => Loc.GetString("Personalize_ImportSuccess");
+    public static string Personalize_ImportAdvancedSuffix  => Loc.GetString("Personalize_ImportAdvancedSuffix");
+    public static string Personalize_PresetMissingTitle    => Loc.GetString("Personalize_PresetMissingTitle");
+    public static string Personalize_PresetMissingMsg      => Loc.GetString("Personalize_PresetMissingMsg");
+    public static string Personalize_ExportTooltip         => Loc.GetString("Personalize_ExportTooltip");
+    public static string Personalize_ImportTooltip         => Loc.GetString("Personalize_ImportTooltip");
+    public static string Error_ExportFailed                => Loc.GetString("Error_ExportFailed");
+
+    // ── CustomRules / AddRule ──────────────────────────────────────────────
+    public static string CustomRules_Title                  => Loc.GetString("CustomRules_Title");
+    public static string CustomRules_UpdateGeoTooltip       => Loc.GetString("CustomRules_UpdateGeoTooltip");
+    public static string CustomRules_AdvancedEditorTooltip  => Loc.GetString("CustomRules_AdvancedEditorTooltip");
+    public static string CustomRules_EditRowTooltip         => Loc.GetString("CustomRules_EditRowTooltip");
+    public static string CustomRules_DeleteRowTooltip       => Loc.GetString("CustomRules_DeleteRowTooltip");
+    public static string CustomRules_PrepFailedTitle        => Loc.GetString("CustomRules_PrepFailedTitle");
+    public static string CustomRules_OpenEditorFailedTitle  => Loc.GetString("CustomRules_OpenEditorFailedTitle");
+
+    public static string AddRule_Title       => Loc.GetString("AddRule_Title");
+    public static string AddRule_EditTitle   => Loc.GetString("AddRule_EditTitle");
+    public static string AddRule_ErrorEmpty  => Loc.GetString("AddRule_ErrorEmpty");
+    public static string AddRule_BrowseExe   => Loc.GetString("AddRule_BrowseExe");
+    public static string AddRule_BrowseFolder => Loc.GetString("AddRule_BrowseFolder");
+    public static string AddRule_PlaceholderDomain  => Loc.GetString("AddRule_PlaceholderDomain");
+    public static string AddRule_PlaceholderIp      => Loc.GetString("AddRule_PlaceholderIp");
+    public static string AddRule_PlaceholderProcess => Loc.GetString("AddRule_PlaceholderProcess");
+    public static string AddRule_HintDomain  => Loc.GetString("AddRule_HintDomain");
+    public static string AddRule_HintIp      => Loc.GetString("AddRule_HintIp");
+    public static string AddRule_HintProcess => Loc.GetString("AddRule_HintProcess");
+
+    public static string GeoUpdate_Updating         => Loc.GetString("GeoUpdate_Updating");
+    public static string GeoUpdate_AlreadyLatest    => Loc.GetString("GeoUpdate_AlreadyLatest");
+    public static string GeoUpdate_AlreadyLatestMsg => Loc.GetString("GeoUpdate_AlreadyLatestMsg");
+    public static string GeoUpdate_TunRestart       => Loc.GetString("GeoUpdate_TunRestart");
+    public static string GeoUpdate_ReloadedOk       => Loc.GetString("GeoUpdate_ReloadedOk");
+    public static string GeoUpdate_RestartRequired  => Loc.GetString("GeoUpdate_RestartRequired");
+    public static string GeoUpdate_NextStart        => Loc.GetString("GeoUpdate_NextStart");
+    public static string GeoUpdate_Success          => Loc.GetString("GeoUpdate_Success");
+
+    // ── LogWindow ──────────────────────────────────────────────────────────
+    public static string Log_Title         => Loc.GetString("Log_Title");
+    public static string Log_Running       => Loc.GetString("Log_Running");
+    public static string Log_NotRunning    => Loc.GetString("Log_NotRunning");
+    public static string Log_PrivacyTitle  => Loc.GetString("Log_PrivacyTitle");
+    public static string Log_PrivacySaved  => Loc.GetString("Log_PrivacySaved");
+    public static string Log_IpMask        => Loc.GetString("Log_IpMask");
+    public static string Log_MaskOff       => Loc.GetString("Log_MaskOff");
+    public static string Log_AutoScroll    => Loc.GetString("Log_AutoScroll");
+    public static string Log_CopyAll       => Loc.GetString("Log_CopyAll");
+    public static string Log_Clear         => Loc.GetString("Log_Clear");
+    public static string Log_PrivacyTooltip => Loc.GetString("Log_PrivacyTooltip");
+
+    // ── MainWindow / Tray ──────────────────────────────────────────────────
+    public static string MainWindow_Title      => Loc.GetString("MainWindow_Title");
+    public static string MainWindow_ToggleMini => Loc.GetString("MainWindow_ToggleMini");
+    public static string MainWindow_ExpandFull => Loc.GetString("MainWindow_ExpandFull");
+    public static string MainWindow_Close      => Loc.GetString("MainWindow_Close");
+    public static string Tray_Open             => Loc.GetString("Tray_Open");
+    public static string Tray_Exit             => Loc.GetString("Tray_Exit");
+
+    // ── ServerList ─────────────────────────────────────────────────────────
+    public static string ServerList_AllServers       => Loc.GetString("ServerList_AllServers");
+    public static string ServerList_Ungrouped        => Loc.GetString("ServerList_Ungrouped");
+    public static string ServerList_Favorites        => Loc.GetString("ServerList_Favorites");
+    public static string ServerList_UnnamedSub       => Loc.GetString("ServerList_UnnamedSub");
+    public static string ServerList_OrphanSub        => Loc.GetString("ServerList_OrphanSub");
+    public static string ServerList_Edit             => Loc.GetString("ServerList_Edit");
+    public static string ServerList_Delete           => Loc.GetString("ServerList_Delete");
+    public static string ServerList_Share            => Loc.GetString("ServerList_Share");
+    public static string ServerList_AddFavorite      => Loc.GetString("ServerList_AddFavorite");
+    public static string ServerList_RemoveFavorite   => Loc.GetString("ServerList_RemoveFavorite");
+    public static string ServerList_FilterTooltip    => Loc.GetString("ServerList_FilterTooltip");
+    public static string ServerList_SortTooltip      => Loc.GetString("ServerList_SortTooltip");
+    public static string ServerList_SortActiveHint   => Loc.GetString("ServerList_SortActiveHint");
+
+    // ── ServerDetail ──────────────────────────────────────────────────────
+    public static string ServerDetail_NoServer       => Loc.GetString("ServerDetail_NoServer");
+    public static string ServerDetail_Address        => Loc.GetString("ServerDetail_Address");
+    public static string ServerDetail_Port           => Loc.GetString("ServerDetail_Port");
+    public static string ServerDetail_Encryption     => Loc.GetString("ServerDetail_Encryption");
+    public static string ServerDetail_Security       => Loc.GetString("ServerDetail_Security");
+    public static string ServerDetail_Entry          => Loc.GetString("ServerDetail_Entry");
+    public static string ServerDetail_Exit           => Loc.GetString("ServerDetail_Exit");
+    public static string ServerDetail_EntryMissing   => Loc.GetString("ServerDetail_EntryMissing");
+    public static string ServerDetail_ExitMissing    => Loc.GetString("ServerDetail_ExitMissing");
+    public static string ServerDetail_AuthLabel      => Loc.GetString("ServerDetail_AuthLabel");
+    public static string ServerDetail_ChainLabel     => Loc.GetString("ServerDetail_ChainLabel");
+    public static string ServerDetail_NoAuth         => Loc.GetString("ServerDetail_NoAuth");
+    public static string ServerDetail_UserPass       => Loc.GetString("ServerDetail_UserPass");
+    public static string ServerDetail_NotTested      => Loc.GetString("ServerDetail_NotTested");
+    public static string ServerDetail_Testing        => Loc.GetString("ServerDetail_Testing");
+    public static string ServerDetail_Timeout        => Loc.GetString("ServerDetail_Timeout");
+    public static string ServerDetail_Failed         => Loc.GetString("ServerDetail_Failed");
+    public static string ServerDetail_RetestLatency  => Loc.GetString("ServerDetail_RetestLatency");
+    public static string ServerDetail_CopyShareLink  => Loc.GetString("ServerDetail_CopyShareLink");
+
+    // ── Import link dialog ────────────────────────────────────────────────
+    public static string Import_ParseFailed    => Loc.GetString("Import_ParseFailed");
+    public static string Import_ParseFailedMsg => Loc.GetString("Import_ParseFailedMsg");
+
+    // ── Subscription ──────────────────────────────────────────────────────
+    public static string Subscription_FetchFailed       => Loc.GetString("Subscription_FetchFailed");
+    public static string Subscription_NoParsed          => Loc.GetString("Subscription_NoParsed");
+    public static string Subscription_StopFirst_Refresh => Loc.GetString("Subscription_StopFirst_Refresh");
+    public static string Subscription_StopFirst_Delete  => Loc.GetString("Subscription_StopFirst_Delete");
+    public static string Subscription_UnknownError      => Loc.GetString("Subscription_UnknownError");
+
+    // ── Share dialog ──────────────────────────────────────────────────────
+    public static string Share_NotSupported    => Loc.GetString("Share_NotSupported");
+    public static string Share_NotSupportedMsg => Loc.GetString("Share_NotSupportedMsg");
+
+    // ── Confirm delete ────────────────────────────────────────────────────
+    public static string Confirm_DeleteTitle => Loc.GetString("Confirm_DeleteTitle");
 
     // ── DNS settings dialog ────────────────────────────────────────────────
     public static string Dns_DialogTitle        => Loc.GetString("Dns_DialogTitle");

--- a/Helpers/LanguageHelper.cs
+++ b/Helpers/LanguageHelper.cs
@@ -95,22 +95,22 @@ namespace XrayUI.Helpers
                 : null;
 
         /// <summary>
-        /// Sets (or, when <paramref name="tag"/> is <c>null</c> / unsupported, leaves
-        /// alone) the WinAppSDK language override. Must be called before any XAML
-        /// resource resolution — i.e. before <c>App.InitializeComponent</c>.
+        /// Applies the WinAppSDK language override. <c>null</c> / unsupported means
+        /// "follow system", which must explicitly clear any previously-persisted
+        /// override. Must be called before any XAML resource resolution.
         /// </summary>
         public static void ApplyOverride(string? tag)
         {
             var language = Normalize(tag);
-            if (string.IsNullOrEmpty(language)) return;
 
             try
             {
-                ApplicationLanguages.PrimaryLanguageOverride = language;
+                ApplicationLanguages.PrimaryLanguageOverride = language ?? string.Empty;
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[Language] Failed to apply '{language}': {ex.Message}");
+                var label = string.IsNullOrEmpty(language) ? "follow system" : language;
+                Debug.WriteLine($"[Language] Failed to apply '{label}': {ex.Message}");
             }
         }
     }

--- a/Helpers/LanguageHelper.cs
+++ b/Helpers/LanguageHelper.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Diagnostics;
+using Microsoft.Windows.Globalization;
+
+namespace XrayUI.Helpers
+{
+    /// <summary>
+    /// One row in <see cref="LanguageHelper.SupportedLanguages"/>. <c>Tag = null</c>
+    /// means "follow system" (no <c>PrimaryLanguageOverride</c> applied).
+    /// Top-level (not nested) so XAML's <c>x:DataType</c> can reference it directly.
+    /// </summary>
+    public sealed partial class LanguageInfo
+    {
+        public string? Tag { get; }
+        public string DisplayName { get; }
+        public LanguageInfo(string? tag, string displayName)
+        {
+            Tag = tag;
+            DisplayName = displayName;
+        }
+    }
+
+    /// <summary>
+    /// Drives the WinAppSDK <see cref="ApplicationLanguages.PrimaryLanguageOverride"/>.
+    /// Adding a new language means adding one row to <see cref="SupportedLanguages"/> —
+    /// the UI dropdown, persisted-setting normalization and index lookups all read
+    /// from this single table.
+    ///
+    /// Index 0 is the "follow system" choice (Tag = null): when applied, no override
+    /// is set and WinAppSDK falls back to the OS locale.
+    /// </summary>
+    public static class LanguageHelper
+    {
+        public static readonly LanguageInfo[] SupportedLanguages =
+        [
+            new(null,    "跟随系统"),   // index 0 — leaves PrimaryLanguageOverride alone
+            new("zh-CN", "简体中文"),
+            new("en-US", "English"),
+        ];
+
+        /// <summary>
+        /// Returns the canonical tag if supported. A <c>null</c> return is also the
+        /// signal to skip <see cref="ApplyOverride"/> (i.e. follow system) — that
+        /// mapping is deliberate, not an error case.
+        /// </summary>
+        public static string? Normalize(string? tag)
+        {
+            if (string.IsNullOrEmpty(tag)) return null;
+            foreach (var lang in SupportedLanguages)
+            {
+                if (lang.Tag is not null
+                    && string.Equals(lang.Tag, tag, StringComparison.OrdinalIgnoreCase))
+                    return lang.Tag;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// 0-based index in <see cref="SupportedLanguages"/>. <c>null</c> and unknown
+        /// tags both map to index 0 ("follow system"), keeping the UI dropdown
+        /// truthful when no explicit choice has been persisted.
+        /// </summary>
+        public static int IndexOf(string? tag)
+        {
+            if (string.IsNullOrEmpty(tag)) return 0;
+            for (int i = 0; i < SupportedLanguages.Length; i++)
+            {
+                if (string.Equals(SupportedLanguages[i].Tag, tag, StringComparison.OrdinalIgnoreCase))
+                    return i;
+            }
+            return 0;
+        }
+
+        /// <summary>Tag at the given index. Index 0 ("follow system") returns <c>null</c>.</summary>
+        public static string? TagAt(int index)
+            => (uint)index < (uint)SupportedLanguages.Length
+                ? SupportedLanguages[index].Tag
+                : null;
+
+        /// <summary>
+        /// Sets (or, when <paramref name="tag"/> is <c>null</c> / unsupported, leaves
+        /// alone) the WinAppSDK language override. Must be called before any XAML
+        /// resource resolution — i.e. before <c>App.InitializeComponent</c>.
+        /// </summary>
+        public static void ApplyOverride(string? tag)
+        {
+            var language = Normalize(tag);
+            if (string.IsNullOrEmpty(language)) return;
+
+            try
+            {
+                ApplicationLanguages.PrimaryLanguageOverride = language;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[Language] Failed to apply '{language}': {ex.Message}");
+            }
+        }
+    }
+}

--- a/Helpers/LanguageHelper.cs
+++ b/Helpers/LanguageHelper.cs
@@ -8,15 +8,30 @@ namespace XrayUI.Helpers
     /// One row in <see cref="LanguageHelper.SupportedLanguages"/>. <c>Tag = null</c>
     /// means "follow system" (no <c>PrimaryLanguageOverride</c> applied).
     /// Top-level (not nested) so XAML's <c>x:DataType</c> can reference it directly.
+    ///
+    /// Real language rows pass a fixed <paramref name="displayName"/> endonym
+    /// (the language's name in its own script — "简体中文", "English") so that
+    /// users always see their own language spelled the way they recognize it,
+    /// regardless of the currently-applied UI locale. The "follow system" row is
+    /// the exception: it isn't a language name, it's an action description, so it
+    /// passes a <c>resourceKey</c> and the display string is resolved against the
+    /// current UI locale instead.
     /// </summary>
     public sealed partial class LanguageInfo
     {
+        private readonly string _displayName;
+        private readonly string? _resourceKey;
+
         public string? Tag { get; }
-        public string DisplayName { get; }
-        public LanguageInfo(string? tag, string displayName)
+
+        public string DisplayName =>
+            _resourceKey is null ? _displayName : Loc.GetString(_resourceKey);
+
+        public LanguageInfo(string? tag, string displayName, string? resourceKey = null)
         {
             Tag = tag;
-            DisplayName = displayName;
+            _displayName = displayName;
+            _resourceKey = resourceKey;
         }
     }
 
@@ -33,7 +48,9 @@ namespace XrayUI.Helpers
     {
         public static readonly LanguageInfo[] SupportedLanguages =
         [
-            new(null,    "跟随系统"),   // index 0 — leaves PrimaryLanguageOverride alone
+            // Index 0 — "follow system" is an action label, not a language name, so
+            // it must follow the current UI locale (not stay in Chinese forever).
+            new(null,    "跟随系统", resourceKey: "Language_FollowSystem"),
             new("zh-CN", "简体中文"),
             new("en-US", "English"),
         ];

--- a/Helpers/Loc.cs
+++ b/Helpers/Loc.cs
@@ -1,0 +1,20 @@
+using Microsoft.Windows.ApplicationModel.Resources;
+
+namespace XrayUI.Helpers;
+
+/// <summary>
+/// Thin wrapper over WinAppSDK's <see cref="ResourceLoader"/>. The default
+/// constructor resolves to the "Resources" resource map (which maps to
+/// <c>Strings/{lang}/Resources.resw</c>). Cached once at static init; values
+/// are frozen at the locale active when this class is first touched, so any
+/// language change requires a process restart.
+/// </summary>
+public static class Loc
+{
+    private static readonly ResourceLoader _loader = new();
+
+    public static string GetString(string key) => _loader.GetString(key);
+
+    public static string Format(string key, params object?[] args) =>
+        string.Format(_loader.GetString(key), args);
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -25,7 +25,8 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
-            <Button Grid.Column="0"
+            <Button x:Name="DockButton"
+                    Grid.Column="0"
                     Click="DockButton_Click"
                     Background="Transparent"
                     BorderThickness="0"
@@ -33,8 +34,7 @@
                     Width="30" Height="28"
                     Padding="0"
                     Margin="8,0,0,0"
-                    VerticalAlignment="Center"
-                    ToolTipService.ToolTip="切换mini窗口">
+                    VerticalAlignment="Center">
                 <FontIcon Glyph="&#xE90C;"  FontSize="13"  />
             </Button>
 
@@ -51,7 +51,8 @@
                 <FontIcon Glyph="&#xE72B;"  FontSize="12" />
             </Button>
 
-            <TextBlock Grid.Column="2"
+            <TextBlock x:Uid="MainWindow_TitleText"
+                       Grid.Column="2"
                        Text="代理控制台"
                        FontSize="13"
                        VerticalAlignment="Center"
@@ -141,8 +142,7 @@
                         Width="28" Height="22"
                         Padding="0"
                         BorderThickness="0"
-                        Background="Transparent"
-                        ToolTipService.ToolTip="返回完整窗口">
+                        Background="Transparent">
                     <FontIcon Glyph="&#xE740;" FontSize="12" />
                 </Button>
 
@@ -151,8 +151,7 @@
                         Width="28" Height="22"
                         Padding="0"
                         BorderThickness="0"
-                        Background="Transparent"
-                        ToolTipService.ToolTip="关闭">
+                        Background="Transparent">
                     <FontIcon Glyph="&#xE711;" FontSize="12" />
                 </Button>
             </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -61,6 +61,11 @@ namespace XrayUI
 
             InitializeComponent();
 
+            Title = L.MainWindow_Title;
+            ToolTipService.SetToolTip(DockButton,        L.MainWindow_ToggleMini);
+            ToolTipService.SetToolTip(MiniExpandButton,  L.MainWindow_ExpandFull);
+            ToolTipService.SetToolTip(MinicloseButton,   L.MainWindow_Close);
+
             var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
             var scale = DpiHelper.GetWindowScale(hWnd);
             AppWindow.Resize(new SizeInt32((int)Math.Round(950 * scale), (int)Math.Round(600 * scale)));
@@ -146,13 +151,13 @@ namespace XrayUI
             {
                 var flyout = new MenuFlyout();
 
-                var openItem = new MenuFlyoutItem { Text = "\u6253\u5f00\u7a97\u53e3" };
+                var openItem = new MenuFlyoutItem { Text = L.Tray_Open };
                 openItem.Click += (_, _) => RestoreFromTray();
                 flyout.Items.Add(openItem);
 
                 flyout.Items.Add(new MenuFlyoutSeparator());
 
-                var exitItem = new MenuFlyoutItem { Text = "\u9000\u51fa" };
+                var exitItem = new MenuFlyoutItem { Text = L.Tray_Exit };
                 exitItem.Click += (_, _) => ExitApplication();
                 flyout.Items.Add(exitItem);
 

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -25,6 +25,10 @@ namespace XrayUI.Models
         /// <summary>"" | "quarter" | "half" | "full"; controls Xray log IP masking.</summary>
         public string LogMaskAddress { get; set; } = string.Empty;
 
+        // ── Internationalization ──────────────────────────────────────────────
+        /// <summary>BCP-47 tag from <see cref="XrayUI.Helpers.LanguageHelper.SupportedLanguages"/>, or null to follow system.</summary>
+        public string? Language { get; set; }
+
         // ── Personalization ───────────────────────────────────────────────────
         /// <summary>"Light" | "Dark" | "Default" (follows system)</summary>
         public string? ThemeSetting { get; set; }

--- a/Models/SubscriptionEntry.cs
+++ b/Models/SubscriptionEntry.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
+using XrayUI.Helpers;
 
 namespace XrayUI.Models
 {
@@ -60,15 +61,15 @@ namespace XrayUI.Models
         {
             get
             {
-                if (!_lastUpdated.HasValue) return "上次更新: 从未更新";
+                if (!_lastUpdated.HasValue) return L.Subscription_NeverUpdated;
                 var delta = DateTimeOffset.Now - _lastUpdated.Value;
                 string rel;
-                if (delta.TotalSeconds < 60)      rel = "刚刚";
-                else if (delta.TotalMinutes < 60) rel = $"{(int)delta.TotalMinutes} 分钟前";
-                else if (delta.TotalHours   < 24) rel = $"{(int)delta.TotalHours} 小时前";
-                else if (delta.TotalDays    < 30) rel = $"{(int)delta.TotalDays} 天前";
+                if (delta.TotalSeconds < 60)      rel = L.Subscription_JustNow;
+                else if (delta.TotalMinutes < 60) rel = Loc.Format("Subscription_MinutesAgo", (int)delta.TotalMinutes);
+                else if (delta.TotalHours   < 24) rel = Loc.Format("Subscription_HoursAgo",   (int)delta.TotalHours);
+                else if (delta.TotalDays    < 30) rel = Loc.Format("Subscription_DaysAgo",    (int)delta.TotalDays);
                 else                              rel = _lastUpdated.Value.LocalDateTime.ToString("yyyy-MM-dd");
-                return $"上次更新: {rel}";
+                return Loc.Format("Subscription_LastUpdated", rel);
             }
         }
 

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -31,7 +31,7 @@ namespace XrayUI.Services
         {
             var textBox = new TextBox
             {
-                PlaceholderText = "粘贴节点链接（支持多协议）",
+                PlaceholderText = L.Import_Placeholder,
                 AcceptsReturn = true,
                 Width = 360,
                 Height = 148,
@@ -41,9 +41,9 @@ namespace XrayUI.Services
             };
 
             var dialog = CreateDialog();
-            dialog.Title = "导入节点链接";
-            dialog.PrimaryButtonText = "确定";
-            dialog.CloseButtonText = "取消";
+            dialog.Title = L.Import_Title;
+            dialog.PrimaryButtonText = L.Dialog_OK;
+            dialog.CloseButtonText = L.Dialog_Cancel;
             dialog.DefaultButton = ContentDialogButton.Primary;
             dialog.Content = new StackPanel
             {
@@ -53,7 +53,7 @@ namespace XrayUI.Services
                 {
                     new TextBlock
                     {
-                        Text = "支持常见协议链接",
+                        Text = L.Import_SupportHint,
                         Opacity = 0.65,
                     },
                     textBox
@@ -78,15 +78,15 @@ namespace XrayUI.Services
             {
                 if (vm.IsAddPage)
                 {
-                    dialog.PrimaryButtonText = "添加";
-                    dialog.CloseButtonText = "取消";
+                    dialog.PrimaryButtonText = L.Dialog_Add;
+                    dialog.CloseButtonText = L.Dialog_Cancel;
                     dialog.DefaultButton = ContentDialogButton.Primary;
                     dialog.IsPrimaryButtonEnabled = vm.CanAddSubscription;
                     return;
                 }
 
                 dialog.PrimaryButtonText = string.Empty;
-                dialog.CloseButtonText = "完成";
+                dialog.CloseButtonText = L.Dialog_Done;
                 dialog.DefaultButton = ContentDialogButton.Close;
                 dialog.IsPrimaryButtonEnabled = false;
             }
@@ -111,19 +111,19 @@ namespace XrayUI.Services
         public async Task<ServerEntry?> ShowEditServerDialogAsync(ServerEntry? existing)
         {
             // ── Controls ──────────────────────────────────────────────────────
-            var txtName = new TextBox { Header = "名称", Text = existing?.Name ?? string.Empty, MinWidth = 420 };
-            var txtHost = new TextBox { Header = "地址 / 域名", Text = existing?.Host ?? string.Empty };
+            var txtName = new TextBox { Header = L.EditServer_Name, Text = existing?.Name ?? string.Empty, MinWidth = 420 };
+            var txtHost = new TextBox { Header = L.EditServer_Address, Text = existing?.Host ?? string.Empty };
             var numPort = new NumberBox
             {
-                Header = "端口", Value = existing?.Port ?? 443, Minimum = 1, Maximum = 65535,
+                Header = L.EditServer_Port, Value = existing?.Port ?? 443, Minimum = 1, Maximum = 65535,
                 SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline
             };
-            var cmbProtocol = new ComboBox { Header = "协议", MinWidth = 200 };
+            var cmbProtocol = new ComboBox { Header = L.EditServer_Protocol, MinWidth = 200 };
             foreach (var p in new[] { "ss", "vmess", "vless", "hysteria2", "trojan", "socks" })
                 cmbProtocol.Items.Add(p);
             cmbProtocol.SelectedItem = existing?.Protocol?.ToLower() ?? "ss";
 
-            var cmbEncryption = new ComboBox { Header = "加密方式 (SS)", MinWidth = 200 };
+            var cmbEncryption = new ComboBox { Header = L.EditServer_Encryption, MinWidth = 200 };
             foreach (var m in new[]
                      {
                          "aes-128-gcm", "aes-256-gcm", "chacha20-ietf-poly1305", "2022-blake3-aes-128-gcm",
@@ -133,31 +133,31 @@ namespace XrayUI.Services
             if (existing?.Encryption is { Length: > 0 } existingEnc && !cmbEncryption.Items.Contains(existingEnc))
                 cmbEncryption.Items.Add(existingEnc);
             cmbEncryption.SelectedItem = existing?.Encryption ?? "aes-128-gcm";
-            var txtUsername = new TextBox { Header = "用户名 (SOCKS)", Text = existing?.Username ?? string.Empty };
-            var txtPassword = new PasswordBox { Header = "密码", Password = existing?.Password ?? string.Empty };
+            var txtUsername = new TextBox { Header = L.EditServer_SocksUsername, Text = existing?.Username ?? string.Empty };
+            var txtPassword = new PasswordBox { Header = L.EditServer_Password, Password = existing?.Password ?? string.Empty };
             var txtUuid = new TextBox { Header = "UUID (VMess / VLESS)", Text = existing?.Uuid ?? string.Empty };
             var numAlterId = new NumberBox
                 { Header = "AlterId (VMess)", Value = existing?.AlterId ?? 0, Minimum = 0, Maximum = 65535 };
-            var cmbNetwork = new ComboBox { Header = "传输协议", MinWidth = 200 };
+            var cmbNetwork = new ComboBox { Header = L.EditServer_Transport, MinWidth = 200 };
             foreach (var n in new[] { "tcp", "ws", "grpc", "xhttp" })
                 cmbNetwork.Items.Add(n);
             cmbNetwork.SelectedItem = existing?.Network ?? "tcp";
 
-            var txtPath = new TextBox { Header = "路径 (WS/gRPC/XHTTP)", Text = existing?.Path ?? string.Empty };
-            var txtWsHost = new TextBox { Header = "Host 头 (WS/XHTTP)", Text = existing?.WsHost ?? string.Empty };
-            var cmbSecurity = new ComboBox { Header = "安全", MinWidth = 200 };
+            var txtPath = new TextBox { Header = L.EditServer_Path, Text = existing?.Path ?? string.Empty };
+            var txtWsHost = new TextBox { Header = L.EditServer_WsHost, Text = existing?.WsHost ?? string.Empty };
+            var cmbSecurity = new ComboBox { Header = L.EditServer_Security, MinWidth = 200 };
             foreach (var s in new[] { "none", "tls", "reality" })
                 cmbSecurity.Items.Add(s);
             cmbSecurity.SelectedItem = existing?.Security ?? "none";
 
             var txtSni = new TextBox { Header = "SNI", Text = existing?.Sni ?? string.Empty };
-            var txtFp = new TextBox { Header = "指纹 (uTLS)", Text = existing?.Fingerprint ?? string.Empty };
+            var txtFp = new TextBox { Header = L.EditServer_Fingerprint, Text = existing?.Fingerprint ?? string.Empty };
             var chkAllowInsecure = new CheckBox
-                { Content = "允许不安全连接（跳过证书校验）", IsChecked = existing?.AllowInsecure ?? false };
+                { Content = L.EditServer_AllowInsecure, IsChecked = existing?.AllowInsecure ?? false };
             var txtEchConfigList = new TextBox
             {
                 Header = "ECH ConfigList",
-                PlaceholderText = "例如 udp://1.1.1.1 或服务端生成的 ECHConfig",
+                PlaceholderText = L.EditServer_EchPlaceholder,
                 Text = existing?.EchConfigList ?? string.Empty,
                 TextWrapping = TextWrapping.Wrap
             };
@@ -173,12 +173,12 @@ namespace XrayUI.Services
             var txtSpx = new TextBox { Header = "SpiderX (Reality)", Text = existing?.SpiderX ?? string.Empty };
             var txtFlow = new TextBox
             {
-                Header = "Flow (VLESS)", PlaceholderText = "xtls-rprx-vision 或留空", Text = existing?.Flow ?? string.Empty
+                Header = "Flow (VLESS)", PlaceholderText = L.EditServer_FlowPlaceholder, Text = existing?.Flow ?? string.Empty
             };
             var txtVlessEncryption = new TextBox
             {
                 Header = "VLESS encryption (PQ)",
-                PlaceholderText = "留空 = none;或 mlkem768x25519plus.native.0rtt....",
+                PlaceholderText = L.EditServer_FinalmaskPlaceholder,
                 Text = existing?.VlessEncryption ?? string.Empty,
                 TextWrapping = TextWrapping.Wrap
             };
@@ -294,9 +294,9 @@ namespace XrayUI.Services
             };
 
             var dialog = CreateDialog();
-            dialog.Title = existing == null ? "手动添加服务器" : "编辑服务器";
-            dialog.PrimaryButtonText = "保存";
-            dialog.CloseButtonText = "取消";
+            dialog.Title = existing == null ? L.EditServer_AddTitle : L.EditServer_EditTitle;
+            dialog.PrimaryButtonText = L.Dialog_Save;
+            dialog.CloseButtonText = L.Dialog_Cancel;
             dialog.DefaultButton = ContentDialogButton.Primary;
             dialog.Content = scrollViewer;
 
@@ -385,9 +385,9 @@ namespace XrayUI.Services
             ServerEntry? saved = null;
 
             var dialog = CreateDialog();
-            dialog.Title = existing is null ? "链式代理" : "编辑链式代理";
-            dialog.PrimaryButtonText = "保存";
-            dialog.CloseButtonText = "取消";
+            dialog.Title = existing is null ? L.ChainProxy_AddTitle : L.ChainProxy_EditTitle;
+            dialog.PrimaryButtonText = L.Dialog_Save;
+            dialog.CloseButtonText = L.Dialog_Cancel;
             dialog.DefaultButton = ContentDialogButton.Primary;
             dialog.Content = content;
 
@@ -409,7 +409,7 @@ namespace XrayUI.Services
         {
             var numBox = new NumberBox
             {
-                Header = "本地端口",
+                Header = L.EditPort_Header,
                 Value = currentPort,
                 Minimum = 1024,
                 Maximum = 65535,
@@ -417,9 +417,9 @@ namespace XrayUI.Services
             };
 
             var dialog = CreateDialog();
-            dialog.Title = "编辑本地端口";
-            dialog.PrimaryButtonText = "确定";
-            dialog.CloseButtonText = "取消";
+            dialog.Title = L.EditPort_Title;
+            dialog.PrimaryButtonText = L.Dialog_OK;
+            dialog.CloseButtonText = L.Dialog_Cancel;
             dialog.DefaultButton = ContentDialogButton.Primary;
             dialog.Content = new StackPanel
             {
@@ -430,7 +430,7 @@ namespace XrayUI.Services
                     numBox,
                     new TextBlock
                     {
-                        Text = $"有效范围：{numBox.Minimum} - {numBox.Maximum}",
+                        Text = Loc.Format("EditPort_Range", numBox.Minimum, numBox.Maximum),
                         Opacity = 0.65,
                     }
                 }
@@ -444,9 +444,11 @@ namespace XrayUI.Services
 
         // ── Error ─────────────────────────────────────────────────────────────
 
-        public async Task<bool> ShowConfirmationAsync(string title, string message, string confirmText = "确定",
-            string cancelText = "取消", bool isDanger = false)
+        public async Task<bool> ShowConfirmationAsync(string title, string message, string? confirmText = null,
+            string? cancelText = null, bool isDanger = false)
         {
+            confirmText ??= L.Dialog_OK;
+            cancelText  ??= L.Dialog_Cancel;
             var content = new TextBlock
             {
                 Text = message,
@@ -474,10 +476,10 @@ namespace XrayUI.Services
             var content = new TunConfirmationDialog(settings.TunMtu, settings.TunOutboundInterface);
 
             var dialog = CreateDialog();
-            dialog.Title = "开启TUN模式";
+            dialog.Title = L.Tun_EnableTitle;
             dialog.Content = content;
-            dialog.PrimaryButtonText = "确认";
-            dialog.CloseButtonText = "取消";
+            dialog.PrimaryButtonText = L.Dialog_Confirm;
+            dialog.CloseButtonText = L.Dialog_Cancel;
             dialog.DefaultButton = ContentDialogButton.Primary;
 
             if (await dialog.ShowAsync() != ContentDialogResult.Primary)
@@ -493,7 +495,7 @@ namespace XrayUI.Services
             var dialog = CreateDialog(xamlRoot);
             dialog.Title = title;
             dialog.Content = message;
-            dialog.CloseButtonText = "确定";
+            dialog.CloseButtonText = L.Dialog_OK;
             await dialog.ShowAsync();
         }
 
@@ -506,7 +508,7 @@ namespace XrayUI.Services
 
             var statusText = new TextBlock
             {
-                Text = "正在准备…",
+                Text = L.Dialog_Preparing,
                 TextWrapping = TextWrapping.Wrap,
                 MaxWidth = 320,
                 HorizontalAlignment = HorizontalAlignment.Center,
@@ -521,7 +523,7 @@ namespace XrayUI.Services
 
             var dialog = CreateDialog(xamlRoot);
             dialog.Title = title;
-            dialog.CloseButtonText = "取消";
+            dialog.CloseButtonText = L.Dialog_Cancel;
             dialog.Content = new StackPanel
             {
                 Spacing = 16,
@@ -602,7 +604,7 @@ namespace XrayUI.Services
 
             var statusText = new TextBlock
             {
-                Text = "正在准备…",
+                Text = L.Dialog_Preparing,
                 TextWrapping = TextWrapping.Wrap,
                 MaxWidth = 320,
                 HorizontalAlignment = HorizontalAlignment.Center,
@@ -618,7 +620,7 @@ namespace XrayUI.Services
 
             var dialog = CreateDialog(xamlRoot);
             dialog.Title = title;
-            dialog.CloseButtonText = "取消";
+            dialog.CloseButtonText = L.Dialog_Cancel;
             dialog.Content = new StackPanel
             {
                 Spacing = 12,
@@ -729,7 +731,7 @@ namespace XrayUI.Services
             header.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
             var titleText = new TextBlock
             {
-                Text = "分享节点",
+                Text = L.Share_Title,
                 FontSize = 20,
                 FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
                 VerticalAlignment = VerticalAlignment.Center,
@@ -762,7 +764,7 @@ namespace XrayUI.Services
             };
             if (Application.Current.Resources.TryGetValue("SubtleButtonStyle", out var subtleStyle2))
                 nameCopyBtn.Style = (Style)subtleStyle2;
-            ToolTipService.SetToolTip(nameCopyBtn, "复制链接");
+            ToolTipService.SetToolTip(nameCopyBtn, L.Share_CopyLink);
 
             nameCopyBtn.Click += async (_, _) =>
             {
@@ -815,15 +817,15 @@ namespace XrayUI.Services
             var toggle = new ToggleSwitch
             {
                 IsOn = currentEnabled,
-                OnContent = "开",
-                OffContent = "关",
+                OnContent = L.Dialog_On,
+                OffContent = L.Dialog_Off,
                 MinWidth = 0,
                 Margin = new Thickness(0),
             };
 
             var toggleLabel = new TextBlock
             {
-                Text = "开机自动启动",
+                Text = L.Startup_AutoStart,
                 VerticalAlignment = VerticalAlignment.Center,
             };
 
@@ -837,7 +839,7 @@ namespace XrayUI.Services
 
             var checkBox = new CheckBox
             {
-                Content = "自动连接上次节点",
+                Content = L.Startup_AutoConnect,
                 IsChecked = currentAutoConnect,
                 IsEnabled = currentEnabled,
                 Margin = new Thickness(16, 0, 0, 0),
@@ -846,9 +848,9 @@ namespace XrayUI.Services
             toggle.Toggled += (_, _) => checkBox.IsEnabled = toggle.IsOn;
 
             var dialog = CreateDialog();
-            dialog.Title = "开机启动";
-            dialog.PrimaryButtonText = "确认";
-            dialog.CloseButtonText = "取消";
+            dialog.Title = L.Startup_Title;
+            dialog.PrimaryButtonText = L.Dialog_Confirm;
+            dialog.CloseButtonText = L.Dialog_Cancel;
             dialog.DefaultButton = ContentDialogButton.Primary;
             dialog.Content = new StackPanel
             {
@@ -870,30 +872,30 @@ namespace XrayUI.Services
             var directBox = new TextBox
             {
                 Text = settings.DirectDnsServer ?? string.Empty,
-                PlaceholderText = "输入 IP 或 DoH 地址 (留空为自动)",
+                PlaceholderText = L.Dns_ServerPlaceholder,
                 HorizontalAlignment = HorizontalAlignment.Stretch,
             };
             var proxyBox = new TextBox
             {
                 Text = settings.ProxyDnsServer ?? string.Empty,
-                PlaceholderText = "输入 IP 或 DoH 地址 (留空为自动)",
+                PlaceholderText = L.Dns_ServerPlaceholder,
                 HorizontalAlignment = HorizontalAlignment.Stretch,
             };
 
             var directPresets = CreatePresetButtons(directBox,
-                ("阿里", "223.5.5.5"),
-                ("腾讯", "119.29.29.29"),
+                (L.Dns_Provider_Ali, "223.5.5.5"),
+                (L.Dns_Provider_Tencent, "119.29.29.29"),
                 ("114",  "114.114.114.114"),
                 ("DoH",  "https://dns.alidns.com/dns-query"));
 
             var proxyPresets = CreatePresetButtons(proxyBox,
-                ("谷歌", "8.8.8.8"),
+                (L.Dns_Provider_Google, "8.8.8.8"),
                 ("CF", "1.1.1.1"),
                 ("Quad9", "9.9.9.9"),
                 ("DoH", "https://cloudflare-dns.com/dns-query"));
 
             var strategyCmb = new ComboBox { MinWidth = 100 };
-            foreach (var item in new[] { "仅 IPv4", "仅 IPv6", "自动" })
+            foreach (var item in new[] { L.Dns_Strategy_V4Only, L.Dns_Strategy_V6Only, L.Dns_Strategy_Auto })
                 strategyCmb.Items.Add(item);
             strategyCmb.SelectedIndex = settings.DnsQueryStrategy switch
             {
@@ -905,8 +907,8 @@ namespace XrayUI.Services
             var cacheSwitch = new ToggleSwitch
             {
                 IsOn = settings.DnsCacheEnabled,
-                OnContent = "开",
-                OffContent = "关",
+                OnContent = L.Dialog_On,
+                OffContent = L.Dialog_Off,
                 MinWidth = 0,
                 Margin = new Thickness(0),
             };
@@ -915,8 +917,8 @@ namespace XrayUI.Services
             {
                 IsOn = settings.FakeDnsEnabled && isTunMode,
                 IsEnabled = isTunMode,
-                OnContent = "开",
-                OffContent = "关",
+                OnContent = L.Dialog_On,
+                OffContent = L.Dialog_Off,
                 MinWidth = 0,
                 Margin = new Thickness(0),
             };
@@ -926,7 +928,7 @@ namespace XrayUI.Services
                 Text = "FakeDNS",
                 VerticalAlignment = VerticalAlignment.Center,
             };
-            ToolTipService.SetToolTip(fakeDnsTitleText, "仅TUN模式有效");
+            ToolTipService.SetToolTip(fakeDnsTitleText, L.Dns_TunOnlyHint);
 
             var fakeDnsLabel = new StackPanel
             {
@@ -938,7 +940,7 @@ namespace XrayUI.Services
                     fakeDnsTitleText,
                     new TextBlock
                     {
-                        Text = "实验性",
+                        Text = L.Dns_Experimental,
                         FontSize = 10,
                         VerticalAlignment = VerticalAlignment.Center,
                         Foreground =
@@ -956,8 +958,8 @@ namespace XrayUI.Services
             fakeDnsRow.Children.Add(fakeDnsLabel);
             fakeDnsRow.Children.Add(fakeDnsSwitch);
 
-            var strategyRow = CreateLabelRow("查询策略", strategyCmb);
-            var cacheRow = CreateLabelRow("启用 DNS 缓存", cacheSwitch);
+            var strategyRow = CreateLabelRow(L.Dns_QueryStrategyLabel, strategyCmb);
+            var cacheRow = CreateLabelRow(L.Dns_EnableCacheLabel, cacheSwitch);
 
             var content = new StackPanel
             {
@@ -970,10 +972,10 @@ namespace XrayUI.Services
                         Spacing = 6,
                         Children =
                         {
-                            new TextBlock { Text = "直连 DNS", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold },
+                            new TextBlock { Text = L.Dns_DirectTitle, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold },
                             new TextBlock
                             {
-                                Text = "用于国内域名 (geosite:cn)，走直连出站解析",
+                                Text = L.Dns_DirectDesc,
                                 FontSize = 11,
                                 Opacity = 0.6,
                                 TextWrapping = TextWrapping.Wrap,
@@ -988,10 +990,10 @@ namespace XrayUI.Services
                         Spacing = 6,
                         Children =
                         {
-                            new TextBlock { Text = "代理 DNS", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold },
+                            new TextBlock { Text = L.Dns_ProxyTitle, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold },
                             new TextBlock
                             {
-                                Text = "用于境外域名，经代理出站解析，防止 DNS 污染",
+                                Text = L.Dns_ProxyDesc,
                                 FontSize = 11,
                                 Opacity = 0.6,
                                 TextWrapping = TextWrapping.Wrap,
@@ -1006,10 +1008,10 @@ namespace XrayUI.Services
             };
 
             var dialog = CreateDialog();
-            dialog.Title = "DNS 设置";
-            dialog.PrimaryButtonText = "保存";
-            dialog.SecondaryButtonText = "重置默认";
-            dialog.CloseButtonText = "取消";
+            dialog.Title = L.Dns_DialogTitle;
+            dialog.PrimaryButtonText = L.Dialog_Save;
+            dialog.SecondaryButtonText = L.Dns_ResetDefaults;
+            dialog.CloseButtonText = L.Dialog_Cancel;
             dialog.DefaultButton = ContentDialogButton.Primary;
             dialog.Content = content;
 

--- a/Services/IDialogService.cs
+++ b/Services/IDialogService.cs
@@ -14,7 +14,7 @@ namespace XrayUI.Services
         Task<ServerEntry?> ShowChainProxyDialogAsync(IEnumerable<ServerEntry> servers, ServerEntry? existing = null);
         Task<int?> ShowEditPortDialogAsync(int currentPort);
         Task ShowErrorAsync(string title, string message, XamlRoot? xamlRoot = null);
-        Task<bool> ShowConfirmationAsync(string title, string message, string confirmText = "确定", string cancelText = "取消", bool isDanger = false);
+        Task<bool> ShowConfirmationAsync(string title, string message, string? confirmText = null, string? cancelText = null, bool isDanger = false);
         /// <summary>
         /// Shows the TUN confirmation dialog. Mutates <paramref name="settings"/>.TunMtu and
         /// <paramref name="settings"/>.TunOutboundInterface in-place on confirm. Returns true if

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -14,7 +14,7 @@ namespace XrayUI.Services
     {
         private static readonly string DataDir = AppPaths.LocalAppDataDir;
 
-        private static readonly string SettingsFile = Path.Combine(DataDir, "settings.json");
+        private static readonly string SettingsFile = AppPaths.SettingsJsonPath;
         private static readonly string ServersFile  = Path.Combine(DataDir, "servers.json");
 
         private AppSettings? _cachedSettings;

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -104,19 +104,19 @@ namespace XrayUI.Services
             using var client = CreateHttpClient(proxyUrl, TimeSpan.FromMinutes(10));
 
             // ── 1. .sha256 first (small, fail-fast on bad release) ─────────────────
-            progress.Report(new ProgressDialogUpdate("正在获取校验文件…"));
+            progress.Report(new ProgressDialogUpdate(Loc.GetString("Update_FetchingChecksum")));
             string expectedHash;
             try
             {
                 var shaText = await client.GetStringAsync(info.Sha256Url, ct);
                 expectedHash = ParseSha256SumLine(shaText)
-                    ?? throw new InvalidDataException("更新校验文件格式异常");
+                    ?? throw new InvalidDataException(Loc.GetString("Update_ChecksumFormatError"));
             }
             catch (OperationCanceledException) { throw; }
             catch (InvalidDataException) { throw; }
             catch (Exception ex)
             {
-                throw new InvalidDataException("无法下载更新校验文件：" + ex.Message);
+                throw new InvalidDataException(Loc.GetString("Update_ChecksumDownloadFailed") + ex.Message);
             }
 
             // ── 2. zip — hash is computed during the streaming write so we don't ──
@@ -126,27 +126,27 @@ namespace XrayUI.Services
                 client, info.ZipUrl, zipPath, info.ZipAssetName, progress, ct);
 
             if (!string.Equals(actualHash, expectedHash, StringComparison.OrdinalIgnoreCase))
-                throw new InvalidDataException("更新包校验失败：SHA256 与服务器公布的不一致。");
+                throw new InvalidDataException(Loc.GetString("Update_ChecksumMismatch"));
 
             // ── 4. Extract ──────────────────────────────────────────────────────────
-            progress.Report(new ProgressDialogUpdate("正在解压更新包…"));
+            progress.Report(new ProgressDialogUpdate(Loc.GetString("Update_Extracting")));
             try
             {
                 await ZipFile.ExtractToDirectoryAsync(zipPath, extractDir, overwriteFiles: true, cancellationToken: ct);
             }
             catch (Exception ex)
             {
-                throw new InvalidDataException("更新包解压失败：" + ex.Message);
+                throw new InvalidDataException(Loc.GetString("Update_ExtractFailed") + ex.Message);
             }
 
             // ── 5. Sanity check extracted contents ──────────────────────────────────
-            progress.Report(new ProgressDialogUpdate("正在验证更新包…"));
+            progress.Report(new ProgressDialogUpdate(Loc.GetString("Update_Verifying")));
 
             var newAppExe     = Path.Combine(extractDir, AppExeName);
             var newUpdaterExe = Path.Combine(extractDir, UpdaterExeName);
 
             if (!File.Exists(newAppExe) || !File.Exists(newUpdaterExe))
-                throw new InvalidDataException("更新包内容异常：缺少必要文件。");
+                throw new InvalidDataException(Loc.GetString("Update_MissingFiles"));
 
             var actualFileVersion = FileVersionInfo.GetVersionInfo(newAppExe).FileVersion;
             if (string.IsNullOrEmpty(actualFileVersion) ||
@@ -154,7 +154,7 @@ namespace XrayUI.Services
                 NormalizeForCompare(parsedFv) != NormalizeForCompare(info.NewVersion))
             {
                 throw new InvalidDataException(
-                    $"更新包版本不匹配：期望 {info.NewVersion}，实际 {actualFileVersion}。");
+                    Loc.Format("Update_VersionMismatch", info.NewVersion, actualFileVersion));
             }
 
             // ── 6. Stage a runnable copy of the CURRENT updater ─────────────────────
@@ -167,14 +167,14 @@ namespace XrayUI.Services
             if (!File.Exists(currentUpdater))
             {
                 throw new FileNotFoundException(
-                    "缺少升级器组件，请重新下载完整安装包。",
+                    Loc.GetString("Update_MissingUpdater"),
                     currentUpdater);
             }
 
             var stagedRunner = Path.Combine(runnerDir, UpdaterExeName);
             File.Copy(currentUpdater, stagedRunner, overwrite: true);
 
-            progress.Report(new ProgressDialogUpdate("正在准备重启…"));
+            progress.Report(new ProgressDialogUpdate(Loc.GetString("Update_PrepRestart")));
 
             return new UpdateStaging(extractDir, stagedRunner, installDir, info.NewVersion);
         }
@@ -310,11 +310,11 @@ namespace XrayUI.Services
                 var mbTotal = total.Value / 1024.0 / 1024.0;
                 var percent = received * 100.0 / total.Value;
                 return new ProgressDialogUpdate(
-                    $"正在下载 {name} … {mbReceived:0.0} / {mbTotal:0.0} MB",
+                    Loc.Format("Update_Downloading", name, mbReceived, mbTotal),
                     percent);
             }
 
-            return new ProgressDialogUpdate($"正在下载 {name} … {mbReceived:0.0} MB");
+            return new ProgressDialogUpdate(Loc.Format("Update_DownloadingNoTotal", name, mbReceived));
         }
     }
 }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -1,5 +1,64 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -58,8 +117,848 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="_LocaleProbe" xml:space="preserve">
-    <value>en-US</value>
-    <comment>Sentinel — confirms the en-US resw is selected. Real keys land in commit 3.</comment>
+  <data name="MainWindow_Title" xml:space="preserve">
+    <value>Proxy Console</value>
+  </data>
+  <data name="MainWindow_ToggleMini" xml:space="preserve">
+    <value>Toggle mini window</value>
+  </data>
+  <data name="MainWindow_ExpandFull" xml:space="preserve">
+    <value>Back to full window</value>
+  </data>
+  <data name="MainWindow_Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="Tray_Open" xml:space="preserve">
+    <value>Open Window</value>
+  </data>
+  <data name="Tray_Exit" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="ServerList_Header" xml:space="preserve">
+    <value>Server List</value>
+  </data>
+  <data name="ServerList_Add" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ServerList_Edit" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="ServerList_Delete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="ServerList_Share" xml:space="preserve">
+    <value>Share</value>
+  </data>
+  <data name="ServerList_ImportNode" xml:space="preserve">
+    <value>Import Nodes</value>
+  </data>
+  <data name="ServerList_AddSubscription" xml:space="preserve">
+    <value>Add Subscription</value>
+  </data>
+  <data name="ServerList_AddManual" xml:space="preserve">
+    <value>Add Manually</value>
+  </data>
+  <data name="ServerList_SearchPlaceholder" xml:space="preserve">
+    <value>Search servers</value>
+  </data>
+  <data name="ServerList_FilterLabel" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="ServerList_Filter" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="ServerList_Sort" xml:space="preserve">
+    <value>Sort</value>
+  </data>
+  <data name="ServerList_SortDefault" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="ServerList_SortActive" xml:space="preserve">
+    <value>Active</value>
+  </data>
+  <data name="ServerList_SortProtocol" xml:space="preserve">
+    <value>Protocol</value>
+  </data>
+  <data name="ServerList_SortActiveHint" xml:space="preserve">
+    <value>Only available when filter is "All Servers"</value>
+  </data>
+  <data name="ServerList_AllServers" xml:space="preserve">
+    <value>All Servers</value>
+  </data>
+  <data name="ServerList_Ungrouped" xml:space="preserve">
+    <value>Ungrouped</value>
+  </data>
+  <data name="ServerList_UnnamedSub" xml:space="preserve">
+    <value>(Unnamed Subscription)</value>
+  </data>
+  <data name="ServerList_OrphanSub" xml:space="preserve">
+    <value>(Deleted Subscription)</value>
+  </data>
+  <data name="ServerList_Activated" xml:space="preserve">
+    <value>● Active</value>
+  </data>
+  <data name="ControlPanel_Start" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="ControlPanel_Stop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="ControlPanel_StatusNotRunning" xml:space="preserve">
+    <value>Idle</value>
+  </data>
+  <data name="ControlPanel_StatusApplying" xml:space="preserve">
+    <value>Applying...</value>
+  </data>
+  <data name="ControlPanel_Personalize" xml:space="preserve">
+    <value>Personalize</value>
+  </data>
+  <data name="ControlPanel_GitHub" xml:space="preserve">
+    <value>GitHub</value>
+  </data>
+  <data name="ControlPanel_EditLocalPort" xml:space="preserve">
+    <value>Edit Local Port</value>
+  </data>
+  <data name="ControlPanel_ViewLog" xml:space="preserve">
+    <value>Log</value>
+  </data>
+  <data name="ControlPanel_ProxySettings" xml:space="preserve">
+    <value>Proxy Setting</value>
+  </data>
+  <data name="ControlPanel_GlobalProxy" xml:space="preserve">
+    <value>Global Proxy</value>
+  </data>
+  <data name="ControlPanel_NoProxy" xml:space="preserve">
+    <value>No Proxy Takeover</value>
+  </data>
+  <data name="ControlPanel_Startup" xml:space="preserve">
+    <value>Startup</value>
+  </data>
+  <data name="ControlPanel_RoutingSettings" xml:space="preserve">
+    <value>Routing Settings</value>
+  </data>
+  <data name="ControlPanel_RoutingGlobal" xml:space="preserve">
+    <value>Global </value>
+  </data>
+  <data name="ControlPanel_RoutingSmart" xml:space="preserve">
+    <value>Smart </value>
+  </data>
+  <data name="ControlPanel_CustomRules" xml:space="preserve">
+    <value>Custom Rules...</value>
+  </data>
+  <data name="ControlPanel_TunMode" xml:space="preserve">
+    <value>TUN Mode</value>
+  </data>
+  <data name="ControlPanel_RoutingLabel" xml:space="preserve">
+    <value>Routing:</value>
+  </data>
+  <data name="ControlPanel_UpdateFound" xml:space="preserve">
+    <value>New version {0}</value>
+  </data>
+  <data name="ServerDetail_Header" xml:space="preserve">
+    <value>Server Details</value>
+  </data>
+  <data name="ServerDetail_Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ServerDetail_Protocol" xml:space="preserve">
+    <value>Protocol</value>
+  </data>
+  <data name="ServerDetail_Address" xml:space="preserve">
+    <value>Address</value>
+  </data>
+  <data name="ServerDetail_Port" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="ServerDetail_Transport" xml:space="preserve">
+    <value>Transport</value>
+  </data>
+  <data name="ServerDetail_Encryption" xml:space="preserve">
+    <value>Encryption</value>
+  </data>
+  <data name="ServerDetail_Security" xml:space="preserve">
+    <value>Security</value>
+  </data>
+  <data name="ServerDetail_AiUnlock" xml:space="preserve">
+    <value>AI Access Unlock</value>
+  </data>
+  <data name="ServerDetail_OpenInBrowser" xml:space="preserve">
+    <value>Open {0} in browser</value>
+  </data>
+  <data name="ServerDetail_Latency" xml:space="preserve">
+    <value>Latency</value>
+  </data>
+  <data name="ServerDetail_RetestLatency" xml:space="preserve">
+    <value>Retest latency</value>
+  </data>
+  <data name="ServerDetail_CopyShareLink" xml:space="preserve">
+    <value>Copy share link</value>
+  </data>
+  <data name="ServerDetail_NoServer" xml:space="preserve">
+    <value>No server selected</value>
+  </data>
+  <data name="ServerDetail_NotTested" xml:space="preserve">
+    <value>Not tested</value>
+  </data>
+  <data name="ServerDetail_Testing" xml:space="preserve">
+    <value>Testing...</value>
+  </data>
+  <data name="ServerDetail_Timeout" xml:space="preserve">
+    <value>Timeout</value>
+  </data>
+  <data name="ServerDetail_Failed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="Personalize_Header.Text" xml:space="preserve">
+    <value>Personalization</value>
+  </data>
+  <data name="Personalize_Theme.Text" xml:space="preserve">
+    <value>Theme</value>
+  </data>
+  <data name="Personalize_ThemeDesc.Text" xml:space="preserve">
+    <value>Choose the app appearance mode</value>
+  </data>
+  <data name="Personalize_Light.Content" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="Personalize_Dark.Content" xml:space="preserve">
+    <value>Dark</value>
+  </data>
+  <data name="Personalize_FollowSystem.Content" xml:space="preserve">
+    <value>System</value>
+  </data>
+  <data name="Personalize_Backdrop.Text" xml:space="preserve">
+    <value>Background Effect</value>
+  </data>
+  <data name="Personalize_BackdropDesc.Text" xml:space="preserve">
+    <value>Choose window background material</value>
+  </data>
+  <data name="Personalize_Acrylic.Content" xml:space="preserve">
+    <value>Acrylic</value>
+  </data>
+  <data name="Personalize_ProtocolColors.Text" xml:space="preserve">
+    <value>Protocol Colors</value>
+  </data>
+  <data name="Personalize_Reset.Text" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="Personalize_OtherProtocol.Text" xml:space="preserve">
+    <value>Other Protocols</value>
+  </data>
+  <data name="Personalize_OtherProtocolDesc.Text" xml:space="preserve">
+    <value>Unmatched protocols will use this color</value>
+  </data>
+  <data name="Personalize_DataManagement.Text" xml:space="preserve">
+    <value>Data Management</value>
+  </data>
+  <data name="Personalize_ExportConfig.Text" xml:space="preserve">
+    <value>Export Configuration</value>
+  </data>
+  <data name="Personalize_Export.Text" xml:space="preserve">
+    <value>Export</value>
+  </data>
+  <data name="Personalize_Done.Content" xml:space="preserve">
+    <value>Done</value>
+  </data>
+  <data name="Personalize_ExportSuccess" xml:space="preserve">
+    <value>Export Successful</value>
+  </data>
+  <data name="Personalize_ExportSuccessMsg" xml:space="preserve">
+    <value>Exported to the Import folder.</value>
+  </data>
+  <data name="Personalize_Language" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="Personalize_LanguageDesc" xml:space="preserve">
+    <value>Choose the app display language</value>
+  </data>
+  <data name="Personalize_RestartRequired" xml:space="preserve">
+    <value>Changing language requires a restart</value>
+  </data>
+  <data name="Personalize_RestartNow" xml:space="preserve">
+    <value>Restart Now</value>
+  </data>
+  <data name="Personalize_RestartLater" xml:space="preserve">
+    <value>Later</value>
+  </data>
+  <data name="Subscription_AddTooltip" xml:space="preserve">
+    <value>Add Subscription</value>
+  </data>
+  <data name="Subscription_ManageTooltip" xml:space="preserve">
+    <value>Manage Subscriptions</value>
+  </data>
+  <data name="Subscription_LinkHeader" xml:space="preserve">
+    <value>Subscription URL</value>
+  </data>
+  <data name="Subscription_NameHeader" xml:space="preserve">
+    <value>Name (optional)</value>
+  </data>
+  <data name="Subscription_NamePlaceholder" xml:space="preserve">
+    <value>Leave empty to use link domain</value>
+  </data>
+  <data name="Subscription_AutoImportHint" xml:space="preserve">
+    <value>All nodes from the subscription will be imported automatically</value>
+  </data>
+  <data name="Subscription_Empty" xml:space="preserve">
+    <value>No subscriptions</value>
+  </data>
+  <data name="Subscription_Refresh" xml:space="preserve">
+    <value>Refresh Subscription</value>
+  </data>
+  <data name="Subscription_DeleteTooltip" xml:space="preserve">
+    <value>Delete Subscription</value>
+  </data>
+  <data name="Subscription_DeleteConfirm" xml:space="preserve">
+    <value>Delete subscription?</value>
+  </data>
+  <data name="Subscription_DeleteDesc" xml:space="preserve">
+    <value>All nodes under this subscription will also be deleted.</value>
+  </data>
+  <data name="Subscription_FetchFailed" xml:space="preserve">
+    <value>Subscription fetch failed</value>
+  </data>
+  <data name="Subscription_NoParsed" xml:space="preserve">
+    <value>No valid nodes could be parsed from the subscription.</value>
+  </data>
+  <data name="Subscription_StopFirst_Refresh" xml:space="preserve">
+    <value>Please stop the proxy before refreshing</value>
+  </data>
+  <data name="Subscription_UpdateFailed" xml:space="preserve">
+    <value>Update failed: {0}</value>
+  </data>
+  <data name="Subscription_StopFirst_Delete" xml:space="preserve">
+    <value>Please stop the proxy before deleting</value>
+  </data>
+  <data name="CustomRules_Title" xml:space="preserve">
+    <value>Custom Routing Rules</value>
+  </data>
+  <data name="CustomRules_RuleList" xml:space="preserve">
+    <value>Rules</value>
+  </data>
+  <data name="CustomRules_UpdateGeoTooltip" xml:space="preserve">
+    <value>Update GeoFile routing data</value>
+  </data>
+  <data name="CustomRules_Add" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="CustomRules_Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="CustomRules_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="CustomRules_EditTooltip" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="CustomRules_DeleteTooltip" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="CustomRules_NotEffective" xml:space="preserve">
+    <value>Global routing is active — custom rules are not in effect. They will apply when switching back to Smart Routing.</value>
+  </data>
+  <data name="AddRule_Title" xml:space="preserve">
+    <value>Add Rule</value>
+  </data>
+  <data name="AddRule_Add" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="AddRule_TypeLabel" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="AddRule_TypeDomain" xml:space="preserve">
+    <value>Domain</value>
+  </data>
+  <data name="AddRule_MatchLabel" xml:space="preserve">
+    <value>Match Content</value>
+  </data>
+  <data name="AddRule_MatchHint" xml:space="preserve">
+    <value>Supports exact match, regexp:, geosite:, geoip: prefixes</value>
+  </data>
+  <data name="AddRule_OutboundLabel" xml:space="preserve">
+    <value>Outbound</value>
+  </data>
+  <data name="AddRule_OutboundProxy" xml:space="preserve">
+    <value>proxy</value>
+  </data>
+  <data name="AddRule_OutboundDirect" xml:space="preserve">
+    <value>direct</value>
+  </data>
+  <data name="AddRule_OutboundBlock" xml:space="preserve">
+    <value>block</value>
+  </data>
+  <data name="AddRule_ErrorEmpty" xml:space="preserve">
+    <value>Please enter match content</value>
+  </data>
+  <data name="Log_Title" xml:space="preserve">
+    <value>Proxy Log</value>
+  </data>
+  <data name="Log_NotRunning" xml:space="preserve">
+    <value>Not running</value>
+  </data>
+  <data name="Log_Running" xml:space="preserve">
+    <value>Running</value>
+  </data>
+  <data name="Log_Lines" xml:space="preserve">
+    <value>({0} lines)</value>
+  </data>
+  <data name="Log_PrivacyTooltip" xml:space="preserve">
+    <value>Log privacy settings</value>
+  </data>
+  <data name="Log_IpMask" xml:space="preserve">
+    <value>IP Address Mask</value>
+  </data>
+  <data name="Log_MaskOff" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="Log_AutoScroll" xml:space="preserve">
+    <value>Auto Scroll</value>
+  </data>
+  <data name="Log_CopyAll" xml:space="preserve">
+    <value>Copy All</value>
+  </data>
+  <data name="Log_Clear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="Log_PrivacyTitle" xml:space="preserve">
+    <value>Log Privacy Settings</value>
+  </data>
+  <data name="Log_PrivacySaved" xml:space="preserve">
+    <value>Saved. Takes effect on next TUN session start.</value>
+  </data>
+  <data name="Log_PrivacyFailed" xml:space="preserve">
+    <value>Save failed: {0}</value>
+  </data>
+  <data name="Dialog_OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="Dialog_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Dialog_Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Dialog_Done" xml:space="preserve">
+    <value>Done</value>
+  </data>
+  <data name="Dialog_Confirm" xml:space="preserve">
+    <value>Confirm</value>
+  </data>
+  <data name="Dialog_Add" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="Dialog_Delete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="Dialog_Replace" xml:space="preserve">
+    <value>Replace</value>
+  </data>
+  <data name="Dialog_Preparing" xml:space="preserve">
+    <value>Preparing…</value>
+  </data>
+  <data name="Dialog_On" xml:space="preserve">
+    <value>On</value>
+  </data>
+  <data name="Dialog_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="Import_Placeholder" xml:space="preserve">
+    <value>Paste node links (multi-protocol supported)</value>
+  </data>
+  <data name="Import_Title" xml:space="preserve">
+    <value>Import Node Links</value>
+  </data>
+  <data name="Import_SupportHint" xml:space="preserve">
+    <value>Supports common protocol links</value>
+  </data>
+  <data name="Import_ParseFailed" xml:space="preserve">
+    <value>Parse Failed</value>
+  </data>
+  <data name="Import_ParseFailedMsg" xml:space="preserve">
+    <value>Could not identify valid node links. Please check and try again.</value>
+  </data>
+  <data name="EditServer_AddTitle" xml:space="preserve">
+    <value>Add Server Manually</value>
+  </data>
+  <data name="EditServer_EditTitle" xml:space="preserve">
+    <value>Edit Server</value>
+  </data>
+  <data name="EditServer_Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="EditServer_Address" xml:space="preserve">
+    <value>Address / Domain</value>
+  </data>
+  <data name="EditServer_Port" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="EditServer_Protocol" xml:space="preserve">
+    <value>Protocol</value>
+  </data>
+  <data name="EditServer_Encryption" xml:space="preserve">
+    <value>Encryption (SS)</value>
+  </data>
+  <data name="EditServer_Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="EditServer_UUID" xml:space="preserve">
+    <value>UUID (VMess / VLESS)</value>
+  </data>
+  <data name="EditServer_AlterId" xml:space="preserve">
+    <value>AlterId (VMess)</value>
+  </data>
+  <data name="EditServer_Transport" xml:space="preserve">
+    <value>Transport Protocol</value>
+  </data>
+  <data name="EditServer_Path" xml:space="preserve">
+    <value>Path (WS/gRPC/XHTTP)</value>
+  </data>
+  <data name="EditServer_WsHost" xml:space="preserve">
+    <value>Host Header (WS/XHTTP)</value>
+  </data>
+  <data name="EditServer_Security" xml:space="preserve">
+    <value>Security</value>
+  </data>
+  <data name="EditServer_Fingerprint" xml:space="preserve">
+    <value>Fingerprint (uTLS)</value>
+  </data>
+  <data name="EditServer_AllowInsecure" xml:space="preserve">
+    <value>Allow insecure connection (skip certificate verification)</value>
+  </data>
+  <data name="EditServer_FlowPlaceholder" xml:space="preserve">
+    <value>xtls-rprx-vision or leave empty</value>
+  </data>
+  <data name="EditPort_Title" xml:space="preserve">
+    <value>Edit Local Port</value>
+  </data>
+  <data name="EditPort_Header" xml:space="preserve">
+    <value>Local Port</value>
+  </data>
+  <data name="EditPort_Range" xml:space="preserve">
+    <value>Valid range: {0} - {1}</value>
+  </data>
+  <data name="Share_Title" xml:space="preserve">
+    <value>Share Node</value>
+  </data>
+  <data name="Share_CopyLink" xml:space="preserve">
+    <value>Copy Link</value>
+  </data>
+  <data name="Share_NotSupported" xml:space="preserve">
+    <value>Sharing Not Supported</value>
+  </data>
+  <data name="Share_NotSupportedMsg" xml:space="preserve">
+    <value>This node protocol does not support generating share links.</value>
+  </data>
+  <data name="Startup_Title" xml:space="preserve">
+    <value>Startup</value>
+  </data>
+  <data name="Startup_AutoStart" xml:space="preserve">
+    <value>Launch at startup</value>
+  </data>
+  <data name="Startup_AutoConnect" xml:space="preserve">
+    <value>Auto-connect to last node</value>
+  </data>
+  <data name="Startup_SetFailed" xml:space="preserve">
+    <value>Startup settings failed</value>
+  </data>
+  <data name="Confirm_DeleteTitle" xml:space="preserve">
+    <value>Confirm Delete</value>
+  </data>
+  <data name="Confirm_DeleteMsg" xml:space="preserve">
+    <value>Are you sure you want to delete {0}?</value>
+  </data>
+  <data name="Confirm_ReplaceTitle" xml:space="preserve">
+    <value>Replace current configuration?</value>
+  </data>
+  <data name="Confirm_ReplaceMsg" xml:space="preserve">
+    <value>This will overwrite all current servers and routing rules. We strongly recommend exporting a backup first. Continue?</value>
+  </data>
+  <data name="EditServer_SocksUsername" xml:space="preserve">
+    <value>Username (SOCKS)</value>
+  </data>
+  <data name="EditServer_EchPlaceholder" xml:space="preserve">
+    <value>e.g. udp://1.1.1.1 or server-generated ECHConfig</value>
+  </data>
+  <data name="EditServer_FinalmaskPlaceholder" xml:space="preserve">
+    <value>Empty = none; or mlkem768x25519plus.native.0rtt...</value>
+  </data>
+  <data name="ChainProxy_AddTitle" xml:space="preserve">
+    <value>Chain proxy</value>
+  </data>
+  <data name="ChainProxy_EditTitle" xml:space="preserve">
+    <value>Edit chain proxy</value>
+  </data>
+  <data name="Dns_DialogTitle" xml:space="preserve">
+    <value>DNS Settings</value>
+  </data>
+  <data name="ControlPanel_DnsItem.Text" xml:space="preserve">
+    <value>DNS Settings</value>
+  </data>
+  <data name="Dns_ResetDefaults" xml:space="preserve">
+    <value>Reset to defaults</value>
+  </data>
+  <data name="Dns_ServerPlaceholder" xml:space="preserve">
+    <value>Enter IP or DoH address (empty = auto)</value>
+  </data>
+  <data name="Dns_QueryStrategyLabel" xml:space="preserve">
+    <value>Query strategy</value>
+  </data>
+  <data name="Dns_EnableCacheLabel" xml:space="preserve">
+    <value>Enable DNS cache</value>
+  </data>
+  <data name="Dns_DirectTitle" xml:space="preserve">
+    <value>Direct DNS</value>
+  </data>
+  <data name="Dns_DirectDesc" xml:space="preserve">
+    <value>For domestic domains (geosite:cn), resolved via direct outbound</value>
+  </data>
+  <data name="Dns_ProxyTitle" xml:space="preserve">
+    <value>Proxy DNS</value>
+  </data>
+  <data name="Dns_ProxyDesc" xml:space="preserve">
+    <value>For foreign domains, resolved via proxy outbound to prevent DNS pollution</value>
+  </data>
+  <data name="Dns_TunOnlyHint" xml:space="preserve">
+    <value>TUN mode only</value>
+  </data>
+  <data name="Dns_Experimental" xml:space="preserve">
+    <value>Experimental</value>
+  </data>
+  <data name="Dns_Provider_Ali" xml:space="preserve">
+    <value>Alibaba</value>
+  </data>
+  <data name="Dns_Provider_Tencent" xml:space="preserve">
+    <value>Tencent</value>
+  </data>
+  <data name="Dns_Provider_Google" xml:space="preserve">
+    <value>Google</value>
+  </data>
+  <data name="Dns_Strategy_V4Only" xml:space="preserve">
+    <value>IPv4 only</value>
+  </data>
+  <data name="Dns_Strategy_V6Only" xml:space="preserve">
+    <value>IPv6 only</value>
+  </data>
+  <data name="Dns_Strategy_Auto" xml:space="preserve">
+    <value>Auto</value>
+  </data>
+  <data name="Error_NoServer" xml:space="preserve">
+    <value>No Server Selected</value>
+  </data>
+  <data name="Error_NoServerMsg" xml:space="preserve">
+    <value>Please select a server from the list first</value>
+  </data>
+  <data name="Error_StartFailed" xml:space="preserve">
+    <value>Start Failed</value>
+  </data>
+  <data name="Error_XrayStartFailed" xml:space="preserve">
+    <value>xray failed to start. Please check server configuration.</value>
+  </data>
+  <data name="Error_ReapplyFailed" xml:space="preserve">
+    <value>Apply Configuration Failed</value>
+  </data>
+  <data name="Error_XrayReapplyFailed" xml:space="preserve">
+    <value>xray failed to apply new configuration and has stopped.</value>
+  </data>
+  <data name="Error_UpdateFailed" xml:space="preserve">
+    <value>Update Failed</value>
+  </data>
+  <data name="Error_UpdaterLaunchFailed" xml:space="preserve">
+    <value>Could not launch updater: {0}</value>
+  </data>
+  <data name="Update_Updating" xml:space="preserve">
+    <value>Updating XrayUI</value>
+  </data>
+  <data name="Tun_EnableTitle" xml:space="preserve">
+    <value>Enable TUN Mode</value>
+  </data>
+  <data name="Tun_EnableMsg" xml:space="preserve">
+    <value>Enabling TUN mode requires administrator privileges. The app will restart. Continue?</value>
+  </data>
+  <data name="Main_NoSelection" xml:space="preserve">
+    <value>Not selected</value>
+  </data>
+  <data name="Main_NotConnected" xml:space="preserve">
+    <value>Not connected</value>
+  </data>
+  <data name="CopyButton_Tooltip" xml:space="preserve">
+    <value>Copy to clipboard</value>
+  </data>
+  <data name="CopyButton_Copied" xml:space="preserve">
+    <value>Copied to clipboard</value>
+  </data>
+  <data name="GeoUpdate_Updating" xml:space="preserve">
+    <value>Updating routing data</value>
+  </data>
+  <data name="GeoUpdate_AlreadyLatest" xml:space="preserve">
+    <value>Already Up to Date</value>
+  </data>
+  <data name="GeoUpdate_AlreadyLatestMsg" xml:space="preserve">
+    <value>geoip.dat and geosite.dat are already the latest version. No download needed.</value>
+  </data>
+  <data name="GeoUpdate_Success" xml:space="preserve">
+    <value>Update Successful</value>
+  </data>
+  <data name="GeoUpdate_TunRestart" xml:space="preserve">
+    <value>Updated. Please restart manually in TUN mode for changes to take effect.</value>
+  </data>
+  <data name="GeoUpdate_ReloadedOk" xml:space="preserve">
+    <value>Updated and xray reloaded.</value>
+  </data>
+  <data name="GeoUpdate_ReloadFailed" xml:space="preserve">
+    <value>Data files updated, but xray restart failed: {0}</value>
+  </data>
+  <data name="GeoUpdate_RestartRequired" xml:space="preserve">
+    <value>Updated. Please restart xray for changes to take effect.</value>
+  </data>
+  <data name="GeoUpdate_NextStart" xml:space="preserve">
+    <value>Updated. Changes will take effect on next xray start.</value>
+  </data>
+  <data name="Xray_NotFound" xml:space="preserve">
+    <value>xray.exe not found
+Path: {0}</value>
+  </data>
+  <data name="Xray_LogError" xml:space="preserve">
+    <value>[Error]</value>
+  </data>
+  <data name="Xray_ProcessExited" xml:space="preserve">
+    <value>[xray process exited]</value>
+  </data>
+  <data name="Xray_LogStart" xml:space="preserve">
+    <value>[Start]</value>
+  </data>
+  <data name="Xray_LogConfig" xml:space="preserve">
+    <value>[Config]</value>
+  </data>
+  <data name="Xray_ImmediateExit" xml:space="preserve">
+    <value>xray exited immediately (exit code {0})</value>
+  </data>
+  <data name="Xray_LogStartFailed" xml:space="preserve">
+    <value>[Error] Start failed:</value>
+  </data>
+  <data name="Xray_LogException" xml:space="preserve">
+    <value>[Exception]</value>
+  </data>
+  <data name="Xray_LogStopped" xml:space="preserve">
+    <value>[Stopped]</value>
+  </data>
+  <data name="Update_FetchingChecksum" xml:space="preserve">
+    <value>Fetching checksum file…</value>
+  </data>
+  <data name="Update_ChecksumFormatError" xml:space="preserve">
+    <value>Update checksum file format error</value>
+  </data>
+  <data name="Update_ChecksumDownloadFailed" xml:space="preserve">
+    <value>Could not download update checksum file: </value>
+  </data>
+  <data name="Update_ChecksumMismatch" xml:space="preserve">
+    <value>Update verification failed: SHA256 does not match the server checksum.</value>
+  </data>
+  <data name="Update_Extracting" xml:space="preserve">
+    <value>Extracting update…</value>
+  </data>
+  <data name="Update_ExtractFailed" xml:space="preserve">
+    <value>Update extraction failed: </value>
+  </data>
+  <data name="Update_Verifying" xml:space="preserve">
+    <value>Verifying update…</value>
+  </data>
+  <data name="Update_MissingFiles" xml:space="preserve">
+    <value>Update package is invalid: required files are missing.</value>
+  </data>
+  <data name="Update_VersionMismatch" xml:space="preserve">
+    <value>Update version mismatch: expected {0}, got {1}.</value>
+  </data>
+  <data name="Update_MissingUpdater" xml:space="preserve">
+    <value>Updater component missing. Please re-download the full installer.</value>
+  </data>
+  <data name="Update_PrepRestart" xml:space="preserve">
+    <value>Preparing to restart…</value>
+  </data>
+  <data name="Update_Downloading" xml:space="preserve">
+    <value>Downloading {0} … {1:0.0} / {2:0.0} MB</value>
+  </data>
+  <data name="Update_DownloadingNoTotal" xml:space="preserve">
+    <value>Downloading {0} … {1:0.0} MB</value>
+  </data>
+  <data name="AddRule_EditTitle" xml:space="preserve">
+    <value>Edit Rule</value>
+  </data>
+  <data name="Error_ExportFailed" xml:space="preserve">
+    <value>Export Failed</value>
+  </data>
+  <data name="GeoUpdate_ViaProxy" xml:space="preserve">
+    <value>Downloading via local proxy ({0})…</value>
+  </data>
+  <data name="GeoUpdate_Checking" xml:space="preserve">
+    <value>Checking {0}.dat …</value>
+  </data>
+  <data name="GeoUpdate_UpToDate" xml:space="preserve">
+    <value>{0}.dat is already up to date</value>
+  </data>
+  <data name="GeoUpdate_ChecksumFailed" xml:space="preserve">
+    <value>{0}.dat verification failed: downloaded file SHA256 does not match server.</value>
+  </data>
+  <data name="Subscription_NeverUpdated" xml:space="preserve">
+    <value>Last updated: never</value>
+  </data>
+  <data name="Subscription_JustNow" xml:space="preserve">
+    <value>just now</value>
+  </data>
+  <data name="Subscription_MinutesAgo" xml:space="preserve">
+    <value>{0} min ago</value>
+  </data>
+  <data name="Subscription_HoursAgo" xml:space="preserve">
+    <value>{0} hr ago</value>
+  </data>
+  <data name="Subscription_DaysAgo" xml:space="preserve">
+    <value>{0} days ago</value>
+  </data>
+  <data name="Subscription_LastUpdated" xml:space="preserve">
+    <value>Last updated: {0}</value>
+  </data>
+  <data name="SystemProxy_RegError" xml:space="preserve">
+    <value>Cannot open registry key: </value>
+  </data>
+  <data name="ControlPanel_EditPortItem.Text" xml:space="preserve">
+    <value>Local Port</value>
+  </data>
+  <data name="ControlPanel_ViewLogItem.Text" xml:space="preserve">
+    <value>Logs</value>
+  </data>
+  <data name="ControlPanel_ProxySettingsItem.Text" xml:space="preserve">
+    <value>Proxy Setting</value>
+  </data>
+  <data name="ControlPanel_GlobalProxyItem.Text" xml:space="preserve">
+    <value>Global Proxy</value>
+  </data>
+  <data name="ControlPanel_NoProxyItem.Text" xml:space="preserve">
+    <value>No Proxy Takeover</value>
+  </data>
+  <data name="ControlPanel_StartupItem.Text" xml:space="preserve">
+    <value>Startup</value>
+  </data>
+  <data name="ControlPanel_RoutingSettingsItem.Text" xml:space="preserve">
+    <value>Routing</value>
+  </data>
+  <data name="ControlPanel_RoutingGlobalItem.Text" xml:space="preserve">
+    <value>Global </value>
+  </data>
+  <data name="ControlPanel_RoutingSmartItem.Text" xml:space="preserve">
+    <value>Smart</value>
+  </data>
+  <data name="ControlPanel_CustomRulesItem.Text" xml:space="preserve">
+    <value>Custom Rules...</value>
+  </data>
+  <data name="ControlPanel_TunModeLabel.Text" xml:space="preserve">
+    <value>TUN Mode</value>
+  </data>
+  <data name="ControlPanel_RoutingLbl.Text" xml:space="preserve">
+    <value>Routing:</value>
+  </data>
+  <data name="Personalize_LanguageLbl.Text" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="Personalize_LanguageDescLbl.Text" xml:space="preserve">
+    <value>Choose the app display language</value>
   </data>
 </root>

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MainWindow_Title" xml:space="preserve">
-    <value>Proxy Console</value>
+    <value>Proxy Panel</value>
   </data>
   <data name="MainWindow_ToggleMini" xml:space="preserve">
     <value>Toggle mini window</value>
@@ -130,16 +130,10 @@
     <value>Close</value>
   </data>
   <data name="Tray_Open" xml:space="preserve">
-    <value>Open Window</value>
+    <value>Open</value>
   </data>
   <data name="Tray_Exit" xml:space="preserve">
     <value>Exit</value>
-  </data>
-  <data name="ServerList_Header" xml:space="preserve">
-    <value>Server List</value>
-  </data>
-  <data name="ServerList_Add" xml:space="preserve">
-    <value>Add</value>
   </data>
   <data name="ServerList_Edit" xml:space="preserve">
     <value>Edit</value>
@@ -149,36 +143,6 @@
   </data>
   <data name="ServerList_Share" xml:space="preserve">
     <value>Share</value>
-  </data>
-  <data name="ServerList_ImportNode" xml:space="preserve">
-    <value>Import Nodes</value>
-  </data>
-  <data name="ServerList_AddSubscription" xml:space="preserve">
-    <value>Add Subscription</value>
-  </data>
-  <data name="ServerList_AddManual" xml:space="preserve">
-    <value>Add Manually</value>
-  </data>
-  <data name="ServerList_SearchPlaceholder" xml:space="preserve">
-    <value>Search servers</value>
-  </data>
-  <data name="ServerList_FilterLabel" xml:space="preserve">
-    <value>Filter:</value>
-  </data>
-  <data name="ServerList_Filter" xml:space="preserve">
-    <value>Filter</value>
-  </data>
-  <data name="ServerList_Sort" xml:space="preserve">
-    <value>Sort</value>
-  </data>
-  <data name="ServerList_SortDefault" xml:space="preserve">
-    <value>Default</value>
-  </data>
-  <data name="ServerList_SortActive" xml:space="preserve">
-    <value>Active</value>
-  </data>
-  <data name="ServerList_SortProtocol" xml:space="preserve">
-    <value>Protocol</value>
   </data>
   <data name="ServerList_SortActiveHint" xml:space="preserve">
     <value>Only available when filter is "All Servers"</value>
@@ -195,9 +159,6 @@
   <data name="ServerList_OrphanSub" xml:space="preserve">
     <value>(Deleted Subscription)</value>
   </data>
-  <data name="ServerList_Activated" xml:space="preserve">
-    <value>● Active</value>
-  </data>
   <data name="ControlPanel_Start" xml:space="preserve">
     <value>Start</value>
   </data>
@@ -213,56 +174,14 @@
   <data name="ControlPanel_Personalize" xml:space="preserve">
     <value>Personalize</value>
   </data>
-  <data name="ControlPanel_GitHub" xml:space="preserve">
-    <value>GitHub</value>
-  </data>
-  <data name="ControlPanel_EditLocalPort" xml:space="preserve">
-    <value>Edit Local Port</value>
-  </data>
-  <data name="ControlPanel_ViewLog" xml:space="preserve">
-    <value>Log</value>
-  </data>
-  <data name="ControlPanel_ProxySettings" xml:space="preserve">
-    <value>Proxy Setting</value>
-  </data>
-  <data name="ControlPanel_GlobalProxy" xml:space="preserve">
-    <value>Global Proxy</value>
-  </data>
-  <data name="ControlPanel_NoProxy" xml:space="preserve">
-    <value>No Proxy Takeover</value>
-  </data>
-  <data name="ControlPanel_Startup" xml:space="preserve">
-    <value>Startup</value>
-  </data>
-  <data name="ControlPanel_RoutingSettings" xml:space="preserve">
-    <value>Routing Settings</value>
-  </data>
   <data name="ControlPanel_RoutingGlobal" xml:space="preserve">
-    <value>Global </value>
+    <value>Global</value>
   </data>
   <data name="ControlPanel_RoutingSmart" xml:space="preserve">
-    <value>Smart </value>
-  </data>
-  <data name="ControlPanel_CustomRules" xml:space="preserve">
-    <value>Custom Rules...</value>
-  </data>
-  <data name="ControlPanel_TunMode" xml:space="preserve">
-    <value>TUN Mode</value>
-  </data>
-  <data name="ControlPanel_RoutingLabel" xml:space="preserve">
-    <value>Routing:</value>
+    <value>Smart</value>
   </data>
   <data name="ControlPanel_UpdateFound" xml:space="preserve">
     <value>New version {0}</value>
-  </data>
-  <data name="ServerDetail_Header" xml:space="preserve">
-    <value>Server Details</value>
-  </data>
-  <data name="ServerDetail_Name" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="ServerDetail_Protocol" xml:space="preserve">
-    <value>Protocol</value>
   </data>
   <data name="ServerDetail_Address" xml:space="preserve">
     <value>Address</value>
@@ -270,23 +189,14 @@
   <data name="ServerDetail_Port" xml:space="preserve">
     <value>Port</value>
   </data>
-  <data name="ServerDetail_Transport" xml:space="preserve">
-    <value>Transport</value>
-  </data>
   <data name="ServerDetail_Encryption" xml:space="preserve">
     <value>Encryption</value>
   </data>
   <data name="ServerDetail_Security" xml:space="preserve">
     <value>Security</value>
   </data>
-  <data name="ServerDetail_AiUnlock" xml:space="preserve">
-    <value>AI Access Unlock</value>
-  </data>
   <data name="ServerDetail_OpenInBrowser" xml:space="preserve">
     <value>Open {0} in browser</value>
-  </data>
-  <data name="ServerDetail_Latency" xml:space="preserve">
-    <value>Latency</value>
   </data>
   <data name="ServerDetail_RetestLatency" xml:space="preserve">
     <value>Retest latency</value>
@@ -315,9 +225,6 @@
   <data name="Personalize_Theme.Text" xml:space="preserve">
     <value>Theme</value>
   </data>
-  <data name="Personalize_ThemeDesc.Text" xml:space="preserve">
-    <value>Choose the app appearance mode</value>
-  </data>
   <data name="Personalize_Light.Content" xml:space="preserve">
     <value>Light</value>
   </data>
@@ -329,9 +236,6 @@
   </data>
   <data name="Personalize_Backdrop.Text" xml:space="preserve">
     <value>Background Effect</value>
-  </data>
-  <data name="Personalize_BackdropDesc.Text" xml:space="preserve">
-    <value>Choose window background material</value>
   </data>
   <data name="Personalize_Acrylic.Content" xml:space="preserve">
     <value>Acrylic</value>
@@ -351,35 +255,15 @@
   <data name="Personalize_DataManagement.Text" xml:space="preserve">
     <value>Data Management</value>
   </data>
-  <data name="Personalize_ExportConfig.Text" xml:space="preserve">
-    <value>Export Configuration</value>
-  </data>
-  <data name="Personalize_Export.Text" xml:space="preserve">
-    <value>Export</value>
-  </data>
   <data name="Personalize_Done.Content" xml:space="preserve">
     <value>Done</value>
   </data>
   <data name="Personalize_ExportSuccess" xml:space="preserve">
     <value>Export Successful</value>
   </data>
-  <data name="Personalize_ExportSuccessMsg" xml:space="preserve">
-    <value>Exported to the Import folder.</value>
-  </data>
-  <data name="Personalize_Language" xml:space="preserve">
-    <value>Language</value>
-  </data>
-  <data name="Personalize_LanguageDesc" xml:space="preserve">
-    <value>Choose the app display language</value>
-  </data>
-  <data name="Personalize_RestartRequired" xml:space="preserve">
-    <value>Changing language requires a restart</value>
-  </data>
-  <data name="Personalize_RestartNow" xml:space="preserve">
-    <value>Restart Now</value>
-  </data>
-  <data name="Personalize_RestartLater" xml:space="preserve">
-    <value>Later</value>
+  <data name="Language_FollowSystem" xml:space="preserve">
+    <value>Follow System</value>
+    <comment>Display name of the "follow system" language row — referenced by LanguageInfo.DisplayName when Tag is null.</comment>
   </data>
   <data name="Subscription_AddTooltip" xml:space="preserve">
     <value>Add Subscription</value>
@@ -387,32 +271,11 @@
   <data name="Subscription_ManageTooltip" xml:space="preserve">
     <value>Manage Subscriptions</value>
   </data>
-  <data name="Subscription_LinkHeader" xml:space="preserve">
-    <value>Subscription URL</value>
-  </data>
-  <data name="Subscription_NameHeader" xml:space="preserve">
-    <value>Name (optional)</value>
-  </data>
-  <data name="Subscription_NamePlaceholder" xml:space="preserve">
-    <value>Leave empty to use link domain</value>
-  </data>
-  <data name="Subscription_AutoImportHint" xml:space="preserve">
-    <value>All nodes from the subscription will be imported automatically</value>
-  </data>
-  <data name="Subscription_Empty" xml:space="preserve">
-    <value>No subscriptions</value>
-  </data>
   <data name="Subscription_Refresh" xml:space="preserve">
     <value>Refresh Subscription</value>
   </data>
   <data name="Subscription_DeleteTooltip" xml:space="preserve">
     <value>Delete Subscription</value>
-  </data>
-  <data name="Subscription_DeleteConfirm" xml:space="preserve">
-    <value>Delete subscription?</value>
-  </data>
-  <data name="Subscription_DeleteDesc" xml:space="preserve">
-    <value>All nodes under this subscription will also be deleted.</value>
   </data>
   <data name="Subscription_FetchFailed" xml:space="preserve">
     <value>Subscription fetch failed</value>
@@ -432,59 +295,11 @@
   <data name="CustomRules_Title" xml:space="preserve">
     <value>Custom Routing Rules</value>
   </data>
-  <data name="CustomRules_RuleList" xml:space="preserve">
-    <value>Rules</value>
-  </data>
   <data name="CustomRules_UpdateGeoTooltip" xml:space="preserve">
     <value>Update GeoFile routing data</value>
   </data>
-  <data name="CustomRules_Add" xml:space="preserve">
-    <value>Add</value>
-  </data>
-  <data name="CustomRules_Save" xml:space="preserve">
-    <value>Save</value>
-  </data>
-  <data name="CustomRules_Cancel" xml:space="preserve">
-    <value>Cancel</value>
-  </data>
-  <data name="CustomRules_EditTooltip" xml:space="preserve">
-    <value>Edit</value>
-  </data>
-  <data name="CustomRules_DeleteTooltip" xml:space="preserve">
-    <value>Delete</value>
-  </data>
-  <data name="CustomRules_NotEffective" xml:space="preserve">
-    <value>Global routing is active — custom rules are not in effect. They will apply when switching back to Smart Routing.</value>
-  </data>
   <data name="AddRule_Title" xml:space="preserve">
     <value>Add Rule</value>
-  </data>
-  <data name="AddRule_Add" xml:space="preserve">
-    <value>Add</value>
-  </data>
-  <data name="AddRule_TypeLabel" xml:space="preserve">
-    <value>Type</value>
-  </data>
-  <data name="AddRule_TypeDomain" xml:space="preserve">
-    <value>Domain</value>
-  </data>
-  <data name="AddRule_MatchLabel" xml:space="preserve">
-    <value>Match Content</value>
-  </data>
-  <data name="AddRule_MatchHint" xml:space="preserve">
-    <value>Supports exact match, regexp:, geosite:, geoip: prefixes</value>
-  </data>
-  <data name="AddRule_OutboundLabel" xml:space="preserve">
-    <value>Outbound</value>
-  </data>
-  <data name="AddRule_OutboundProxy" xml:space="preserve">
-    <value>proxy</value>
-  </data>
-  <data name="AddRule_OutboundDirect" xml:space="preserve">
-    <value>direct</value>
-  </data>
-  <data name="AddRule_OutboundBlock" xml:space="preserve">
-    <value>block</value>
   </data>
   <data name="AddRule_ErrorEmpty" xml:space="preserve">
     <value>Please enter match content</value>
@@ -574,7 +389,7 @@
     <value>Parse Failed</value>
   </data>
   <data name="Import_ParseFailedMsg" xml:space="preserve">
-    <value>Could not identify valid node links. Please check and try again.</value>
+    <value>No valid node links found. Please verify your input and try again.</value>
   </data>
   <data name="EditServer_AddTitle" xml:space="preserve">
     <value>Add Server Manually</value>
@@ -599,12 +414,6 @@
   </data>
   <data name="EditServer_Password" xml:space="preserve">
     <value>Password</value>
-  </data>
-  <data name="EditServer_UUID" xml:space="preserve">
-    <value>UUID (VMess / VLESS)</value>
-  </data>
-  <data name="EditServer_AlterId" xml:space="preserve">
-    <value>AlterId (VMess)</value>
   </data>
   <data name="EditServer_Transport" xml:space="preserve">
     <value>Transport Protocol</value>
@@ -634,7 +443,7 @@
     <value>Local Port</value>
   </data>
   <data name="EditPort_Range" xml:space="preserve">
-    <value>Valid range: {0} - {1}</value>
+    <value>Range: {0} - {1}</value>
   </data>
   <data name="Share_Title" xml:space="preserve">
     <value>Share Node</value>
@@ -682,10 +491,10 @@
     <value>Empty = none; or mlkem768x25519plus.native.0rtt...</value>
   </data>
   <data name="ChainProxy_AddTitle" xml:space="preserve">
-    <value>Chain proxy</value>
+    <value>Add Chain Proxy</value>
   </data>
   <data name="ChainProxy_EditTitle" xml:space="preserve">
-    <value>Edit chain proxy</value>
+    <value>Edit Chain Proxy</value>
   </data>
   <data name="Dns_DialogTitle" xml:space="preserve">
     <value>DNS Settings</value>
@@ -709,13 +518,13 @@
     <value>Direct DNS</value>
   </data>
   <data name="Dns_DirectDesc" xml:space="preserve">
-    <value>For domestic domains (geosite:cn), resolved via direct outbound</value>
+    <value>For domestic domains (geosite:cn), resolved directly without proxy</value>
   </data>
   <data name="Dns_ProxyTitle" xml:space="preserve">
     <value>Proxy DNS</value>
   </data>
   <data name="Dns_ProxyDesc" xml:space="preserve">
-    <value>For foreign domains, resolved via proxy outbound to prevent DNS pollution</value>
+    <value>For foreign domains, resolved via proxy outbound to prevent DNS hijacking</value>
   </data>
   <data name="Dns_TunOnlyHint" xml:space="preserve">
     <value>TUN mode only</value>
@@ -771,7 +580,7 @@
   <data name="Tun_EnableTitle" xml:space="preserve">
     <value>Enable TUN Mode</value>
   </data>
-  <data name="Tun_EnableMsg" xml:space="preserve">
+  <data name="Tun_EnableMsg.Text" xml:space="preserve">
     <value>Enabling TUN mode requires administrator privileges. The app will restart. Continue?</value>
   </data>
   <data name="Main_NoSelection" xml:space="preserve">
@@ -779,12 +588,6 @@
   </data>
   <data name="Main_NotConnected" xml:space="preserve">
     <value>Not connected</value>
-  </data>
-  <data name="CopyButton_Tooltip" xml:space="preserve">
-    <value>Copy to clipboard</value>
-  </data>
-  <data name="CopyButton_Copied" xml:space="preserve">
-    <value>Copied to clipboard</value>
   </data>
   <data name="GeoUpdate_Updating" xml:space="preserve">
     <value>Updating routing data</value>
@@ -812,34 +615,6 @@
   </data>
   <data name="GeoUpdate_NextStart" xml:space="preserve">
     <value>Updated. Changes will take effect on next xray start.</value>
-  </data>
-  <data name="Xray_NotFound" xml:space="preserve">
-    <value>xray.exe not found
-Path: {0}</value>
-  </data>
-  <data name="Xray_LogError" xml:space="preserve">
-    <value>[Error]</value>
-  </data>
-  <data name="Xray_ProcessExited" xml:space="preserve">
-    <value>[xray process exited]</value>
-  </data>
-  <data name="Xray_LogStart" xml:space="preserve">
-    <value>[Start]</value>
-  </data>
-  <data name="Xray_LogConfig" xml:space="preserve">
-    <value>[Config]</value>
-  </data>
-  <data name="Xray_ImmediateExit" xml:space="preserve">
-    <value>xray exited immediately (exit code {0})</value>
-  </data>
-  <data name="Xray_LogStartFailed" xml:space="preserve">
-    <value>[Error] Start failed:</value>
-  </data>
-  <data name="Xray_LogException" xml:space="preserve">
-    <value>[Exception]</value>
-  </data>
-  <data name="Xray_LogStopped" xml:space="preserve">
-    <value>[Stopped]</value>
   </data>
   <data name="Update_FetchingChecksum" xml:space="preserve">
     <value>Fetching checksum file…</value>
@@ -886,18 +661,6 @@ Path: {0}</value>
   <data name="Error_ExportFailed" xml:space="preserve">
     <value>Export Failed</value>
   </data>
-  <data name="GeoUpdate_ViaProxy" xml:space="preserve">
-    <value>Downloading via local proxy ({0})…</value>
-  </data>
-  <data name="GeoUpdate_Checking" xml:space="preserve">
-    <value>Checking {0}.dat …</value>
-  </data>
-  <data name="GeoUpdate_UpToDate" xml:space="preserve">
-    <value>{0}.dat is already up to date</value>
-  </data>
-  <data name="GeoUpdate_ChecksumFailed" xml:space="preserve">
-    <value>{0}.dat verification failed: downloaded file SHA256 does not match server.</value>
-  </data>
   <data name="Subscription_NeverUpdated" xml:space="preserve">
     <value>Last updated: never</value>
   </data>
@@ -916,11 +679,8 @@ Path: {0}</value>
   <data name="Subscription_LastUpdated" xml:space="preserve">
     <value>Last updated: {0}</value>
   </data>
-  <data name="SystemProxy_RegError" xml:space="preserve">
-    <value>Cannot open registry key: </value>
-  </data>
   <data name="ControlPanel_EditPortItem.Text" xml:space="preserve">
-    <value>Local Port</value>
+    <value>Edit Port</value>
   </data>
   <data name="ControlPanel_ViewLogItem.Text" xml:space="preserve">
     <value>Logs</value>
@@ -929,10 +689,10 @@ Path: {0}</value>
     <value>Proxy Setting</value>
   </data>
   <data name="ControlPanel_GlobalProxyItem.Text" xml:space="preserve">
-    <value>Global Proxy</value>
+    <value>System Proxy</value>
   </data>
   <data name="ControlPanel_NoProxyItem.Text" xml:space="preserve">
-    <value>No Proxy Takeover</value>
+    <value>Bypass System Proxy</value>
   </data>
   <data name="ControlPanel_StartupItem.Text" xml:space="preserve">
     <value>Startup</value>
@@ -941,7 +701,7 @@ Path: {0}</value>
     <value>Routing</value>
   </data>
   <data name="ControlPanel_RoutingGlobalItem.Text" xml:space="preserve">
-    <value>Global </value>
+    <value>Global</value>
   </data>
   <data name="ControlPanel_RoutingSmartItem.Text" xml:space="preserve">
     <value>Smart</value>
@@ -958,7 +718,364 @@ Path: {0}</value>
   <data name="Personalize_LanguageLbl.Text" xml:space="preserve">
     <value>Language</value>
   </data>
-  <data name="Personalize_LanguageDescLbl.Text" xml:space="preserve">
-    <value>Choose the app display language</value>
+  <data name="ServerList_HeaderText.Text" xml:space="preserve">
+    <value>Server List</value>
+  </data>
+  <data name="ServerList_AddBtnText.Text" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ServerList_ImportNodeItem.Text" xml:space="preserve">
+    <value>Import Nodes</value>
+  </data>
+  <data name="ServerList_AddSubscriptionItem.Text" xml:space="preserve">
+    <value>Add Subscription</value>
+  </data>
+  <data name="ServerList_AddManualItem.Text" xml:space="preserve">
+    <value>Add Manually</value>
+  </data>
+  <data name="ServerList_AddChainProxyItem.Text" xml:space="preserve">
+    <value>Chain Proxy</value>
+  </data>
+  <data name="ServerList_EditText.Text" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="ServerList_DeleteText.Text" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="ServerList_SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search servers</value>
+  </data>
+  <data name="ServerList_FilterLabelText.Text" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="ServerList_SortDefaultItem.Text" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="ServerList_SortActiveItem.Text" xml:space="preserve">
+    <value>Active</value>
+  </data>
+  <data name="ServerList_SortProtocolItem.Text" xml:space="preserve">
+    <value>Protocol</value>
+  </data>
+  <data name="ServerList_ActivatedBadge.Text" xml:space="preserve">
+    <value>● Activated</value>
+  </data>
+  <data name="ServerList_ChainBadgeText.Text" xml:space="preserve">
+    <value>Chain Proxy</value>
+  </data>
+  <data name="ServerList_Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
+  <data name="ServerList_AddFavorite" xml:space="preserve">
+    <value>Add to Favorites</value>
+  </data>
+  <data name="ServerList_RemoveFavorite" xml:space="preserve">
+    <value>Remove from Favorites</value>
+  </data>
+  <data name="ServerList_FilterTooltip" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="ServerList_SortTooltip" xml:space="preserve">
+    <value>Sort</value>
+  </data>
+  <data name="Confirm_DeleteBatchMsg" xml:space="preserve">
+    <value>Are you sure you want to delete the selected {0} items?</value>
+  </data>
+  <data name="Subscription_UnknownError" xml:space="preserve">
+    <value>Unknown error</value>
+  </data>
+  <data name="ServerDetail_HeaderText.Text" xml:space="preserve">
+    <value>Server Details</value>
+  </data>
+  <data name="ServerDetail_NameLabel.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ServerDetail_ProtocolLabel.Text" xml:space="preserve">
+    <value>Protocol</value>
+  </data>
+  <data name="ServerDetail_TransportLabel.Text" xml:space="preserve">
+    <value>Transport</value>
+  </data>
+  <data name="ServerDetail_AiUnlockLabel.Text" xml:space="preserve">
+    <value>AI Unlock Status</value>
+  </data>
+  <data name="ServerDetail_LatencyLabel.Text" xml:space="preserve">
+    <value>Latency</value>
+  </data>
+  <data name="ServerDetail_Entry" xml:space="preserve">
+    <value>Entry</value>
+  </data>
+  <data name="ServerDetail_Exit" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="ServerDetail_EntryMissing" xml:space="preserve">
+    <value>(entry node missing)</value>
+  </data>
+  <data name="ServerDetail_ExitMissing" xml:space="preserve">
+    <value>(exit node missing)</value>
+  </data>
+  <data name="ServerDetail_AuthLabel" xml:space="preserve">
+    <value>Auth</value>
+  </data>
+  <data name="ServerDetail_ChainLabel" xml:space="preserve">
+    <value>Chain</value>
+  </data>
+  <data name="ServerDetail_NoAuth" xml:space="preserve">
+    <value>No auth</value>
+  </data>
+  <data name="ServerDetail_UserPass" xml:space="preserve">
+    <value>Username/Password</value>
+  </data>
+  <data name="ServerDetail_LatencyMs" xml:space="preserve">
+    <value>{0} ms</value>
+  </data>
+  <data name="MainWindow_TitleText.Text" xml:space="preserve">
+    <value>Proxy Panel</value>
+  </data>
+  <data name="CustomRules_RuleListText.Text" xml:space="preserve">
+    <value>Rules</value>
+  </data>
+  <data name="CustomRules_AddBtnText.Text" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="CustomRules_NotEffectiveText.Text" xml:space="preserve">
+    <value>Global routing is active — custom rules are not in effect. They will apply when switching back to Smart Routing.</value>
+  </data>
+  <data name="CustomRules_SaveBtn.Content" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="CustomRules_CancelBtn.Content" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="CustomRules_AdvancedEditorTooltip" xml:space="preserve">
+    <value>Advanced edit (open settings.json externally)</value>
+  </data>
+  <data name="CustomRules_EditRowTooltip" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="CustomRules_DeleteRowTooltip" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="CustomRules_PrepFailedTitle" xml:space="preserve">
+    <value>Could not prepare settings.json</value>
+  </data>
+  <data name="CustomRules_OpenEditorFailedTitle" xml:space="preserve">
+    <value>Could not open editor</value>
+  </data>
+  <data name="CustomRules_OpenEditorFailedMsg" xml:space="preserve">
+    <value>No .json file association or launch failed: {0}</value>
+  </data>
+  <data name="AddRule_TypeLabelText.Text" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="AddRule_TypeDomainItem.Content" xml:space="preserve">
+    <value>Domain</value>
+  </data>
+  <data name="AddRule_TypeProcessItem.Content" xml:space="preserve">
+    <value>Process</value>
+  </data>
+  <data name="AddRule_MatchLabelText.Text" xml:space="preserve">
+    <value>Match Content</value>
+  </data>
+  <data name="AddRule_BrowseNameItem.Content" xml:space="preserve">
+    <value>Match by name</value>
+  </data>
+  <data name="AddRule_BrowsePathItem.Content" xml:space="preserve">
+    <value>Match by full path</value>
+  </data>
+  <data name="AddRule_BrowseFolderItem.Content" xml:space="preserve">
+    <value>Match entire folder</value>
+  </data>
+  <data name="AddRule_OutboundLabelText.Text" xml:space="preserve">
+    <value>Outbound</value>
+  </data>
+  <data name="AddRule_OutboundProxyItem.Content" xml:space="preserve">
+    <value>proxy</value>
+  </data>
+  <data name="AddRule_OutboundDirectItem.Content" xml:space="preserve">
+    <value>direct</value>
+  </data>
+  <data name="AddRule_OutboundBlockItem.Content" xml:space="preserve">
+    <value>block</value>
+  </data>
+  <data name="AddRule_ErrorTextElem.Text" xml:space="preserve">
+    <value>Please enter match content</value>
+  </data>
+  <data name="AddRule_BrowseExe" xml:space="preserve">
+    <value>Browse exe...</value>
+  </data>
+  <data name="AddRule_BrowseFolder" xml:space="preserve">
+    <value>Browse folder...</value>
+  </data>
+  <data name="AddRule_PlaceholderDomain" xml:space="preserve">
+    <value>youtube.com or geosite:cn</value>
+  </data>
+  <data name="AddRule_PlaceholderIp" xml:space="preserve">
+    <value>192.168.0.0/16 or geoip:cn</value>
+  </data>
+  <data name="AddRule_PlaceholderProcess" xml:space="preserve">
+    <value>Type a process name / path / folder, or click Browse</value>
+  </data>
+  <data name="AddRule_HintDomain" xml:space="preserve">
+    <value>Supports exact match, regexp:, geosite: prefixes</value>
+  </data>
+  <data name="AddRule_HintIp" xml:space="preserve">
+    <value>Supports CIDR and geoip: prefixes</value>
+  </data>
+  <data name="AddRule_HintProcess" xml:space="preserve">
+    <value>By name: matches any exe with this name. By full path: matches only this exe. By folder: matches all exes under the folder.</value>
+  </data>
+  <data name="Personalize_AppLanguageTitle.Text" xml:space="preserve">
+    <value>Application language</value>
+  </data>
+  <data name="Personalize_AppLanguageDesc.Text" xml:space="preserve">
+    <value>Choose interface language</value>
+  </data>
+  <data name="Personalize_LangRestartBar.Title" xml:space="preserve">
+    <value>Restart XrayUI to apply  language changes</value>
+  </data>
+  <data name="Personalize_LangRestartBtn.Content" xml:space="preserve">
+    <value>Restart</value>
+  </data>
+  <data name="Personalize_ProtocolColorsDesc.Text" xml:space="preserve">
+    <value>Customize the color indicator for each protocol</value>
+  </data>
+  <data name="Personalize_DetailSettings.Text" xml:space="preserve">
+    <value>Detail Settings</value>
+  </data>
+  <data name="Personalize_DetailsHeader.Text" xml:space="preserve">
+    <value>Server info display</value>
+  </data>
+  <data name="Personalize_DetailsDesc.Text" xml:space="preserve">
+    <value>Choose what to show on the detail card</value>
+  </data>
+  <data name="Personalize_DetailLatency.Text" xml:space="preserve">
+    <value>Latency</value>
+  </data>
+  <data name="Personalize_DetailLatencyDesc.Text" xml:space="preserve">
+    <value>Show latency on the node card</value>
+  </data>
+  <data name="Personalize_DetailAiUnlock.Text" xml:space="preserve">
+    <value>AI Unlock</value>
+  </data>
+  <data name="Personalize_DetailAiUnlockDesc.Text" xml:space="preserve">
+    <value>Show AI unlock status on the node card</value>
+  </data>
+  <data name="Personalize_ImportExportTitle.Text" xml:space="preserve">
+    <value>Import &amp; Export Configuration</value>
+  </data>
+  <data name="Personalize_ImportExportDesc.Text" xml:space="preserve">
+    <value>Back up the current nodes and routing rules, or restore from a file</value>
+  </data>
+  <data name="Personalize_ExportBtn.Content" xml:space="preserve">
+    <value>Export</value>
+  </data>
+  <data name="Personalize_ImportBtn.Content" xml:space="preserve">
+    <value>Import</value>
+  </data>
+  <data name="Personalize_ExportTooltip" xml:space="preserve">
+    <value>Export preset configuration</value>
+  </data>
+  <data name="Personalize_ImportTooltip" xml:space="preserve">
+    <value>Import preset configuration</value>
+  </data>
+  <data name="Personalize_ExportSuccessMsgFmt" xml:space="preserve">
+    <value>Exported to {0}</value>
+  </data>
+  <data name="Personalize_ImportFailed" xml:space="preserve">
+    <value>Import failed</value>
+  </data>
+  <data name="Personalize_ImportSuccess" xml:space="preserve">
+    <value>Import successful</value>
+  </data>
+  <data name="Personalize_ImportSuccessMsg" xml:space="preserve">
+    <value>Imported {0} nodes, {1} subscriptions, {2} rules{3}.</value>
+  </data>
+  <data name="Personalize_ImportAdvancedSuffix" xml:space="preserve">
+    <value>, including advanced routing</value>
+  </data>
+  <data name="Personalize_PresetMissingTitle" xml:space="preserve">
+    <value>Preset files not found</value>
+  </data>
+  <data name="Personalize_PresetMissingMsg" xml:space="preserve">
+    <value>Please prepare servers.json / settings.json under the Import folder first.</value>
+  </data>
+  <data name="ChainProxy_NameLabel.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ChainProxy_NameBox.PlaceholderText" xml:space="preserve">
+    <value>Chain proxy name</value>
+  </data>
+  <data name="ChainProxy_EntryLabel.Text" xml:space="preserve">
+    <value>Entry proxy</value>
+  </data>
+  <data name="ChainProxy_EntryBox.PlaceholderText" xml:space="preserve">
+    <value>Select front node</value>
+  </data>
+  <data name="ChainProxy_ExitLabel.Text" xml:space="preserve">
+    <value>Exit proxy</value>
+  </data>
+  <data name="ChainProxy_ExitBox.PlaceholderText" xml:space="preserve">
+    <value>Select exit node</value>
+  </data>
+  <data name="ChainProxy_Hint.Text" xml:space="preserve">
+    <value>Traffic is forwarded through the entry proxy and routed out via the exit proxy</value>
+  </data>
+  <data name="ChainProxy_NameRequired" xml:space="preserve">
+    <value>Please enter a chain proxy name.</value>
+  </data>
+  <data name="ChainProxy_EntryRequired" xml:space="preserve">
+    <value>Please select an entry proxy.</value>
+  </data>
+  <data name="ChainProxy_ExitRequired" xml:space="preserve">
+    <value>Please select an exit proxy.</value>
+  </data>
+  <data name="ChainProxy_EntryExitSame" xml:space="preserve">
+    <value>Entry proxy and exit proxy cannot be the same node.</value>
+  </data>
+  <data name="Tun_MoreOptionsBtn.Content" xml:space="preserve">
+    <value>More options</value>
+  </data>
+  <data name="Tun_MtuLabel.Text" xml:space="preserve">
+    <value>Maximum transmission unit</value>
+  </data>
+  <data name="Tun_InterfaceLabel.Text" xml:space="preserve">
+    <value>Outbound interface</value>
+  </data>
+  <data name="Tun_InterfaceTooltip" xml:space="preserve">
+    <value>Xray picks automatically by default; only set this manually if auto mode is unavailable.</value>
+  </data>
+  <data name="Tun_AutoInterfaceLabel" xml:space="preserve">
+    <value>auto (recommended)</value>
+  </data>
+  <data name="Subscription_DialogTitle_Add" xml:space="preserve">
+    <value>Add Subscription</value>
+  </data>
+  <data name="Subscription_DialogTitle_Manage" xml:space="preserve">
+    <value>Manage Subscriptions</value>
+  </data>
+  <data name="Subscription_UrlBox.Header" xml:space="preserve">
+    <value>Subscription URL</value>
+  </data>
+  <data name="Subscription_NameBox.Header" xml:space="preserve">
+    <value>Name (optional)</value>
+  </data>
+  <data name="Subscription_NameBox.PlaceholderText" xml:space="preserve">
+    <value>Leave empty to use link domain</value>
+  </data>
+  <data name="Subscription_AutoImportHintText.Text" xml:space="preserve">
+    <value>All nodes from the subscription will be parsed and imported automatically</value>
+  </data>
+  <data name="Subscription_EmptyText.Text" xml:space="preserve">
+    <value>No subscriptions</value>
+  </data>
+  <data name="Subscription_DeleteConfirmText.Text" xml:space="preserve">
+    <value>Delete subscription?</value>
+  </data>
+  <data name="Subscription_DeleteDescText.Text" xml:space="preserve">
+    <value>All nodes under this subscription will also be deleted.</value>
+  </data>
+  <data name="Subscription_DeleteConfirmBtn.Content" xml:space="preserve">
+    <value>Delete</value>
   </data>
 </root>

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="_LocaleProbe" xml:space="preserve">
+    <value>en-US</value>
+    <comment>Sentinel — confirms the en-US resw is selected. Real keys land in commit 3.</comment>
+  </data>
+</root>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -1,37 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
                 <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
                 <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="xml:space" use="optional" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
@@ -46,20 +27,392 @@
       </xsd:complexType>
     </xsd:element>
   </xsd:schema>
-  <resheader name="resmimetype">
-    <value>text/microsoft-resx</value>
-  </resheader>
-  <resheader name="version">
-    <value>2.0</value>
-  </resheader>
-  <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <data name="_LocaleProbe" xml:space="preserve">
-    <value>zh-CN</value>
-    <comment>Sentinel — confirms the zh-CN resw is selected. Real keys land in commit 3.</comment>
-  </data>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       MainWindow
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="MainWindow_Title" xml:space="preserve"><value>代理控制台</value></data>
+  <data name="MainWindow_ToggleMini" xml:space="preserve"><value>切换mini窗口</value></data>
+  <data name="MainWindow_ExpandFull" xml:space="preserve"><value>返回完整窗口</value></data>
+  <data name="MainWindow_Close" xml:space="preserve"><value>关闭</value></data>
+  <data name="Tray_Open" xml:space="preserve"><value>打开窗口</value></data>
+  <data name="Tray_Exit" xml:space="preserve"><value>退出</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       ServerList
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="ServerList_Header" xml:space="preserve"><value>服务器列表</value></data>
+  <data name="ServerList_Add" xml:space="preserve"><value>添加</value></data>
+  <data name="ServerList_Edit" xml:space="preserve"><value>编辑</value></data>
+  <data name="ServerList_Delete" xml:space="preserve"><value>删除</value></data>
+  <data name="ServerList_Share" xml:space="preserve"><value>分享</value></data>
+  <data name="ServerList_ImportNode" xml:space="preserve"><value>导入节点</value></data>
+  <data name="ServerList_AddSubscription" xml:space="preserve"><value>添加订阅</value></data>
+  <data name="ServerList_AddManual" xml:space="preserve"><value>手动添加</value></data>
+  <data name="ServerList_SearchPlaceholder" xml:space="preserve"><value>搜索服务器</value></data>
+  <data name="ServerList_FilterLabel" xml:space="preserve"><value>筛选条件:</value></data>
+  <data name="ServerList_Filter" xml:space="preserve"><value>筛选</value></data>
+  <data name="ServerList_Sort" xml:space="preserve"><value>排序</value></data>
+  <data name="ServerList_SortDefault" xml:space="preserve"><value>默认</value></data>
+  <data name="ServerList_SortActive" xml:space="preserve"><value>当前连接</value></data>
+  <data name="ServerList_SortProtocol" xml:space="preserve"><value>协议</value></data>
+  <data name="ServerList_SortActiveHint" xml:space="preserve"><value>只在筛选为「所有服务器」时可用</value></data>
+  <data name="ServerList_AllServers" xml:space="preserve"><value>所有服务器</value></data>
+  <data name="ServerList_Ungrouped" xml:space="preserve"><value>未分组</value></data>
+  <data name="ServerList_UnnamedSub" xml:space="preserve"><value>(未命名订阅)</value></data>
+  <data name="ServerList_OrphanSub" xml:space="preserve"><value>(已删除订阅)</value></data>
+  <data name="ServerList_Activated" xml:space="preserve"><value>● 已连接</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       ControlPanel
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="ControlPanel_Start" xml:space="preserve"><value>启动</value></data>
+  <data name="ControlPanel_Stop" xml:space="preserve"><value>停止</value></data>
+  <data name="ControlPanel_StatusNotRunning" xml:space="preserve"><value>未运行</value></data>
+  <data name="ControlPanel_StatusApplying" xml:space="preserve"><value>正在应用...</value></data>
+  <data name="ControlPanel_Personalize" xml:space="preserve"><value>个性化</value></data>
+  <data name="ControlPanel_GitHub" xml:space="preserve"><value>GitHub</value></data>
+  <data name="ControlPanel_EditLocalPort" xml:space="preserve"><value>编辑本地端口</value></data>
+  <data name="ControlPanel_ViewLog" xml:space="preserve"><value>查看日志</value></data>
+  <data name="ControlPanel_ProxySettings" xml:space="preserve"><value>代理设置</value></data>
+  <data name="ControlPanel_GlobalProxy" xml:space="preserve"><value>全局代理</value></data>
+  <data name="ControlPanel_NoProxy" xml:space="preserve"><value>不接管代理</value></data>
+  <data name="ControlPanel_Startup" xml:space="preserve"><value>开机启动</value></data>
+  <data name="ControlPanel_RoutingSettings" xml:space="preserve"><value>路由设置</value></data>
+  <data name="ControlPanel_RoutingGlobal" xml:space="preserve"><value>全局路由</value></data>
+  <data name="ControlPanel_RoutingSmart" xml:space="preserve"><value>智能分流</value></data>
+  <data name="ControlPanel_CustomRules" xml:space="preserve"><value>自定义规则...</value></data>
+  <data name="ControlPanel_TunMode" xml:space="preserve"><value>TUN 模式</value></data>
+  <data name="ControlPanel_RoutingLabel" xml:space="preserve"><value>路由:</value></data>
+  <data name="ControlPanel_UpdateFound" xml:space="preserve"><value>发现新版本 {0}</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       ServerDetail
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="ServerDetail_Header" xml:space="preserve"><value>服务器详情</value></data>
+  <data name="ServerDetail_Name" xml:space="preserve"><value>名称</value></data>
+  <data name="ServerDetail_Protocol" xml:space="preserve"><value>协议</value></data>
+  <data name="ServerDetail_Address" xml:space="preserve"><value>地址</value></data>
+  <data name="ServerDetail_Port" xml:space="preserve"><value>端口</value></data>
+  <data name="ServerDetail_Transport" xml:space="preserve"><value>传输</value></data>
+  <data name="ServerDetail_Encryption" xml:space="preserve"><value>加密</value></data>
+  <data name="ServerDetail_Security" xml:space="preserve"><value>安全</value></data>
+  <data name="ServerDetail_AiUnlock" xml:space="preserve"><value>AI 访问解锁</value></data>
+  <data name="ServerDetail_OpenInBrowser" xml:space="preserve"><value>在浏览器中打开 {0}</value></data>
+  <data name="ServerDetail_Latency" xml:space="preserve"><value>网络延迟</value></data>
+  <data name="ServerDetail_RetestLatency" xml:space="preserve"><value>重新测试延迟</value></data>
+  <data name="ServerDetail_CopyShareLink" xml:space="preserve"><value>复制分享链接</value></data>
+  <data name="ServerDetail_NoServer" xml:space="preserve"><value>未选择服务器</value></data>
+  <data name="ServerDetail_NotTested" xml:space="preserve"><value>未测试</value></data>
+  <data name="ServerDetail_Testing" xml:space="preserve"><value>测试中...</value></data>
+  <data name="ServerDetail_Timeout" xml:space="preserve"><value>超时</value></data>
+  <data name="ServerDetail_Failed" xml:space="preserve"><value>失败</value></data>
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       Personalize
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="Personalize_Header.Text" xml:space="preserve"><value>个性化设置</value></data>
+  <data name="Personalize_Theme.Text" xml:space="preserve"><value>主题</value></data>
+  <data name="Personalize_ThemeDesc.Text" xml:space="preserve"><value>选择应用的外观模式</value></data>
+  <data name="Personalize_Light.Content" xml:space="preserve"><value>浅色</value></data>
+  <data name="Personalize_Dark.Content" xml:space="preserve"><value>深色</value></data>
+  <data name="Personalize_FollowSystem.Content" xml:space="preserve"><value>跟随系统</value></data>
+  <data name="Personalize_Backdrop.Text" xml:space="preserve"><value>背景效果</value></data>
+  <data name="Personalize_BackdropDesc.Text" xml:space="preserve"><value>选择窗口背景材质</value></data>
+  <data name="Personalize_Acrylic.Content" xml:space="preserve"><value>亚克力</value></data>
+  <data name="Personalize_ProtocolColors.Text" xml:space="preserve"><value>协议颜色</value></data>
+  <data name="Personalize_Reset.Text" xml:space="preserve"><value>重置</value></data>
+  <data name="Personalize_OtherProtocol.Text" xml:space="preserve"><value>其他协议</value></data>
+  <data name="Personalize_OtherProtocolDesc.Text" xml:space="preserve"><value>未匹配的协议将使用此颜色</value></data>
+  <data name="Personalize_DataManagement.Text" xml:space="preserve"><value>数据管理</value></data>
+  <data name="Personalize_ExportConfig.Text" xml:space="preserve"><value>导出配置</value></data>
+  <data name="Personalize_Export.Text" xml:space="preserve"><value>导出</value></data>
+  <data name="Personalize_Done.Content" xml:space="preserve"><value>完成</value></data>
+  <data name="Personalize_ExportSuccess" xml:space="preserve"><value>导出成功</value></data>
+  <data name="Personalize_ExportSuccessMsg" xml:space="preserve"><value>已导出至Import文件夹。</value></data>
+  <data name="Personalize_Language" xml:space="preserve"><value>语言</value></data>
+  <data name="Personalize_LanguageDesc" xml:space="preserve"><value>选择应用的显示语言</value></data>
+  <data name="Personalize_RestartRequired" xml:space="preserve"><value>切换语言需要重启应用</value></data>
+  <data name="Personalize_RestartNow" xml:space="preserve"><value>立即重启</value></data>
+  <data name="Personalize_RestartLater" xml:space="preserve"><value>稍后</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       Subscriptions
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="Subscription_AddTooltip" xml:space="preserve"><value>添加订阅</value></data>
+  <data name="Subscription_ManageTooltip" xml:space="preserve"><value>管理订阅</value></data>
+  <data name="Subscription_LinkHeader" xml:space="preserve"><value>订阅链接</value></data>
+  <data name="Subscription_NameHeader" xml:space="preserve"><value>备注名称（可选）</value></data>
+  <data name="Subscription_NamePlaceholder" xml:space="preserve"><value>留空则使用链接域名</value></data>
+  <data name="Subscription_AutoImportHint" xml:space="preserve"><value>将自动拉取并导入订阅中的全部节点</value></data>
+  <data name="Subscription_Empty" xml:space="preserve"><value>暂无订阅</value></data>
+  <data name="Subscription_Refresh" xml:space="preserve"><value>刷新订阅</value></data>
+  <data name="Subscription_DeleteTooltip" xml:space="preserve"><value>删除订阅</value></data>
+  <data name="Subscription_DeleteConfirm" xml:space="preserve"><value>删除订阅？</value></data>
+  <data name="Subscription_DeleteDesc" xml:space="preserve"><value>将同时删除该订阅下的所有节点。</value></data>
+  <data name="Subscription_FetchFailed" xml:space="preserve"><value>订阅拉取失败</value></data>
+  <data name="Subscription_NoParsed" xml:space="preserve"><value>未能从订阅中解析出任何有效节点。</value></data>
+  <data name="Subscription_StopFirst_Refresh" xml:space="preserve"><value>请先停止代理后再刷新</value></data>
+  <data name="Subscription_UpdateFailed" xml:space="preserve"><value>更新失败: {0}</value></data>
+  <data name="Subscription_StopFirst_Delete" xml:space="preserve"><value>请先停止代理后再删除</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       CustomRules
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="CustomRules_Title" xml:space="preserve"><value>自定义路由规则</value></data>
+  <data name="CustomRules_RuleList" xml:space="preserve"><value>规则列表</value></data>
+  <data name="CustomRules_UpdateGeoTooltip" xml:space="preserve"><value>更新geoFile路由数据</value></data>
+  <data name="CustomRules_Add" xml:space="preserve"><value>添加</value></data>
+  <data name="CustomRules_Save" xml:space="preserve"><value>保存</value></data>
+  <data name="CustomRules_Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="CustomRules_EditTooltip" xml:space="preserve"><value>编辑</value></data>
+  <data name="CustomRules_DeleteTooltip" xml:space="preserve"><value>删除</value></data>
+  <data name="CustomRules_NotEffective" xml:space="preserve"><value>当前为全局路由模式，自定义规则不生效。切回智能分流后自动启用。</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       AddRuleDialog
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="AddRule_Title" xml:space="preserve"><value>添加规则</value></data>
+  <data name="AddRule_Add" xml:space="preserve"><value>添加</value></data>
+  <data name="AddRule_TypeLabel" xml:space="preserve"><value>类型</value></data>
+  <data name="AddRule_TypeDomain" xml:space="preserve"><value>域名（Domain）</value></data>
+  <data name="AddRule_MatchLabel" xml:space="preserve"><value>匹配内容</value></data>
+  <data name="AddRule_MatchHint" xml:space="preserve"><value>支持精确匹配、regexp:、geosite:、geoip: 前缀</value></data>
+  <data name="AddRule_OutboundLabel" xml:space="preserve"><value>出站</value></data>
+  <data name="AddRule_OutboundProxy" xml:space="preserve"><value>proxy（代理）</value></data>
+  <data name="AddRule_OutboundDirect" xml:space="preserve"><value>direct（直连）</value></data>
+  <data name="AddRule_OutboundBlock" xml:space="preserve"><value>block（阻断）</value></data>
+  <data name="AddRule_ErrorEmpty" xml:space="preserve"><value>请填写匹配内容</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       LogWindow
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="Log_Title" xml:space="preserve"><value>代理日志</value></data>
+  <data name="Log_NotRunning" xml:space="preserve"><value>未运行</value></data>
+  <data name="Log_Running" xml:space="preserve"><value>运行中</value></data>
+  <data name="Log_Lines" xml:space="preserve"><value>({0} 行)</value></data>
+  <data name="Log_PrivacyTooltip" xml:space="preserve"><value>日志隐私设置</value></data>
+  <data name="Log_IpMask" xml:space="preserve"><value>IP地址遮罩</value></data>
+  <data name="Log_MaskOff" xml:space="preserve"><value>关闭</value></data>
+  <data name="Log_AutoScroll" xml:space="preserve"><value>自动滚动</value></data>
+  <data name="Log_CopyAll" xml:space="preserve"><value>复制全部</value></data>
+  <data name="Log_Clear" xml:space="preserve"><value>清除</value></data>
+  <data name="Log_PrivacyTitle" xml:space="preserve"><value>日志隐私设置</value></data>
+  <data name="Log_PrivacySaved" xml:space="preserve"><value>已保存，当前 TUN 会话下次启动时生效。</value></data>
+  <data name="Log_PrivacyFailed" xml:space="preserve"><value>保存失败：{0}</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       Dialogs (DialogService)
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="Dialog_OK" xml:space="preserve"><value>确定</value></data>
+  <data name="Dialog_Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="Dialog_Save" xml:space="preserve"><value>保存</value></data>
+  <data name="Dialog_Done" xml:space="preserve"><value>完成</value></data>
+  <data name="Dialog_Confirm" xml:space="preserve"><value>确认</value></data>
+  <data name="Dialog_Add" xml:space="preserve"><value>添加</value></data>
+  <data name="Dialog_Delete" xml:space="preserve"><value>删除</value></data>
+  <data name="Dialog_Replace" xml:space="preserve"><value>替换</value></data>
+  <data name="Dialog_Preparing" xml:space="preserve"><value>正在准备…</value></data>
+  <data name="Dialog_On" xml:space="preserve"><value>开</value></data>
+  <data name="Dialog_Off" xml:space="preserve"><value>关</value></data>
+
+  <!-- Import link dialog -->
+  <data name="Import_Placeholder" xml:space="preserve"><value>粘贴节点链接（支持多协议）</value></data>
+  <data name="Import_Title" xml:space="preserve"><value>导入节点链接</value></data>
+  <data name="Import_SupportHint" xml:space="preserve"><value>支持常见协议链接</value></data>
+  <data name="Import_ParseFailed" xml:space="preserve"><value>解析失败</value></data>
+  <data name="Import_ParseFailedMsg" xml:space="preserve"><value>无法识别有效的节点链接，请检查后重试。</value></data>
+
+  <!-- Edit server dialog -->
+  <data name="EditServer_AddTitle" xml:space="preserve"><value>手动添加服务器</value></data>
+  <data name="EditServer_EditTitle" xml:space="preserve"><value>编辑服务器</value></data>
+  <data name="EditServer_Name" xml:space="preserve"><value>名称</value></data>
+  <data name="EditServer_Address" xml:space="preserve"><value>地址 / 域名</value></data>
+  <data name="EditServer_Port" xml:space="preserve"><value>端口</value></data>
+  <data name="EditServer_Protocol" xml:space="preserve"><value>协议</value></data>
+  <data name="EditServer_Encryption" xml:space="preserve"><value>加密方式 (SS)</value></data>
+  <data name="EditServer_Password" xml:space="preserve"><value>密码</value></data>
+  <data name="EditServer_UUID" xml:space="preserve"><value>UUID (VMess / VLESS)</value></data>
+  <data name="EditServer_AlterId" xml:space="preserve"><value>AlterId (VMess)</value></data>
+  <data name="EditServer_Transport" xml:space="preserve"><value>传输协议</value></data>
+  <data name="EditServer_Path" xml:space="preserve"><value>路径 (WS/gRPC/XHTTP)</value></data>
+  <data name="EditServer_WsHost" xml:space="preserve"><value>Host 头 (WS/XHTTP)</value></data>
+  <data name="EditServer_Security" xml:space="preserve"><value>安全</value></data>
+  <data name="EditServer_Fingerprint" xml:space="preserve"><value>指纹 (uTLS)</value></data>
+  <data name="EditServer_AllowInsecure" xml:space="preserve"><value>允许不安全连接（跳过证书校验）</value></data>
+  <data name="EditServer_FlowPlaceholder" xml:space="preserve"><value>xtls-rprx-vision 或留空</value></data>
+
+  <!-- Edit local port dialog -->
+  <data name="EditPort_Title" xml:space="preserve"><value>编辑本地端口</value></data>
+  <data name="EditPort_Header" xml:space="preserve"><value>本地端口</value></data>
+  <data name="EditPort_Range" xml:space="preserve"><value>有效范围：{0} - {1}</value></data>
+
+  <!-- Share link dialog -->
+  <data name="Share_Title" xml:space="preserve"><value>分享节点</value></data>
+  <data name="Share_CopyLink" xml:space="preserve"><value>复制链接</value></data>
+  <data name="Share_NotSupported" xml:space="preserve"><value>不支持分享</value></data>
+  <data name="Share_NotSupportedMsg" xml:space="preserve"><value>该节点协议暂不支持生成分享链接。</value></data>
+
+  <!-- Startup dialog -->
+  <data name="Startup_Title" xml:space="preserve"><value>开机启动</value></data>
+  <data name="Startup_AutoStart" xml:space="preserve"><value>开机自动启动</value></data>
+  <data name="Startup_AutoConnect" xml:space="preserve"><value>自动连接上次节点</value></data>
+  <data name="Startup_SetFailed" xml:space="preserve"><value>开机启动设置失败</value></data>
+
+  <!-- Confirmation dialog -->
+  <data name="Confirm_DeleteTitle" xml:space="preserve"><value>确认删除</value></data>
+  <data name="Confirm_DeleteMsg" xml:space="preserve"><value>确定要删除 {0}?</value></data>
+  <data name="Confirm_ReplaceTitle" xml:space="preserve"><value>替换当前配置?</value></data>
+  <data name="Confirm_ReplaceMsg" xml:space="preserve"><value>此操作将覆盖您当前的全部节点和路由规则,强烈建议先导出备份。是否继续?</value></data>
+
+  <!-- Edit server dialog: extra fields not yet localized in the stash -->
+  <data name="EditServer_SocksUsername" xml:space="preserve"><value>用户名 (SOCKS)</value></data>
+  <data name="EditServer_EchPlaceholder" xml:space="preserve"><value>例如 udp://1.1.1.1 或服务端生成的 ECHConfig</value></data>
+  <data name="EditServer_FinalmaskPlaceholder" xml:space="preserve"><value>留空 = none;或 mlkem768x25519plus.native.0rtt....</value></data>
+
+  <!-- Chain proxy dialog -->
+  <data name="ChainProxy_AddTitle" xml:space="preserve"><value>链式代理</value></data>
+  <data name="ChainProxy_EditTitle" xml:space="preserve"><value>编辑链式代理</value></data>
+
+  <!-- DNS settings dialog -->
+  <data name="Dns_DialogTitle" xml:space="preserve"><value>DNS 设置</value></data>
+  <data name="ControlPanel_DnsItem.Text" xml:space="preserve"><value>DNS设置</value></data>
+  <data name="Dns_ResetDefaults" xml:space="preserve"><value>重置默认</value></data>
+  <data name="Dns_ServerPlaceholder" xml:space="preserve"><value>输入 IP 或 DoH 地址 (留空为自动)</value></data>
+  <data name="Dns_QueryStrategyLabel" xml:space="preserve"><value>查询策略</value></data>
+  <data name="Dns_EnableCacheLabel" xml:space="preserve"><value>启用 DNS 缓存</value></data>
+  <data name="Dns_DirectTitle" xml:space="preserve"><value>直连 DNS</value></data>
+  <data name="Dns_DirectDesc" xml:space="preserve"><value>用于国内域名 (geosite:cn)，走直连出站解析</value></data>
+  <data name="Dns_ProxyTitle" xml:space="preserve"><value>代理 DNS</value></data>
+  <data name="Dns_ProxyDesc" xml:space="preserve"><value>用于境外域名，经代理出站解析，防止 DNS 污染</value></data>
+  <data name="Dns_TunOnlyHint" xml:space="preserve"><value>仅TUN模式有效</value></data>
+  <data name="Dns_Experimental" xml:space="preserve"><value>实验性</value></data>
+  <data name="Dns_Provider_Ali" xml:space="preserve"><value>阿里</value></data>
+  <data name="Dns_Provider_Tencent" xml:space="preserve"><value>腾讯</value></data>
+  <data name="Dns_Provider_Google" xml:space="preserve"><value>谷歌</value></data>
+  <data name="Dns_Strategy_V4Only" xml:space="preserve"><value>仅 IPv4</value></data>
+  <data name="Dns_Strategy_V6Only" xml:space="preserve"><value>仅 IPv6</value></data>
+  <data name="Dns_Strategy_Auto" xml:space="preserve"><value>自动</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       ControlPanel ViewModel
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="Error_NoServer" xml:space="preserve"><value>未选择服务器</value></data>
+  <data name="Error_NoServerMsg" xml:space="preserve"><value>请先从列表中选择服务器</value></data>
+  <data name="Error_StartFailed" xml:space="preserve"><value>启动失败</value></data>
+  <data name="Error_XrayStartFailed" xml:space="preserve"><value>xray 启动失败. 请检查服务器配置.</value></data>
+  <data name="Error_ReapplyFailed" xml:space="preserve"><value>应用新配置失败</value></data>
+  <data name="Error_XrayReapplyFailed" xml:space="preserve"><value>xray 应用新配置失败，已停止。</value></data>
+  <data name="Error_UpdateFailed" xml:space="preserve"><value>更新失败</value></data>
+  <data name="Error_UpdaterLaunchFailed" xml:space="preserve"><value>无法启动升级器：{0}</value></data>
+  <data name="Update_Updating" xml:space="preserve"><value>正在更新 XrayUI</value></data>
+
+  <!-- TUN mode -->
+  <data name="Tun_EnableTitle" xml:space="preserve"><value>开启TUN模式</value></data>
+  <data name="Tun_EnableMsg" xml:space="preserve"><value>开启 TUN 模式需要管理员权限，程序将会重启，是否继续？</value></data>
+
+  <!-- MainViewModel -->
+  <data name="Main_NoSelection" xml:space="preserve"><value>未选择</value></data>
+  <data name="Main_NotConnected" xml:space="preserve"><value>未连接</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       CopyButton
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="CopyButton_Tooltip" xml:space="preserve"><value>复制到剪贴板</value></data>
+  <data name="CopyButton_Copied" xml:space="preserve"><value>已复制到剪贴板</value></data>
+
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       GeoData Update
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="GeoUpdate_Updating" xml:space="preserve"><value>正在更新路由数据</value></data>
+  <data name="GeoUpdate_AlreadyLatest" xml:space="preserve"><value>已是最新</value></data>
+  <data name="GeoUpdate_AlreadyLatestMsg" xml:space="preserve"><value>geoip.dat 和 geosite.dat 都已是最新版本，无需下载。</value></data>
+  <data name="GeoUpdate_Success" xml:space="preserve"><value>更新成功</value></data>
+  <data name="GeoUpdate_TunRestart" xml:space="preserve"><value>已更新。TUN 模式下请手动重启以生效。</value></data>
+  <data name="GeoUpdate_ReloadedOk" xml:space="preserve"><value>已更新并重新加载 xray。</value></data>
+  <data name="GeoUpdate_ReloadFailed" xml:space="preserve"><value>已更新数据文件，但重启 xray 失败：{0}</value></data>
+  <data name="GeoUpdate_RestartRequired" xml:space="preserve"><value>已更新。请重启 xray 以生效。</value></data>
+  <data name="GeoUpdate_NextStart" xml:space="preserve"><value>已更新。下次启动 xray 时生效。</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       XrayService (Log messages)
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="Xray_NotFound" xml:space="preserve"><value>找不到 xray.exe
+路径：{0}</value></data>
+  <data name="Xray_LogError" xml:space="preserve"><value>[错误]</value></data>
+  <data name="Xray_ProcessExited" xml:space="preserve"><value>[xray 进程已退出]</value></data>
+  <data name="Xray_LogStart" xml:space="preserve"><value>[启动]</value></data>
+  <data name="Xray_LogConfig" xml:space="preserve"><value>[配置]</value></data>
+  <data name="Xray_ImmediateExit" xml:space="preserve"><value>xray 立即退出（退出码 {0}）</value></data>
+  <data name="Xray_LogStartFailed" xml:space="preserve"><value>[错误] 启动失败：</value></data>
+  <data name="Xray_LogException" xml:space="preserve"><value>[异常]</value></data>
+  <data name="Xray_LogStopped" xml:space="preserve"><value>[已停止]</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       UpdateService
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="Update_FetchingChecksum" xml:space="preserve"><value>正在获取校验文件…</value></data>
+  <data name="Update_ChecksumFormatError" xml:space="preserve"><value>更新校验文件格式异常</value></data>
+  <data name="Update_ChecksumDownloadFailed" xml:space="preserve"><value>无法下载更新校验文件：</value></data>
+  <data name="Update_ChecksumMismatch" xml:space="preserve"><value>更新包校验失败：SHA256 与服务器公布的不一致。</value></data>
+  <data name="Update_Extracting" xml:space="preserve"><value>正在解压更新包…</value></data>
+  <data name="Update_ExtractFailed" xml:space="preserve"><value>更新包解压失败：</value></data>
+  <data name="Update_Verifying" xml:space="preserve"><value>正在验证更新包…</value></data>
+  <data name="Update_MissingFiles" xml:space="preserve"><value>更新包内容异常：缺少必要文件。</value></data>
+  <data name="Update_VersionMismatch" xml:space="preserve"><value>更新包版本不匹配：期望 {0}，实际 {1}。</value></data>
+  <data name="Update_MissingUpdater" xml:space="preserve"><value>缺少升级器组件，请重新下载完整安装包。</value></data>
+  <data name="Update_PrepRestart" xml:space="preserve"><value>正在准备重启…</value></data>
+  <data name="Update_Downloading" xml:space="preserve"><value>正在下载 {0} … {1:0.0} / {2:0.0} MB</value></data>
+  <data name="Update_DownloadingNoTotal" xml:space="preserve"><value>正在下载 {0} … {1:0.0} MB</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       AddRuleDialog
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <data name="AddRule_EditTitle" xml:space="preserve"><value>编辑规则</value></data>
+
+  <!-- Personalize export error -->
+  <data name="Error_ExportFailed" xml:space="preserve"><value>导出失败</value></data>
+
+  <!-- GeoUpdate progress -->
+  <data name="GeoUpdate_ViaProxy" xml:space="preserve"><value>通过本地代理下载（{0}）…</value></data>
+  <data name="GeoUpdate_Checking" xml:space="preserve"><value>正在检查 {0}.dat …</value></data>
+  <data name="GeoUpdate_UpToDate" xml:space="preserve"><value>{0}.dat 已是最新</value></data>
+  <data name="GeoUpdate_ChecksumFailed" xml:space="preserve"><value>{0}.dat 校验失败：下载文件的 SHA256 与服务器公布的不一致。</value></data>
+
+  <!-- Subscription relative time -->
+  <data name="Subscription_NeverUpdated" xml:space="preserve"><value>上次更新: 从未更新</value></data>
+  <data name="Subscription_JustNow" xml:space="preserve"><value>刚刚</value></data>
+  <data name="Subscription_MinutesAgo" xml:space="preserve"><value>{0} 分钟前</value></data>
+  <data name="Subscription_HoursAgo" xml:space="preserve"><value>{0} 小时前</value></data>
+  <data name="Subscription_DaysAgo" xml:space="preserve"><value>{0} 天前</value></data>
+  <data name="Subscription_LastUpdated" xml:space="preserve"><value>上次更新: {0}</value></data>
+
+  <!-- SystemProxy -->
+  <data name="SystemProxy_RegError" xml:space="preserve"><value>无法打开注册表项：</value></data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       x:Uid entries for XAML (key = x:Uid + "." + PropertyName)
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- ControlPanel XAML -->
+  <data name="ControlPanel_EditPortItem.Text" xml:space="preserve"><value>编辑本地端口</value></data>
+  <data name="ControlPanel_ViewLogItem.Text" xml:space="preserve"><value>查看日志</value></data>
+  <data name="ControlPanel_ProxySettingsItem.Text" xml:space="preserve"><value>代理设置</value></data>
+  <data name="ControlPanel_GlobalProxyItem.Text" xml:space="preserve"><value>全局代理</value></data>
+  <data name="ControlPanel_NoProxyItem.Text" xml:space="preserve"><value>不接管代理</value></data>
+  <data name="ControlPanel_StartupItem.Text" xml:space="preserve"><value>开机启动</value></data>
+  <data name="ControlPanel_RoutingSettingsItem.Text" xml:space="preserve"><value>路由设置</value></data>
+  <data name="ControlPanel_RoutingGlobalItem.Text" xml:space="preserve"><value>全局路由</value></data>
+  <data name="ControlPanel_RoutingSmartItem.Text" xml:space="preserve"><value>智能分流</value></data>
+  <data name="ControlPanel_CustomRulesItem.Text" xml:space="preserve"><value>自定义规则...</value></data>
+  <data name="ControlPanel_TunModeLabel.Text" xml:space="preserve"><value>TUN 模式</value></data>
+  <data name="ControlPanel_RoutingLbl.Text" xml:space="preserve"><value>路由:</value></data>
+
+  <!-- Personalize Language -->
+  <data name="Personalize_LanguageLbl.Text" xml:space="preserve"><value>语言</value></data>
+  <data name="Personalize_LanguageDescLbl.Text" xml:space="preserve"><value>选择应用的显示语言</value></data>
+
 </root>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="_LocaleProbe" xml:space="preserve">
+    <value>zh-CN</value>
+    <comment>Sentinel — confirms the zh-CN resw is selected. Real keys land in commit 3.</comment>
+  </data>
+</root>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -1,18 +1,96 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
                 <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
                 <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="xml:space" use="optional" />
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
@@ -27,392 +105,977 @@
       </xsd:complexType>
     </xsd:element>
   </xsd:schema>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       MainWindow
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="MainWindow_Title" xml:space="preserve"><value>代理控制台</value></data>
-  <data name="MainWindow_ToggleMini" xml:space="preserve"><value>切换mini窗口</value></data>
-  <data name="MainWindow_ExpandFull" xml:space="preserve"><value>返回完整窗口</value></data>
-  <data name="MainWindow_Close" xml:space="preserve"><value>关闭</value></data>
-  <data name="Tray_Open" xml:space="preserve"><value>打开窗口</value></data>
-  <data name="Tray_Exit" xml:space="preserve"><value>退出</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       ServerList
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="ServerList_Header" xml:space="preserve"><value>服务器列表</value></data>
-  <data name="ServerList_Add" xml:space="preserve"><value>添加</value></data>
-  <data name="ServerList_Edit" xml:space="preserve"><value>编辑</value></data>
-  <data name="ServerList_Delete" xml:space="preserve"><value>删除</value></data>
-  <data name="ServerList_Share" xml:space="preserve"><value>分享</value></data>
-  <data name="ServerList_ImportNode" xml:space="preserve"><value>导入节点</value></data>
-  <data name="ServerList_AddSubscription" xml:space="preserve"><value>添加订阅</value></data>
-  <data name="ServerList_AddManual" xml:space="preserve"><value>手动添加</value></data>
-  <data name="ServerList_SearchPlaceholder" xml:space="preserve"><value>搜索服务器</value></data>
-  <data name="ServerList_FilterLabel" xml:space="preserve"><value>筛选条件:</value></data>
-  <data name="ServerList_Filter" xml:space="preserve"><value>筛选</value></data>
-  <data name="ServerList_Sort" xml:space="preserve"><value>排序</value></data>
-  <data name="ServerList_SortDefault" xml:space="preserve"><value>默认</value></data>
-  <data name="ServerList_SortActive" xml:space="preserve"><value>当前连接</value></data>
-  <data name="ServerList_SortProtocol" xml:space="preserve"><value>协议</value></data>
-  <data name="ServerList_SortActiveHint" xml:space="preserve"><value>只在筛选为「所有服务器」时可用</value></data>
-  <data name="ServerList_AllServers" xml:space="preserve"><value>所有服务器</value></data>
-  <data name="ServerList_Ungrouped" xml:space="preserve"><value>未分组</value></data>
-  <data name="ServerList_UnnamedSub" xml:space="preserve"><value>(未命名订阅)</value></data>
-  <data name="ServerList_OrphanSub" xml:space="preserve"><value>(已删除订阅)</value></data>
-  <data name="ServerList_Activated" xml:space="preserve"><value>● 已连接</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       ControlPanel
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="ControlPanel_Start" xml:space="preserve"><value>启动</value></data>
-  <data name="ControlPanel_Stop" xml:space="preserve"><value>停止</value></data>
-  <data name="ControlPanel_StatusNotRunning" xml:space="preserve"><value>未运行</value></data>
-  <data name="ControlPanel_StatusApplying" xml:space="preserve"><value>正在应用...</value></data>
-  <data name="ControlPanel_Personalize" xml:space="preserve"><value>个性化</value></data>
-  <data name="ControlPanel_GitHub" xml:space="preserve"><value>GitHub</value></data>
-  <data name="ControlPanel_EditLocalPort" xml:space="preserve"><value>编辑本地端口</value></data>
-  <data name="ControlPanel_ViewLog" xml:space="preserve"><value>查看日志</value></data>
-  <data name="ControlPanel_ProxySettings" xml:space="preserve"><value>代理设置</value></data>
-  <data name="ControlPanel_GlobalProxy" xml:space="preserve"><value>全局代理</value></data>
-  <data name="ControlPanel_NoProxy" xml:space="preserve"><value>不接管代理</value></data>
-  <data name="ControlPanel_Startup" xml:space="preserve"><value>开机启动</value></data>
-  <data name="ControlPanel_RoutingSettings" xml:space="preserve"><value>路由设置</value></data>
-  <data name="ControlPanel_RoutingGlobal" xml:space="preserve"><value>全局路由</value></data>
-  <data name="ControlPanel_RoutingSmart" xml:space="preserve"><value>智能分流</value></data>
-  <data name="ControlPanel_CustomRules" xml:space="preserve"><value>自定义规则...</value></data>
-  <data name="ControlPanel_TunMode" xml:space="preserve"><value>TUN 模式</value></data>
-  <data name="ControlPanel_RoutingLabel" xml:space="preserve"><value>路由:</value></data>
-  <data name="ControlPanel_UpdateFound" xml:space="preserve"><value>发现新版本 {0}</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       ServerDetail
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="ServerDetail_Header" xml:space="preserve"><value>服务器详情</value></data>
-  <data name="ServerDetail_Name" xml:space="preserve"><value>名称</value></data>
-  <data name="ServerDetail_Protocol" xml:space="preserve"><value>协议</value></data>
-  <data name="ServerDetail_Address" xml:space="preserve"><value>地址</value></data>
-  <data name="ServerDetail_Port" xml:space="preserve"><value>端口</value></data>
-  <data name="ServerDetail_Transport" xml:space="preserve"><value>传输</value></data>
-  <data name="ServerDetail_Encryption" xml:space="preserve"><value>加密</value></data>
-  <data name="ServerDetail_Security" xml:space="preserve"><value>安全</value></data>
-  <data name="ServerDetail_AiUnlock" xml:space="preserve"><value>AI 访问解锁</value></data>
-  <data name="ServerDetail_OpenInBrowser" xml:space="preserve"><value>在浏览器中打开 {0}</value></data>
-  <data name="ServerDetail_Latency" xml:space="preserve"><value>网络延迟</value></data>
-  <data name="ServerDetail_RetestLatency" xml:space="preserve"><value>重新测试延迟</value></data>
-  <data name="ServerDetail_CopyShareLink" xml:space="preserve"><value>复制分享链接</value></data>
-  <data name="ServerDetail_NoServer" xml:space="preserve"><value>未选择服务器</value></data>
-  <data name="ServerDetail_NotTested" xml:space="preserve"><value>未测试</value></data>
-  <data name="ServerDetail_Testing" xml:space="preserve"><value>测试中...</value></data>
-  <data name="ServerDetail_Timeout" xml:space="preserve"><value>超时</value></data>
-  <data name="ServerDetail_Failed" xml:space="preserve"><value>失败</value></data>
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       Personalize
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="Personalize_Header.Text" xml:space="preserve"><value>个性化设置</value></data>
-  <data name="Personalize_Theme.Text" xml:space="preserve"><value>主题</value></data>
-  <data name="Personalize_ThemeDesc.Text" xml:space="preserve"><value>选择应用的外观模式</value></data>
-  <data name="Personalize_Light.Content" xml:space="preserve"><value>浅色</value></data>
-  <data name="Personalize_Dark.Content" xml:space="preserve"><value>深色</value></data>
-  <data name="Personalize_FollowSystem.Content" xml:space="preserve"><value>跟随系统</value></data>
-  <data name="Personalize_Backdrop.Text" xml:space="preserve"><value>背景效果</value></data>
-  <data name="Personalize_BackdropDesc.Text" xml:space="preserve"><value>选择窗口背景材质</value></data>
-  <data name="Personalize_Acrylic.Content" xml:space="preserve"><value>亚克力</value></data>
-  <data name="Personalize_ProtocolColors.Text" xml:space="preserve"><value>协议颜色</value></data>
-  <data name="Personalize_Reset.Text" xml:space="preserve"><value>重置</value></data>
-  <data name="Personalize_OtherProtocol.Text" xml:space="preserve"><value>其他协议</value></data>
-  <data name="Personalize_OtherProtocolDesc.Text" xml:space="preserve"><value>未匹配的协议将使用此颜色</value></data>
-  <data name="Personalize_DataManagement.Text" xml:space="preserve"><value>数据管理</value></data>
-  <data name="Personalize_ExportConfig.Text" xml:space="preserve"><value>导出配置</value></data>
-  <data name="Personalize_Export.Text" xml:space="preserve"><value>导出</value></data>
-  <data name="Personalize_Done.Content" xml:space="preserve"><value>完成</value></data>
-  <data name="Personalize_ExportSuccess" xml:space="preserve"><value>导出成功</value></data>
-  <data name="Personalize_ExportSuccessMsg" xml:space="preserve"><value>已导出至Import文件夹。</value></data>
-  <data name="Personalize_Language" xml:space="preserve"><value>语言</value></data>
-  <data name="Personalize_LanguageDesc" xml:space="preserve"><value>选择应用的显示语言</value></data>
-  <data name="Personalize_RestartRequired" xml:space="preserve"><value>切换语言需要重启应用</value></data>
-  <data name="Personalize_RestartNow" xml:space="preserve"><value>立即重启</value></data>
-  <data name="Personalize_RestartLater" xml:space="preserve"><value>稍后</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       Subscriptions
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="Subscription_AddTooltip" xml:space="preserve"><value>添加订阅</value></data>
-  <data name="Subscription_ManageTooltip" xml:space="preserve"><value>管理订阅</value></data>
-  <data name="Subscription_LinkHeader" xml:space="preserve"><value>订阅链接</value></data>
-  <data name="Subscription_NameHeader" xml:space="preserve"><value>备注名称（可选）</value></data>
-  <data name="Subscription_NamePlaceholder" xml:space="preserve"><value>留空则使用链接域名</value></data>
-  <data name="Subscription_AutoImportHint" xml:space="preserve"><value>将自动拉取并导入订阅中的全部节点</value></data>
-  <data name="Subscription_Empty" xml:space="preserve"><value>暂无订阅</value></data>
-  <data name="Subscription_Refresh" xml:space="preserve"><value>刷新订阅</value></data>
-  <data name="Subscription_DeleteTooltip" xml:space="preserve"><value>删除订阅</value></data>
-  <data name="Subscription_DeleteConfirm" xml:space="preserve"><value>删除订阅？</value></data>
-  <data name="Subscription_DeleteDesc" xml:space="preserve"><value>将同时删除该订阅下的所有节点。</value></data>
-  <data name="Subscription_FetchFailed" xml:space="preserve"><value>订阅拉取失败</value></data>
-  <data name="Subscription_NoParsed" xml:space="preserve"><value>未能从订阅中解析出任何有效节点。</value></data>
-  <data name="Subscription_StopFirst_Refresh" xml:space="preserve"><value>请先停止代理后再刷新</value></data>
-  <data name="Subscription_UpdateFailed" xml:space="preserve"><value>更新失败: {0}</value></data>
-  <data name="Subscription_StopFirst_Delete" xml:space="preserve"><value>请先停止代理后再删除</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       CustomRules
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="CustomRules_Title" xml:space="preserve"><value>自定义路由规则</value></data>
-  <data name="CustomRules_RuleList" xml:space="preserve"><value>规则列表</value></data>
-  <data name="CustomRules_UpdateGeoTooltip" xml:space="preserve"><value>更新geoFile路由数据</value></data>
-  <data name="CustomRules_Add" xml:space="preserve"><value>添加</value></data>
-  <data name="CustomRules_Save" xml:space="preserve"><value>保存</value></data>
-  <data name="CustomRules_Cancel" xml:space="preserve"><value>取消</value></data>
-  <data name="CustomRules_EditTooltip" xml:space="preserve"><value>编辑</value></data>
-  <data name="CustomRules_DeleteTooltip" xml:space="preserve"><value>删除</value></data>
-  <data name="CustomRules_NotEffective" xml:space="preserve"><value>当前为全局路由模式，自定义规则不生效。切回智能分流后自动启用。</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       AddRuleDialog
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="AddRule_Title" xml:space="preserve"><value>添加规则</value></data>
-  <data name="AddRule_Add" xml:space="preserve"><value>添加</value></data>
-  <data name="AddRule_TypeLabel" xml:space="preserve"><value>类型</value></data>
-  <data name="AddRule_TypeDomain" xml:space="preserve"><value>域名（Domain）</value></data>
-  <data name="AddRule_MatchLabel" xml:space="preserve"><value>匹配内容</value></data>
-  <data name="AddRule_MatchHint" xml:space="preserve"><value>支持精确匹配、regexp:、geosite:、geoip: 前缀</value></data>
-  <data name="AddRule_OutboundLabel" xml:space="preserve"><value>出站</value></data>
-  <data name="AddRule_OutboundProxy" xml:space="preserve"><value>proxy（代理）</value></data>
-  <data name="AddRule_OutboundDirect" xml:space="preserve"><value>direct（直连）</value></data>
-  <data name="AddRule_OutboundBlock" xml:space="preserve"><value>block（阻断）</value></data>
-  <data name="AddRule_ErrorEmpty" xml:space="preserve"><value>请填写匹配内容</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       LogWindow
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="Log_Title" xml:space="preserve"><value>代理日志</value></data>
-  <data name="Log_NotRunning" xml:space="preserve"><value>未运行</value></data>
-  <data name="Log_Running" xml:space="preserve"><value>运行中</value></data>
-  <data name="Log_Lines" xml:space="preserve"><value>({0} 行)</value></data>
-  <data name="Log_PrivacyTooltip" xml:space="preserve"><value>日志隐私设置</value></data>
-  <data name="Log_IpMask" xml:space="preserve"><value>IP地址遮罩</value></data>
-  <data name="Log_MaskOff" xml:space="preserve"><value>关闭</value></data>
-  <data name="Log_AutoScroll" xml:space="preserve"><value>自动滚动</value></data>
-  <data name="Log_CopyAll" xml:space="preserve"><value>复制全部</value></data>
-  <data name="Log_Clear" xml:space="preserve"><value>清除</value></data>
-  <data name="Log_PrivacyTitle" xml:space="preserve"><value>日志隐私设置</value></data>
-  <data name="Log_PrivacySaved" xml:space="preserve"><value>已保存，当前 TUN 会话下次启动时生效。</value></data>
-  <data name="Log_PrivacyFailed" xml:space="preserve"><value>保存失败：{0}</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       Dialogs (DialogService)
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="Dialog_OK" xml:space="preserve"><value>确定</value></data>
-  <data name="Dialog_Cancel" xml:space="preserve"><value>取消</value></data>
-  <data name="Dialog_Save" xml:space="preserve"><value>保存</value></data>
-  <data name="Dialog_Done" xml:space="preserve"><value>完成</value></data>
-  <data name="Dialog_Confirm" xml:space="preserve"><value>确认</value></data>
-  <data name="Dialog_Add" xml:space="preserve"><value>添加</value></data>
-  <data name="Dialog_Delete" xml:space="preserve"><value>删除</value></data>
-  <data name="Dialog_Replace" xml:space="preserve"><value>替换</value></data>
-  <data name="Dialog_Preparing" xml:space="preserve"><value>正在准备…</value></data>
-  <data name="Dialog_On" xml:space="preserve"><value>开</value></data>
-  <data name="Dialog_Off" xml:space="preserve"><value>关</value></data>
-
-  <!-- Import link dialog -->
-  <data name="Import_Placeholder" xml:space="preserve"><value>粘贴节点链接（支持多协议）</value></data>
-  <data name="Import_Title" xml:space="preserve"><value>导入节点链接</value></data>
-  <data name="Import_SupportHint" xml:space="preserve"><value>支持常见协议链接</value></data>
-  <data name="Import_ParseFailed" xml:space="preserve"><value>解析失败</value></data>
-  <data name="Import_ParseFailedMsg" xml:space="preserve"><value>无法识别有效的节点链接，请检查后重试。</value></data>
-
-  <!-- Edit server dialog -->
-  <data name="EditServer_AddTitle" xml:space="preserve"><value>手动添加服务器</value></data>
-  <data name="EditServer_EditTitle" xml:space="preserve"><value>编辑服务器</value></data>
-  <data name="EditServer_Name" xml:space="preserve"><value>名称</value></data>
-  <data name="EditServer_Address" xml:space="preserve"><value>地址 / 域名</value></data>
-  <data name="EditServer_Port" xml:space="preserve"><value>端口</value></data>
-  <data name="EditServer_Protocol" xml:space="preserve"><value>协议</value></data>
-  <data name="EditServer_Encryption" xml:space="preserve"><value>加密方式 (SS)</value></data>
-  <data name="EditServer_Password" xml:space="preserve"><value>密码</value></data>
-  <data name="EditServer_UUID" xml:space="preserve"><value>UUID (VMess / VLESS)</value></data>
-  <data name="EditServer_AlterId" xml:space="preserve"><value>AlterId (VMess)</value></data>
-  <data name="EditServer_Transport" xml:space="preserve"><value>传输协议</value></data>
-  <data name="EditServer_Path" xml:space="preserve"><value>路径 (WS/gRPC/XHTTP)</value></data>
-  <data name="EditServer_WsHost" xml:space="preserve"><value>Host 头 (WS/XHTTP)</value></data>
-  <data name="EditServer_Security" xml:space="preserve"><value>安全</value></data>
-  <data name="EditServer_Fingerprint" xml:space="preserve"><value>指纹 (uTLS)</value></data>
-  <data name="EditServer_AllowInsecure" xml:space="preserve"><value>允许不安全连接（跳过证书校验）</value></data>
-  <data name="EditServer_FlowPlaceholder" xml:space="preserve"><value>xtls-rprx-vision 或留空</value></data>
-
-  <!-- Edit local port dialog -->
-  <data name="EditPort_Title" xml:space="preserve"><value>编辑本地端口</value></data>
-  <data name="EditPort_Header" xml:space="preserve"><value>本地端口</value></data>
-  <data name="EditPort_Range" xml:space="preserve"><value>有效范围：{0} - {1}</value></data>
-
-  <!-- Share link dialog -->
-  <data name="Share_Title" xml:space="preserve"><value>分享节点</value></data>
-  <data name="Share_CopyLink" xml:space="preserve"><value>复制链接</value></data>
-  <data name="Share_NotSupported" xml:space="preserve"><value>不支持分享</value></data>
-  <data name="Share_NotSupportedMsg" xml:space="preserve"><value>该节点协议暂不支持生成分享链接。</value></data>
-
-  <!-- Startup dialog -->
-  <data name="Startup_Title" xml:space="preserve"><value>开机启动</value></data>
-  <data name="Startup_AutoStart" xml:space="preserve"><value>开机自动启动</value></data>
-  <data name="Startup_AutoConnect" xml:space="preserve"><value>自动连接上次节点</value></data>
-  <data name="Startup_SetFailed" xml:space="preserve"><value>开机启动设置失败</value></data>
-
-  <!-- Confirmation dialog -->
-  <data name="Confirm_DeleteTitle" xml:space="preserve"><value>确认删除</value></data>
-  <data name="Confirm_DeleteMsg" xml:space="preserve"><value>确定要删除 {0}?</value></data>
-  <data name="Confirm_ReplaceTitle" xml:space="preserve"><value>替换当前配置?</value></data>
-  <data name="Confirm_ReplaceMsg" xml:space="preserve"><value>此操作将覆盖您当前的全部节点和路由规则,强烈建议先导出备份。是否继续?</value></data>
-
-  <!-- Edit server dialog: extra fields not yet localized in the stash -->
-  <data name="EditServer_SocksUsername" xml:space="preserve"><value>用户名 (SOCKS)</value></data>
-  <data name="EditServer_EchPlaceholder" xml:space="preserve"><value>例如 udp://1.1.1.1 或服务端生成的 ECHConfig</value></data>
-  <data name="EditServer_FinalmaskPlaceholder" xml:space="preserve"><value>留空 = none;或 mlkem768x25519plus.native.0rtt....</value></data>
-
-  <!-- Chain proxy dialog -->
-  <data name="ChainProxy_AddTitle" xml:space="preserve"><value>链式代理</value></data>
-  <data name="ChainProxy_EditTitle" xml:space="preserve"><value>编辑链式代理</value></data>
-
-  <!-- DNS settings dialog -->
-  <data name="Dns_DialogTitle" xml:space="preserve"><value>DNS 设置</value></data>
-  <data name="ControlPanel_DnsItem.Text" xml:space="preserve"><value>DNS设置</value></data>
-  <data name="Dns_ResetDefaults" xml:space="preserve"><value>重置默认</value></data>
-  <data name="Dns_ServerPlaceholder" xml:space="preserve"><value>输入 IP 或 DoH 地址 (留空为自动)</value></data>
-  <data name="Dns_QueryStrategyLabel" xml:space="preserve"><value>查询策略</value></data>
-  <data name="Dns_EnableCacheLabel" xml:space="preserve"><value>启用 DNS 缓存</value></data>
-  <data name="Dns_DirectTitle" xml:space="preserve"><value>直连 DNS</value></data>
-  <data name="Dns_DirectDesc" xml:space="preserve"><value>用于国内域名 (geosite:cn)，走直连出站解析</value></data>
-  <data name="Dns_ProxyTitle" xml:space="preserve"><value>代理 DNS</value></data>
-  <data name="Dns_ProxyDesc" xml:space="preserve"><value>用于境外域名，经代理出站解析，防止 DNS 污染</value></data>
-  <data name="Dns_TunOnlyHint" xml:space="preserve"><value>仅TUN模式有效</value></data>
-  <data name="Dns_Experimental" xml:space="preserve"><value>实验性</value></data>
-  <data name="Dns_Provider_Ali" xml:space="preserve"><value>阿里</value></data>
-  <data name="Dns_Provider_Tencent" xml:space="preserve"><value>腾讯</value></data>
-  <data name="Dns_Provider_Google" xml:space="preserve"><value>谷歌</value></data>
-  <data name="Dns_Strategy_V4Only" xml:space="preserve"><value>仅 IPv4</value></data>
-  <data name="Dns_Strategy_V6Only" xml:space="preserve"><value>仅 IPv6</value></data>
-  <data name="Dns_Strategy_Auto" xml:space="preserve"><value>自动</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       ControlPanel ViewModel
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="Error_NoServer" xml:space="preserve"><value>未选择服务器</value></data>
-  <data name="Error_NoServerMsg" xml:space="preserve"><value>请先从列表中选择服务器</value></data>
-  <data name="Error_StartFailed" xml:space="preserve"><value>启动失败</value></data>
-  <data name="Error_XrayStartFailed" xml:space="preserve"><value>xray 启动失败. 请检查服务器配置.</value></data>
-  <data name="Error_ReapplyFailed" xml:space="preserve"><value>应用新配置失败</value></data>
-  <data name="Error_XrayReapplyFailed" xml:space="preserve"><value>xray 应用新配置失败，已停止。</value></data>
-  <data name="Error_UpdateFailed" xml:space="preserve"><value>更新失败</value></data>
-  <data name="Error_UpdaterLaunchFailed" xml:space="preserve"><value>无法启动升级器：{0}</value></data>
-  <data name="Update_Updating" xml:space="preserve"><value>正在更新 XrayUI</value></data>
-
-  <!-- TUN mode -->
-  <data name="Tun_EnableTitle" xml:space="preserve"><value>开启TUN模式</value></data>
-  <data name="Tun_EnableMsg" xml:space="preserve"><value>开启 TUN 模式需要管理员权限，程序将会重启，是否继续？</value></data>
-
-  <!-- MainViewModel -->
-  <data name="Main_NoSelection" xml:space="preserve"><value>未选择</value></data>
-  <data name="Main_NotConnected" xml:space="preserve"><value>未连接</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       CopyButton
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="CopyButton_Tooltip" xml:space="preserve"><value>复制到剪贴板</value></data>
-  <data name="CopyButton_Copied" xml:space="preserve"><value>已复制到剪贴板</value></data>
-
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       GeoData Update
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="GeoUpdate_Updating" xml:space="preserve"><value>正在更新路由数据</value></data>
-  <data name="GeoUpdate_AlreadyLatest" xml:space="preserve"><value>已是最新</value></data>
-  <data name="GeoUpdate_AlreadyLatestMsg" xml:space="preserve"><value>geoip.dat 和 geosite.dat 都已是最新版本，无需下载。</value></data>
-  <data name="GeoUpdate_Success" xml:space="preserve"><value>更新成功</value></data>
-  <data name="GeoUpdate_TunRestart" xml:space="preserve"><value>已更新。TUN 模式下请手动重启以生效。</value></data>
-  <data name="GeoUpdate_ReloadedOk" xml:space="preserve"><value>已更新并重新加载 xray。</value></data>
-  <data name="GeoUpdate_ReloadFailed" xml:space="preserve"><value>已更新数据文件，但重启 xray 失败：{0}</value></data>
-  <data name="GeoUpdate_RestartRequired" xml:space="preserve"><value>已更新。请重启 xray 以生效。</value></data>
-  <data name="GeoUpdate_NextStart" xml:space="preserve"><value>已更新。下次启动 xray 时生效。</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       XrayService (Log messages)
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="Xray_NotFound" xml:space="preserve"><value>找不到 xray.exe
-路径：{0}</value></data>
-  <data name="Xray_LogError" xml:space="preserve"><value>[错误]</value></data>
-  <data name="Xray_ProcessExited" xml:space="preserve"><value>[xray 进程已退出]</value></data>
-  <data name="Xray_LogStart" xml:space="preserve"><value>[启动]</value></data>
-  <data name="Xray_LogConfig" xml:space="preserve"><value>[配置]</value></data>
-  <data name="Xray_ImmediateExit" xml:space="preserve"><value>xray 立即退出（退出码 {0}）</value></data>
-  <data name="Xray_LogStartFailed" xml:space="preserve"><value>[错误] 启动失败：</value></data>
-  <data name="Xray_LogException" xml:space="preserve"><value>[异常]</value></data>
-  <data name="Xray_LogStopped" xml:space="preserve"><value>[已停止]</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       UpdateService
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="Update_FetchingChecksum" xml:space="preserve"><value>正在获取校验文件…</value></data>
-  <data name="Update_ChecksumFormatError" xml:space="preserve"><value>更新校验文件格式异常</value></data>
-  <data name="Update_ChecksumDownloadFailed" xml:space="preserve"><value>无法下载更新校验文件：</value></data>
-  <data name="Update_ChecksumMismatch" xml:space="preserve"><value>更新包校验失败：SHA256 与服务器公布的不一致。</value></data>
-  <data name="Update_Extracting" xml:space="preserve"><value>正在解压更新包…</value></data>
-  <data name="Update_ExtractFailed" xml:space="preserve"><value>更新包解压失败：</value></data>
-  <data name="Update_Verifying" xml:space="preserve"><value>正在验证更新包…</value></data>
-  <data name="Update_MissingFiles" xml:space="preserve"><value>更新包内容异常：缺少必要文件。</value></data>
-  <data name="Update_VersionMismatch" xml:space="preserve"><value>更新包版本不匹配：期望 {0}，实际 {1}。</value></data>
-  <data name="Update_MissingUpdater" xml:space="preserve"><value>缺少升级器组件，请重新下载完整安装包。</value></data>
-  <data name="Update_PrepRestart" xml:space="preserve"><value>正在准备重启…</value></data>
-  <data name="Update_Downloading" xml:space="preserve"><value>正在下载 {0} … {1:0.0} / {2:0.0} MB</value></data>
-  <data name="Update_DownloadingNoTotal" xml:space="preserve"><value>正在下载 {0} … {1:0.0} MB</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       AddRuleDialog
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <data name="AddRule_EditTitle" xml:space="preserve"><value>编辑规则</value></data>
-
-  <!-- Personalize export error -->
-  <data name="Error_ExportFailed" xml:space="preserve"><value>导出失败</value></data>
-
-  <!-- GeoUpdate progress -->
-  <data name="GeoUpdate_ViaProxy" xml:space="preserve"><value>通过本地代理下载（{0}）…</value></data>
-  <data name="GeoUpdate_Checking" xml:space="preserve"><value>正在检查 {0}.dat …</value></data>
-  <data name="GeoUpdate_UpToDate" xml:space="preserve"><value>{0}.dat 已是最新</value></data>
-  <data name="GeoUpdate_ChecksumFailed" xml:space="preserve"><value>{0}.dat 校验失败：下载文件的 SHA256 与服务器公布的不一致。</value></data>
-
-  <!-- Subscription relative time -->
-  <data name="Subscription_NeverUpdated" xml:space="preserve"><value>上次更新: 从未更新</value></data>
-  <data name="Subscription_JustNow" xml:space="preserve"><value>刚刚</value></data>
-  <data name="Subscription_MinutesAgo" xml:space="preserve"><value>{0} 分钟前</value></data>
-  <data name="Subscription_HoursAgo" xml:space="preserve"><value>{0} 小时前</value></data>
-  <data name="Subscription_DaysAgo" xml:space="preserve"><value>{0} 天前</value></data>
-  <data name="Subscription_LastUpdated" xml:space="preserve"><value>上次更新: {0}</value></data>
-
-  <!-- SystemProxy -->
-  <data name="SystemProxy_RegError" xml:space="preserve"><value>无法打开注册表项：</value></data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       x:Uid entries for XAML (key = x:Uid + "." + PropertyName)
-       ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- ControlPanel XAML -->
-  <data name="ControlPanel_EditPortItem.Text" xml:space="preserve"><value>编辑本地端口</value></data>
-  <data name="ControlPanel_ViewLogItem.Text" xml:space="preserve"><value>查看日志</value></data>
-  <data name="ControlPanel_ProxySettingsItem.Text" xml:space="preserve"><value>代理设置</value></data>
-  <data name="ControlPanel_GlobalProxyItem.Text" xml:space="preserve"><value>全局代理</value></data>
-  <data name="ControlPanel_NoProxyItem.Text" xml:space="preserve"><value>不接管代理</value></data>
-  <data name="ControlPanel_StartupItem.Text" xml:space="preserve"><value>开机启动</value></data>
-  <data name="ControlPanel_RoutingSettingsItem.Text" xml:space="preserve"><value>路由设置</value></data>
-  <data name="ControlPanel_RoutingGlobalItem.Text" xml:space="preserve"><value>全局路由</value></data>
-  <data name="ControlPanel_RoutingSmartItem.Text" xml:space="preserve"><value>智能分流</value></data>
-  <data name="ControlPanel_CustomRulesItem.Text" xml:space="preserve"><value>自定义规则...</value></data>
-  <data name="ControlPanel_TunModeLabel.Text" xml:space="preserve"><value>TUN 模式</value></data>
-  <data name="ControlPanel_RoutingLbl.Text" xml:space="preserve"><value>路由:</value></data>
-
-  <!-- Personalize Language -->
-  <data name="Personalize_LanguageLbl.Text" xml:space="preserve"><value>语言</value></data>
-  <data name="Personalize_LanguageDescLbl.Text" xml:space="preserve"><value>选择应用的显示语言</value></data>
-
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="MainWindow_Title" xml:space="preserve">
+    <value>代理控制台</value>
+  </data>
+  <data name="MainWindow_ToggleMini" xml:space="preserve">
+    <value>切换mini窗口</value>
+  </data>
+  <data name="MainWindow_ExpandFull" xml:space="preserve">
+    <value>返回完整窗口</value>
+  </data>
+  <data name="MainWindow_Close" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Tray_Open" xml:space="preserve">
+    <value>打开窗口</value>
+  </data>
+  <data name="Tray_Exit" xml:space="preserve">
+    <value>退出</value>
+  </data>
+  <data name="ServerList_Edit" xml:space="preserve">
+    <value>编辑</value>
+  </data>
+  <data name="ServerList_Delete" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="ServerList_Share" xml:space="preserve">
+    <value>分享</value>
+  </data>
+  <data name="ServerList_SortActiveHint" xml:space="preserve">
+    <value>只在筛选为「所有服务器」时可用</value>
+  </data>
+  <data name="ServerList_AllServers" xml:space="preserve">
+    <value>所有服务器</value>
+  </data>
+  <data name="ServerList_Ungrouped" xml:space="preserve">
+    <value>未分组</value>
+  </data>
+  <data name="ServerList_UnnamedSub" xml:space="preserve">
+    <value>(未命名订阅)</value>
+  </data>
+  <data name="ServerList_OrphanSub" xml:space="preserve">
+    <value>(已删除订阅)</value>
+  </data>
+  <data name="ControlPanel_Start" xml:space="preserve">
+    <value>启动</value>
+  </data>
+  <data name="ControlPanel_Stop" xml:space="preserve">
+    <value>停止</value>
+  </data>
+  <data name="ControlPanel_StatusNotRunning" xml:space="preserve">
+    <value>未运行</value>
+  </data>
+  <data name="ControlPanel_StatusApplying" xml:space="preserve">
+    <value>正在应用...</value>
+  </data>
+  <data name="ControlPanel_Personalize" xml:space="preserve">
+    <value>个性化</value>
+  </data>
+  <data name="ControlPanel_RoutingGlobal" xml:space="preserve">
+    <value>全局路由</value>
+  </data>
+  <data name="ControlPanel_RoutingSmart" xml:space="preserve">
+    <value>智能分流</value>
+  </data>
+  <data name="ControlPanel_UpdateFound" xml:space="preserve">
+    <value>发现新版本 {0}</value>
+  </data>
+  <data name="ServerDetail_Address" xml:space="preserve">
+    <value>地址</value>
+  </data>
+  <data name="ServerDetail_Port" xml:space="preserve">
+    <value>端口</value>
+  </data>
+  <data name="ServerDetail_Encryption" xml:space="preserve">
+    <value>加密</value>
+  </data>
+  <data name="ServerDetail_Security" xml:space="preserve">
+    <value>安全</value>
+  </data>
+  <data name="ServerDetail_OpenInBrowser" xml:space="preserve">
+    <value>在浏览器中打开 {0}</value>
+  </data>
+  <data name="ServerDetail_RetestLatency" xml:space="preserve">
+    <value>重新测试延迟</value>
+  </data>
+  <data name="ServerDetail_CopyShareLink" xml:space="preserve">
+    <value>复制分享链接</value>
+  </data>
+  <data name="ServerDetail_NoServer" xml:space="preserve">
+    <value>未选择服务器</value>
+  </data>
+  <data name="ServerDetail_NotTested" xml:space="preserve">
+    <value>未测试</value>
+  </data>
+  <data name="ServerDetail_Testing" xml:space="preserve">
+    <value>测试中...</value>
+  </data>
+  <data name="ServerDetail_Timeout" xml:space="preserve">
+    <value>超时</value>
+  </data>
+  <data name="ServerDetail_Failed" xml:space="preserve">
+    <value>失败</value>
+  </data>
+  <data name="Personalize_Header.Text" xml:space="preserve">
+    <value>个性化设置</value>
+  </data>
+  <data name="Personalize_Theme.Text" xml:space="preserve">
+    <value>主题</value>
+  </data>
+  <data name="Personalize_Light.Content" xml:space="preserve">
+    <value>浅色</value>
+  </data>
+  <data name="Personalize_Dark.Content" xml:space="preserve">
+    <value>深色</value>
+  </data>
+  <data name="Personalize_FollowSystem.Content" xml:space="preserve">
+    <value>跟随系统</value>
+  </data>
+  <data name="Personalize_Backdrop.Text" xml:space="preserve">
+    <value>背景效果</value>
+  </data>
+  <data name="Personalize_Acrylic.Content" xml:space="preserve">
+    <value>亚克力</value>
+  </data>
+  <data name="Personalize_ProtocolColors.Text" xml:space="preserve">
+    <value>协议颜色</value>
+  </data>
+  <data name="Personalize_Reset.Text" xml:space="preserve">
+    <value>重置</value>
+  </data>
+  <data name="Personalize_OtherProtocol.Text" xml:space="preserve">
+    <value>其他协议</value>
+  </data>
+  <data name="Personalize_OtherProtocolDesc.Text" xml:space="preserve">
+    <value>未匹配的协议将使用此颜色</value>
+  </data>
+  <data name="Personalize_DataManagement.Text" xml:space="preserve">
+    <value>数据管理</value>
+  </data>
+  <data name="Personalize_Done.Content" xml:space="preserve">
+    <value>完成</value>
+  </data>
+  <data name="Personalize_ExportSuccess" xml:space="preserve">
+    <value>导出成功</value>
+  </data>
+  <data name="Language_FollowSystem" xml:space="preserve">
+    <value>跟随系统</value>
+    <comment>Display name of the "follow system" language row — referenced by LanguageInfo.DisplayName when Tag is null.</comment>
+  </data>
+  <data name="Subscription_AddTooltip" xml:space="preserve">
+    <value>添加订阅</value>
+  </data>
+  <data name="Subscription_ManageTooltip" xml:space="preserve">
+    <value>管理订阅</value>
+  </data>
+  <data name="Subscription_Refresh" xml:space="preserve">
+    <value>刷新订阅</value>
+  </data>
+  <data name="Subscription_DeleteTooltip" xml:space="preserve">
+    <value>删除订阅</value>
+  </data>
+  <data name="Subscription_FetchFailed" xml:space="preserve">
+    <value>订阅拉取失败</value>
+  </data>
+  <data name="Subscription_NoParsed" xml:space="preserve">
+    <value>未能从订阅中解析出任何有效节点。</value>
+  </data>
+  <data name="Subscription_StopFirst_Refresh" xml:space="preserve">
+    <value>请先停止代理后再刷新</value>
+  </data>
+  <data name="Subscription_UpdateFailed" xml:space="preserve">
+    <value>更新失败: {0}</value>
+  </data>
+  <data name="Subscription_StopFirst_Delete" xml:space="preserve">
+    <value>请先停止代理后再删除</value>
+  </data>
+  <data name="CustomRules_Title" xml:space="preserve">
+    <value>自定义路由规则</value>
+  </data>
+  <data name="CustomRules_UpdateGeoTooltip" xml:space="preserve">
+    <value>更新geoFile路由数据</value>
+  </data>
+  <data name="AddRule_Title" xml:space="preserve">
+    <value>添加规则</value>
+  </data>
+  <data name="AddRule_ErrorEmpty" xml:space="preserve">
+    <value>请填写匹配内容</value>
+  </data>
+  <data name="Log_Title" xml:space="preserve">
+    <value>代理日志</value>
+  </data>
+  <data name="Log_NotRunning" xml:space="preserve">
+    <value>未运行</value>
+  </data>
+  <data name="Log_Running" xml:space="preserve">
+    <value>运行中</value>
+  </data>
+  <data name="Log_Lines" xml:space="preserve">
+    <value>({0} 行)</value>
+  </data>
+  <data name="Log_PrivacyTooltip" xml:space="preserve">
+    <value>日志隐私设置</value>
+  </data>
+  <data name="Log_IpMask" xml:space="preserve">
+    <value>IP地址遮罩</value>
+  </data>
+  <data name="Log_MaskOff" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Log_AutoScroll" xml:space="preserve">
+    <value>自动滚动</value>
+  </data>
+  <data name="Log_CopyAll" xml:space="preserve">
+    <value>复制全部</value>
+  </data>
+  <data name="Log_Clear" xml:space="preserve">
+    <value>清除</value>
+  </data>
+  <data name="Log_PrivacyTitle" xml:space="preserve">
+    <value>日志隐私设置</value>
+  </data>
+  <data name="Log_PrivacySaved" xml:space="preserve">
+    <value>已保存，当前 TUN 会话下次启动时生效。</value>
+  </data>
+  <data name="Log_PrivacyFailed" xml:space="preserve">
+    <value>保存失败：{0}</value>
+  </data>
+  <data name="Dialog_OK" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="Dialog_Cancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="Dialog_Save" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="Dialog_Done" xml:space="preserve">
+    <value>完成</value>
+  </data>
+  <data name="Dialog_Confirm" xml:space="preserve">
+    <value>确认</value>
+  </data>
+  <data name="Dialog_Add" xml:space="preserve">
+    <value>添加</value>
+  </data>
+  <data name="Dialog_Delete" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="Dialog_Replace" xml:space="preserve">
+    <value>替换</value>
+  </data>
+  <data name="Dialog_Preparing" xml:space="preserve">
+    <value>正在准备…</value>
+  </data>
+  <data name="Dialog_On" xml:space="preserve">
+    <value>开</value>
+  </data>
+  <data name="Dialog_Off" xml:space="preserve">
+    <value>关</value>
+  </data>
+  <data name="Import_Placeholder" xml:space="preserve">
+    <value>粘贴节点链接（支持多协议）</value>
+  </data>
+  <data name="Import_Title" xml:space="preserve">
+    <value>导入节点链接</value>
+  </data>
+  <data name="Import_SupportHint" xml:space="preserve">
+    <value>支持常见协议链接</value>
+  </data>
+  <data name="Import_ParseFailed" xml:space="preserve">
+    <value>解析失败</value>
+  </data>
+  <data name="Import_ParseFailedMsg" xml:space="preserve">
+    <value>无法识别有效的节点链接，请检查后重试。</value>
+  </data>
+  <data name="EditServer_AddTitle" xml:space="preserve">
+    <value>手动添加服务器</value>
+  </data>
+  <data name="EditServer_EditTitle" xml:space="preserve">
+    <value>编辑服务器</value>
+  </data>
+  <data name="EditServer_Name" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="EditServer_Address" xml:space="preserve">
+    <value>地址 / 域名</value>
+  </data>
+  <data name="EditServer_Port" xml:space="preserve">
+    <value>端口</value>
+  </data>
+  <data name="EditServer_Protocol" xml:space="preserve">
+    <value>协议</value>
+  </data>
+  <data name="EditServer_Encryption" xml:space="preserve">
+    <value>加密方式 (SS)</value>
+  </data>
+  <data name="EditServer_Password" xml:space="preserve">
+    <value>密码</value>
+  </data>
+  <data name="EditServer_Transport" xml:space="preserve">
+    <value>传输协议</value>
+  </data>
+  <data name="EditServer_Path" xml:space="preserve">
+    <value>路径 (WS/gRPC/XHTTP)</value>
+  </data>
+  <data name="EditServer_WsHost" xml:space="preserve">
+    <value>Host 头 (WS/XHTTP)</value>
+  </data>
+  <data name="EditServer_Security" xml:space="preserve">
+    <value>安全</value>
+  </data>
+  <data name="EditServer_Fingerprint" xml:space="preserve">
+    <value>指纹 (uTLS)</value>
+  </data>
+  <data name="EditServer_AllowInsecure" xml:space="preserve">
+    <value>允许不安全连接（跳过证书校验）</value>
+  </data>
+  <data name="EditServer_FlowPlaceholder" xml:space="preserve">
+    <value>xtls-rprx-vision 或留空</value>
+  </data>
+  <data name="EditPort_Title" xml:space="preserve">
+    <value>编辑本地端口</value>
+  </data>
+  <data name="EditPort_Header" xml:space="preserve">
+    <value>本地端口</value>
+  </data>
+  <data name="EditPort_Range" xml:space="preserve">
+    <value>有效范围：{0} - {1}</value>
+  </data>
+  <data name="Share_Title" xml:space="preserve">
+    <value>分享节点</value>
+  </data>
+  <data name="Share_CopyLink" xml:space="preserve">
+    <value>复制链接</value>
+  </data>
+  <data name="Share_NotSupported" xml:space="preserve">
+    <value>不支持分享</value>
+  </data>
+  <data name="Share_NotSupportedMsg" xml:space="preserve">
+    <value>该节点协议暂不支持生成分享链接。</value>
+  </data>
+  <data name="Startup_Title" xml:space="preserve">
+    <value>开机启动</value>
+  </data>
+  <data name="Startup_AutoStart" xml:space="preserve">
+    <value>开机自动启动</value>
+  </data>
+  <data name="Startup_AutoConnect" xml:space="preserve">
+    <value>自动连接上次节点</value>
+  </data>
+  <data name="Startup_SetFailed" xml:space="preserve">
+    <value>开机启动设置失败</value>
+  </data>
+  <data name="Confirm_DeleteTitle" xml:space="preserve">
+    <value>确认删除</value>
+  </data>
+  <data name="Confirm_DeleteMsg" xml:space="preserve">
+    <value>确定要删除 {0}?</value>
+  </data>
+  <data name="Confirm_ReplaceTitle" xml:space="preserve">
+    <value>替换当前配置?</value>
+  </data>
+  <data name="Confirm_ReplaceMsg" xml:space="preserve">
+    <value>此操作将覆盖您当前的全部节点和路由规则,强烈建议先导出备份。是否继续?</value>
+  </data>
+  <data name="EditServer_SocksUsername" xml:space="preserve">
+    <value>用户名 (SOCKS)</value>
+  </data>
+  <data name="EditServer_EchPlaceholder" xml:space="preserve">
+    <value>例如 udp://1.1.1.1 或服务端生成的 ECHConfig</value>
+  </data>
+  <data name="EditServer_FinalmaskPlaceholder" xml:space="preserve">
+    <value>留空 = none;或 mlkem768x25519plus.native.0rtt....</value>
+  </data>
+  <data name="ChainProxy_AddTitle" xml:space="preserve">
+    <value>链式代理</value>
+  </data>
+  <data name="ChainProxy_EditTitle" xml:space="preserve">
+    <value>编辑链式代理</value>
+  </data>
+  <data name="Dns_DialogTitle" xml:space="preserve">
+    <value>DNS 设置</value>
+  </data>
+  <data name="ControlPanel_DnsItem.Text" xml:space="preserve">
+    <value>DNS设置</value>
+  </data>
+  <data name="Dns_ResetDefaults" xml:space="preserve">
+    <value>重置默认</value>
+  </data>
+  <data name="Dns_ServerPlaceholder" xml:space="preserve">
+    <value>输入 IP 或 DoH 地址 (留空为自动)</value>
+  </data>
+  <data name="Dns_QueryStrategyLabel" xml:space="preserve">
+    <value>查询策略</value>
+  </data>
+  <data name="Dns_EnableCacheLabel" xml:space="preserve">
+    <value>启用 DNS 缓存</value>
+  </data>
+  <data name="Dns_DirectTitle" xml:space="preserve">
+    <value>直连 DNS</value>
+  </data>
+  <data name="Dns_DirectDesc" xml:space="preserve">
+    <value>用于国内域名 (geosite:cn)，走直连出站解析</value>
+  </data>
+  <data name="Dns_ProxyTitle" xml:space="preserve">
+    <value>代理 DNS</value>
+  </data>
+  <data name="Dns_ProxyDesc" xml:space="preserve">
+    <value>用于境外域名，经代理出站解析，防止 DNS 污染</value>
+  </data>
+  <data name="Dns_TunOnlyHint" xml:space="preserve">
+    <value>仅TUN模式有效</value>
+  </data>
+  <data name="Dns_Experimental" xml:space="preserve">
+    <value>实验性</value>
+  </data>
+  <data name="Dns_Provider_Ali" xml:space="preserve">
+    <value>阿里</value>
+  </data>
+  <data name="Dns_Provider_Tencent" xml:space="preserve">
+    <value>腾讯</value>
+  </data>
+  <data name="Dns_Provider_Google" xml:space="preserve">
+    <value>谷歌</value>
+  </data>
+  <data name="Dns_Strategy_V4Only" xml:space="preserve">
+    <value>仅 IPv4</value>
+  </data>
+  <data name="Dns_Strategy_V6Only" xml:space="preserve">
+    <value>仅 IPv6</value>
+  </data>
+  <data name="Dns_Strategy_Auto" xml:space="preserve">
+    <value>自动</value>
+  </data>
+  <data name="Error_NoServer" xml:space="preserve">
+    <value>未选择服务器</value>
+  </data>
+  <data name="Error_NoServerMsg" xml:space="preserve">
+    <value>请先从列表中选择服务器</value>
+  </data>
+  <data name="Error_StartFailed" xml:space="preserve">
+    <value>启动失败</value>
+  </data>
+  <data name="Error_XrayStartFailed" xml:space="preserve">
+    <value>xray 启动失败. 请检查服务器配置.</value>
+  </data>
+  <data name="Error_ReapplyFailed" xml:space="preserve">
+    <value>应用新配置失败</value>
+  </data>
+  <data name="Error_XrayReapplyFailed" xml:space="preserve">
+    <value>xray 应用新配置失败，已停止。</value>
+  </data>
+  <data name="Error_UpdateFailed" xml:space="preserve">
+    <value>更新失败</value>
+  </data>
+  <data name="Error_UpdaterLaunchFailed" xml:space="preserve">
+    <value>无法启动升级器：{0}</value>
+  </data>
+  <data name="Update_Updating" xml:space="preserve">
+    <value>正在更新 XrayUI</value>
+  </data>
+  <data name="Tun_EnableTitle" xml:space="preserve">
+    <value>开启TUN模式</value>
+  </data>
+  <data name="Tun_EnableMsg.Text" xml:space="preserve">
+    <value>开启 TUN 模式需要管理员权限，程序将会重启，是否继续？</value>
+  </data>
+  <data name="Main_NoSelection" xml:space="preserve">
+    <value>未选择</value>
+  </data>
+  <data name="Main_NotConnected" xml:space="preserve">
+    <value>未连接</value>
+  </data>
+  <data name="GeoUpdate_Updating" xml:space="preserve">
+    <value>正在更新路由数据</value>
+  </data>
+  <data name="GeoUpdate_AlreadyLatest" xml:space="preserve">
+    <value>已是最新</value>
+  </data>
+  <data name="GeoUpdate_AlreadyLatestMsg" xml:space="preserve">
+    <value>geoip.dat 和 geosite.dat 都已是最新版本，无需下载。</value>
+  </data>
+  <data name="GeoUpdate_Success" xml:space="preserve">
+    <value>更新成功</value>
+  </data>
+  <data name="GeoUpdate_TunRestart" xml:space="preserve">
+    <value>已更新。TUN 模式下请手动重启以生效。</value>
+  </data>
+  <data name="GeoUpdate_ReloadedOk" xml:space="preserve">
+    <value>已更新并重新加载 xray。</value>
+  </data>
+  <data name="GeoUpdate_ReloadFailed" xml:space="preserve">
+    <value>已更新数据文件，但重启 xray 失败：{0}</value>
+  </data>
+  <data name="GeoUpdate_RestartRequired" xml:space="preserve">
+    <value>已更新。请重启 xray 以生效。</value>
+  </data>
+  <data name="GeoUpdate_NextStart" xml:space="preserve">
+    <value>已更新。下次启动 xray 时生效。</value>
+  </data>
+  <data name="Update_FetchingChecksum" xml:space="preserve">
+    <value>正在获取校验文件…</value>
+  </data>
+  <data name="Update_ChecksumFormatError" xml:space="preserve">
+    <value>更新校验文件格式异常</value>
+  </data>
+  <data name="Update_ChecksumDownloadFailed" xml:space="preserve">
+    <value>无法下载更新校验文件：</value>
+  </data>
+  <data name="Update_ChecksumMismatch" xml:space="preserve">
+    <value>更新包校验失败：SHA256 与服务器公布的不一致。</value>
+  </data>
+  <data name="Update_Extracting" xml:space="preserve">
+    <value>正在解压更新包…</value>
+  </data>
+  <data name="Update_ExtractFailed" xml:space="preserve">
+    <value>更新包解压失败：</value>
+  </data>
+  <data name="Update_Verifying" xml:space="preserve">
+    <value>正在验证更新包…</value>
+  </data>
+  <data name="Update_MissingFiles" xml:space="preserve">
+    <value>更新包内容异常：缺少必要文件。</value>
+  </data>
+  <data name="Update_VersionMismatch" xml:space="preserve">
+    <value>更新包版本不匹配：期望 {0}，实际 {1}。</value>
+  </data>
+  <data name="Update_MissingUpdater" xml:space="preserve">
+    <value>缺少升级器组件，请重新下载完整安装包。</value>
+  </data>
+  <data name="Update_PrepRestart" xml:space="preserve">
+    <value>正在准备重启…</value>
+  </data>
+  <data name="Update_Downloading" xml:space="preserve">
+    <value>正在下载 {0} … {1:0.0} / {2:0.0} MB</value>
+  </data>
+  <data name="Update_DownloadingNoTotal" xml:space="preserve">
+    <value>正在下载 {0} … {1:0.0} MB</value>
+  </data>
+  <data name="AddRule_EditTitle" xml:space="preserve">
+    <value>编辑规则</value>
+  </data>
+  <data name="Error_ExportFailed" xml:space="preserve">
+    <value>导出失败</value>
+  </data>
+  <data name="Subscription_NeverUpdated" xml:space="preserve">
+    <value>上次更新: 从未更新</value>
+  </data>
+  <data name="Subscription_JustNow" xml:space="preserve">
+    <value>刚刚</value>
+  </data>
+  <data name="Subscription_MinutesAgo" xml:space="preserve">
+    <value>{0} 分钟前</value>
+  </data>
+  <data name="Subscription_HoursAgo" xml:space="preserve">
+    <value>{0} 小时前</value>
+  </data>
+  <data name="Subscription_DaysAgo" xml:space="preserve">
+    <value>{0} 天前</value>
+  </data>
+  <data name="Subscription_LastUpdated" xml:space="preserve">
+    <value>上次更新: {0}</value>
+  </data>
+  <data name="ControlPanel_EditPortItem.Text" xml:space="preserve">
+    <value>编辑本地端口</value>
+  </data>
+  <data name="ControlPanel_ViewLogItem.Text" xml:space="preserve">
+    <value>查看日志</value>
+  </data>
+  <data name="ControlPanel_ProxySettingsItem.Text" xml:space="preserve">
+    <value>代理设置</value>
+  </data>
+  <data name="ControlPanel_GlobalProxyItem.Text" xml:space="preserve">
+    <value>全局代理</value>
+  </data>
+  <data name="ControlPanel_NoProxyItem.Text" xml:space="preserve">
+    <value>不接管代理</value>
+  </data>
+  <data name="ControlPanel_StartupItem.Text" xml:space="preserve">
+    <value>开机启动</value>
+  </data>
+  <data name="ControlPanel_RoutingSettingsItem.Text" xml:space="preserve">
+    <value>路由设置</value>
+  </data>
+  <data name="ControlPanel_RoutingGlobalItem.Text" xml:space="preserve">
+    <value>全局路由</value>
+  </data>
+  <data name="ControlPanel_RoutingSmartItem.Text" xml:space="preserve">
+    <value>智能分流</value>
+  </data>
+  <data name="ControlPanel_CustomRulesItem.Text" xml:space="preserve">
+    <value>自定义规则...</value>
+  </data>
+  <data name="ControlPanel_TunModeLabel.Text" xml:space="preserve">
+    <value>TUN 模式</value>
+  </data>
+  <data name="ControlPanel_RoutingLbl.Text" xml:space="preserve">
+    <value>路由:</value>
+  </data>
+  <data name="Personalize_LanguageLbl.Text" xml:space="preserve">
+    <value>语言</value>
+  </data>
+  <data name="ServerList_HeaderText.Text" xml:space="preserve">
+    <value>服务器列表</value>
+  </data>
+  <data name="ServerList_AddBtnText.Text" xml:space="preserve">
+    <value>添加</value>
+  </data>
+  <data name="ServerList_ImportNodeItem.Text" xml:space="preserve">
+    <value>导入节点</value>
+  </data>
+  <data name="ServerList_AddSubscriptionItem.Text" xml:space="preserve">
+    <value>添加订阅</value>
+  </data>
+  <data name="ServerList_AddManualItem.Text" xml:space="preserve">
+    <value>手动添加</value>
+  </data>
+  <data name="ServerList_AddChainProxyItem.Text" xml:space="preserve">
+    <value>链式代理</value>
+  </data>
+  <data name="ServerList_EditText.Text" xml:space="preserve">
+    <value>编辑</value>
+  </data>
+  <data name="ServerList_DeleteText.Text" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="ServerList_SearchBox.PlaceholderText" xml:space="preserve">
+    <value>搜索服务器</value>
+  </data>
+  <data name="ServerList_FilterLabelText.Text" xml:space="preserve">
+    <value>筛选条件:</value>
+  </data>
+  <data name="ServerList_SortDefaultItem.Text" xml:space="preserve">
+    <value>默认</value>
+  </data>
+  <data name="ServerList_SortActiveItem.Text" xml:space="preserve">
+    <value>当前连接</value>
+  </data>
+  <data name="ServerList_SortProtocolItem.Text" xml:space="preserve">
+    <value>协议</value>
+  </data>
+  <data name="ServerList_ActivatedBadge.Text" xml:space="preserve">
+    <value>● 已连接</value>
+  </data>
+  <data name="ServerList_ChainBadgeText.Text" xml:space="preserve">
+    <value>链式代理</value>
+  </data>
+  <data name="ServerList_Favorites" xml:space="preserve">
+    <value>收藏列表</value>
+  </data>
+  <data name="ServerList_AddFavorite" xml:space="preserve">
+    <value>加入收藏</value>
+  </data>
+  <data name="ServerList_RemoveFavorite" xml:space="preserve">
+    <value>取消收藏</value>
+  </data>
+  <data name="ServerList_FilterTooltip" xml:space="preserve">
+    <value>筛选</value>
+  </data>
+  <data name="ServerList_SortTooltip" xml:space="preserve">
+    <value>排序</value>
+  </data>
+  <data name="Confirm_DeleteBatchMsg" xml:space="preserve">
+    <value>确定要删除当前 {0} 个项目?</value>
+  </data>
+  <data name="Subscription_UnknownError" xml:space="preserve">
+    <value>未知错误</value>
+  </data>
+  <data name="ServerDetail_HeaderText.Text" xml:space="preserve">
+    <value>服务器详情</value>
+  </data>
+  <data name="ServerDetail_NameLabel.Text" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="ServerDetail_ProtocolLabel.Text" xml:space="preserve">
+    <value>协议</value>
+  </data>
+  <data name="ServerDetail_TransportLabel.Text" xml:space="preserve">
+    <value>传输</value>
+  </data>
+  <data name="ServerDetail_AiUnlockLabel.Text" xml:space="preserve">
+    <value>AI 访问解锁</value>
+  </data>
+  <data name="ServerDetail_LatencyLabel.Text" xml:space="preserve">
+    <value>网络延迟</value>
+  </data>
+  <data name="ServerDetail_Entry" xml:space="preserve">
+    <value>入口</value>
+  </data>
+  <data name="ServerDetail_Exit" xml:space="preserve">
+    <value>出口</value>
+  </data>
+  <data name="ServerDetail_EntryMissing" xml:space="preserve">
+    <value>(入口节点缺失)</value>
+  </data>
+  <data name="ServerDetail_ExitMissing" xml:space="preserve">
+    <value>(出口节点缺失)</value>
+  </data>
+  <data name="ServerDetail_AuthLabel" xml:space="preserve">
+    <value>认证</value>
+  </data>
+  <data name="ServerDetail_ChainLabel" xml:space="preserve">
+    <value>链路</value>
+  </data>
+  <data name="ServerDetail_NoAuth" xml:space="preserve">
+    <value>无认证</value>
+  </data>
+  <data name="ServerDetail_UserPass" xml:space="preserve">
+    <value>用户名/密码</value>
+  </data>
+  <data name="ServerDetail_LatencyMs" xml:space="preserve">
+    <value>{0} ms</value>
+  </data>
+  <data name="MainWindow_TitleText.Text" xml:space="preserve">
+    <value>代理控制台</value>
+  </data>
+  <data name="CustomRules_RuleListText.Text" xml:space="preserve">
+    <value>规则列表</value>
+  </data>
+  <data name="CustomRules_AddBtnText.Text" xml:space="preserve">
+    <value>添加</value>
+  </data>
+  <data name="CustomRules_NotEffectiveText.Text" xml:space="preserve">
+    <value>当前为全局路由模式，自定义规则不生效。切回智能分流后自动启用。</value>
+  </data>
+  <data name="CustomRules_SaveBtn.Content" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="CustomRules_CancelBtn.Content" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="CustomRules_AdvancedEditorTooltip" xml:space="preserve">
+    <value>高级编辑 (用外部编辑器打开 settings.json)</value>
+  </data>
+  <data name="CustomRules_EditRowTooltip" xml:space="preserve">
+    <value>编辑</value>
+  </data>
+  <data name="CustomRules_DeleteRowTooltip" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="CustomRules_PrepFailedTitle" xml:space="preserve">
+    <value>无法准备 settings.json</value>
+  </data>
+  <data name="CustomRules_OpenEditorFailedTitle" xml:space="preserve">
+    <value>无法打开编辑器</value>
+  </data>
+  <data name="CustomRules_OpenEditorFailedMsg" xml:space="preserve">
+    <value>未找到 .json 关联程序或启动失败：{0}</value>
+  </data>
+  <data name="AddRule_TypeLabelText.Text" xml:space="preserve">
+    <value>类型</value>
+  </data>
+  <data name="AddRule_TypeDomainItem.Content" xml:space="preserve">
+    <value>域名（Domain）</value>
+  </data>
+  <data name="AddRule_TypeProcessItem.Content" xml:space="preserve">
+    <value>进程（Process）</value>
+  </data>
+  <data name="AddRule_MatchLabelText.Text" xml:space="preserve">
+    <value>匹配内容</value>
+  </data>
+  <data name="AddRule_BrowseNameItem.Content" xml:space="preserve">
+    <value>匹配同名进程</value>
+  </data>
+  <data name="AddRule_BrowsePathItem.Content" xml:space="preserve">
+    <value>匹配完整路径</value>
+  </data>
+  <data name="AddRule_BrowseFolderItem.Content" xml:space="preserve">
+    <value>匹配整个目录</value>
+  </data>
+  <data name="AddRule_OutboundLabelText.Text" xml:space="preserve">
+    <value>出站</value>
+  </data>
+  <data name="AddRule_OutboundProxyItem.Content" xml:space="preserve">
+    <value>proxy（代理）</value>
+  </data>
+  <data name="AddRule_OutboundDirectItem.Content" xml:space="preserve">
+    <value>direct（直连）</value>
+  </data>
+  <data name="AddRule_OutboundBlockItem.Content" xml:space="preserve">
+    <value>block（阻断）</value>
+  </data>
+  <data name="AddRule_ErrorTextElem.Text" xml:space="preserve">
+    <value>请填写匹配内容</value>
+  </data>
+  <data name="AddRule_BrowseExe" xml:space="preserve">
+    <value>浏览 exe...</value>
+  </data>
+  <data name="AddRule_BrowseFolder" xml:space="preserve">
+    <value>浏览文件夹...</value>
+  </data>
+  <data name="AddRule_PlaceholderDomain" xml:space="preserve">
+    <value>youtube.com 或 geosite:cn</value>
+  </data>
+  <data name="AddRule_PlaceholderIp" xml:space="preserve">
+    <value>192.168.0.0/16 或 geoip:cn</value>
+  </data>
+  <data name="AddRule_PlaceholderProcess" xml:space="preserve">
+    <value>可手填进程名 / 路径 / 文件夹，或点浏览选取</value>
+  </data>
+  <data name="AddRule_HintDomain" xml:space="preserve">
+    <value>支持精确匹配、regexp:、geosite: 前缀</value>
+  </data>
+  <data name="AddRule_HintIp" xml:space="preserve">
+    <value>支持 CIDR 与 geoip: 前缀</value>
+  </data>
+  <data name="AddRule_HintProcess" xml:space="preserve">
+    <value>同名进程：匹配任意路径下的同名 exe；完整路径：只匹配此 exe；整个目录：匹配该目录下所有 exe</value>
+  </data>
+  <data name="Personalize_AppLanguageTitle.Text" xml:space="preserve">
+    <value>应用语言</value>
+  </data>
+  <data name="Personalize_AppLanguageDesc.Text" xml:space="preserve">
+    <value>选择应用界面的显示语言</value>
+  </data>
+  <data name="Personalize_LangRestartBar.Title" xml:space="preserve">
+    <value>重启应用以应用语言更改</value>
+  </data>
+  <data name="Personalize_LangRestartBtn.Content" xml:space="preserve">
+    <value>重启</value>
+  </data>
+  <data name="Personalize_ProtocolColorsDesc.Text" xml:space="preserve">
+    <value>自定义不同协议的颜色标识</value>
+  </data>
+  <data name="Personalize_DetailSettings.Text" xml:space="preserve">
+    <value>详情设置</value>
+  </data>
+  <data name="Personalize_DetailsHeader.Text" xml:space="preserve">
+    <value>服务器信息显示</value>
+  </data>
+  <data name="Personalize_DetailsDesc.Text" xml:space="preserve">
+    <value>选择详情卡片上的信息展示</value>
+  </data>
+  <data name="Personalize_DetailLatency.Text" xml:space="preserve">
+    <value>延迟</value>
+  </data>
+  <data name="Personalize_DetailLatencyDesc.Text" xml:space="preserve">
+    <value>节点卡片上展示延迟</value>
+  </data>
+  <data name="Personalize_DetailAiUnlock.Text" xml:space="preserve">
+    <value>AI 解锁</value>
+  </data>
+  <data name="Personalize_DetailAiUnlockDesc.Text" xml:space="preserve">
+    <value>节点卡片上展示AI的解锁状态</value>
+  </data>
+  <data name="Personalize_ImportExportTitle.Text" xml:space="preserve">
+    <value>配置导入与导出</value>
+  </data>
+  <data name="Personalize_ImportExportDesc.Text" xml:space="preserve">
+    <value>将当前的节点和路由规则备份到本地，或从已有文件中恢复</value>
+  </data>
+  <data name="Personalize_ExportBtn.Content" xml:space="preserve">
+    <value>导出</value>
+  </data>
+  <data name="Personalize_ImportBtn.Content" xml:space="preserve">
+    <value>导入</value>
+  </data>
+  <data name="Personalize_ExportTooltip" xml:space="preserve">
+    <value>导出预置配置</value>
+  </data>
+  <data name="Personalize_ImportTooltip" xml:space="preserve">
+    <value>导入预置配置</value>
+  </data>
+  <data name="Personalize_ExportSuccessMsgFmt" xml:space="preserve">
+    <value>已导出至 {0}</value>
+  </data>
+  <data name="Personalize_ImportFailed" xml:space="preserve">
+    <value>导入失败</value>
+  </data>
+  <data name="Personalize_ImportSuccess" xml:space="preserve">
+    <value>导入成功</value>
+  </data>
+  <data name="Personalize_ImportSuccessMsg" xml:space="preserve">
+    <value>已导入 {0} 个节点、{1} 条订阅、{2} 条规则{3}。</value>
+  </data>
+  <data name="Personalize_ImportAdvancedSuffix" xml:space="preserve">
+    <value>、含高级路由</value>
+  </data>
+  <data name="Personalize_PresetMissingTitle" xml:space="preserve">
+    <value>未找到预置文件</value>
+  </data>
+  <data name="Personalize_PresetMissingMsg" xml:space="preserve">
+    <value>请先准备 Import 文件夹下的 servers.json / settings.json。</value>
+  </data>
+  <data name="ChainProxy_NameLabel.Text" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="ChainProxy_NameBox.PlaceholderText" xml:space="preserve">
+    <value>链式代理名称</value>
+  </data>
+  <data name="ChainProxy_EntryLabel.Text" xml:space="preserve">
+    <value>入口代理</value>
+  </data>
+  <data name="ChainProxy_EntryBox.PlaceholderText" xml:space="preserve">
+    <value>选择前置节点</value>
+  </data>
+  <data name="ChainProxy_ExitLabel.Text" xml:space="preserve">
+    <value>出口代理</value>
+  </data>
+  <data name="ChainProxy_ExitBox.PlaceholderText" xml:space="preserve">
+    <value>选择落地节点</value>
+  </data>
+  <data name="ChainProxy_Hint.Text" xml:space="preserve">
+    <value>流量经入口代理转发，再由出口代理出站</value>
+  </data>
+  <data name="ChainProxy_NameRequired" xml:space="preserve">
+    <value>请输入链式代理名称。</value>
+  </data>
+  <data name="ChainProxy_EntryRequired" xml:space="preserve">
+    <value>请选择入口代理。</value>
+  </data>
+  <data name="ChainProxy_ExitRequired" xml:space="preserve">
+    <value>请选择出口代理。</value>
+  </data>
+  <data name="ChainProxy_EntryExitSame" xml:space="preserve">
+    <value>入口代理和出口代理不能是同一个节点。</value>
+  </data>
+  <data name="Tun_MoreOptionsBtn.Content" xml:space="preserve">
+    <value>更多选项</value>
+  </data>
+  <data name="Tun_MtuLabel.Text" xml:space="preserve">
+    <value>最大传输单元</value>
+  </data>
+  <data name="Tun_InterfaceLabel.Text" xml:space="preserve">
+    <value>出口网卡</value>
+  </data>
+  <data name="Tun_InterfaceTooltip" xml:space="preserve">
+    <value>默认使用 Xray 自动选择；只有自动模式不可用时才手动指定。</value>
+  </data>
+  <data name="Tun_AutoInterfaceLabel" xml:space="preserve">
+    <value>auto（推荐）</value>
+  </data>
+  <data name="Subscription_DialogTitle_Add" xml:space="preserve">
+    <value>添加订阅</value>
+  </data>
+  <data name="Subscription_DialogTitle_Manage" xml:space="preserve">
+    <value>管理订阅</value>
+  </data>
+  <data name="Subscription_UrlBox.Header" xml:space="preserve">
+    <value>订阅链接</value>
+  </data>
+  <data name="Subscription_NameBox.Header" xml:space="preserve">
+    <value>备注名称（可选）</value>
+  </data>
+  <data name="Subscription_NameBox.PlaceholderText" xml:space="preserve">
+    <value>留空则使用链接域名</value>
+  </data>
+  <data name="Subscription_AutoImportHintText.Text" xml:space="preserve">
+    <value>将自动解析并导入该订阅中的全部节点</value>
+  </data>
+  <data name="Subscription_EmptyText.Text" xml:space="preserve">
+    <value>暂无订阅</value>
+  </data>
+  <data name="Subscription_DeleteConfirmText.Text" xml:space="preserve">
+    <value>删除订阅？</value>
+  </data>
+  <data name="Subscription_DeleteDescText.Text" xml:space="preserve">
+    <value>将同时删除该订阅下的所有节点。</value>
+  </data>
+  <data name="Subscription_DeleteConfirmBtn.Content" xml:space="preserve">
+    <value>删除</value>
+  </data>
 </root>

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -25,7 +25,7 @@ namespace XrayUI.ViewModels
         private bool _isRunning;
         private bool _isTunMode;
         private int _localPort = 16890;
-        private string _routingMode = "智能分流";
+        private string _routingMode = "smart";
         private bool _isSystemProxyEnabled = true;
         private bool _isStartupEnabled;
         private bool _isAutoConnect;
@@ -230,7 +230,7 @@ namespace XrayUI.ViewModels
 
             var appSettings = await _settings.LoadSettingsAsync();
             appSettings.LocalMixedPort = LocalPort;
-            appSettings.RoutingMode    = RoutingMode == "智能分流" ? "smart" : "global";
+            appSettings.RoutingMode    = RoutingMode;
             appSettings.IsTunMode      = IsTunMode;
             if (IsAutoConnect)
                 appSettings.LastAutoConnectServerId = server.Id;
@@ -318,7 +318,7 @@ namespace XrayUI.ViewModels
                 {
                     var settings = await _settings.LoadSettingsAsync();
                     settings.LocalMixedPort        = LocalPort;
-                    settings.RoutingMode           = RoutingMode == "智能分流" ? "smart" : "global";
+                    settings.RoutingMode           = RoutingMode;
                     settings.IsTunMode             = IsTunMode;
                     settings.IsSystemProxyEnabled  = _isSystemProxyEnabled;
 
@@ -706,11 +706,21 @@ namespace XrayUI.ViewModels
 
         // ── Routing mode ──────────────────────────────────────────────────────
 
+        /// <summary>Business code: "smart" | "global". This is what gets persisted to
+        /// settings.json and what XAML RadioButton.CommandParameter values match against.
+        /// For display, bind to <see cref="RoutingModeText"/>.</summary>
         public string RoutingMode
         {
             get => _routingMode;
-            set => SetProperty(ref _routingMode, value);
+            set
+            {
+                if (SetProperty(ref _routingMode, value))
+                    OnPropertyChanged(nameof(RoutingModeText));
+            }
         }
+
+        /// <summary>Localized display string for the status bar / mini view.</summary>
+        public string RoutingModeText => _routingMode == "global" ? "全局路由" : "智能分流";
 
         [RelayCommand]
         private async Task SetRoutingMode(string mode)
@@ -721,7 +731,7 @@ namespace XrayUI.ViewModels
 
             RoutingMode = mode;
             var s = await _settings.LoadSettingsAsync();
-            s.RoutingMode = mode == "智能分流" ? "smart" : "global";
+            s.RoutingMode = mode;
             await TrySaveSettingsAsync(s, "persist routing mode");
 
             // Apply live if xray is currently running (UI only allows this when !IsTunMode).
@@ -753,7 +763,9 @@ namespace XrayUI.ViewModels
         [RelayCommand]
         private async Task SetProxyMode(string mode)
         {
-            var want = mode == "全局代理";
+            // Business code: "system" = take over WinINet system proxy, "manual" = leave
+            // registry alone (user wires their apps to the local SOCKS port themselves).
+            var want = mode == "system";
 
             // No-op guard: clicking the already-selected radio must not re-hit
             // the registry or re-write settings.

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -20,7 +20,7 @@ namespace XrayUI.ViewModels
         private readonly IUpdateService _update;
         private UpdateInfo? _availableUpdate;
         private bool _isUpdateAvailable;
-        private string _startStopButtonContent = "启动";
+        private string _startStopButtonContent = L.ControlPanel_Start;
         private bool _startStopButtonChecked;
         private bool _isRunning;
         private bool _isTunMode;
@@ -131,13 +131,13 @@ namespace XrayUI.ViewModels
         }
 
         public string StatusText =>
-            IsReapplying ? "正在应用..." :
+            IsReapplying ? L.ControlPanel_StatusApplying :
             IsRunning    ? _activeServerName :
-                           "未运行";
+                           L.ControlPanel_StatusNotRunning;
 
         private void OnIsRunningChanged(bool value)
         {
-            StartStopButtonContent = value ? "停止" : "启动";
+            StartStopButtonContent = value ? L.ControlPanel_Stop : L.ControlPanel_Start;
             StartStopButtonChecked = value;
             OnPropertyChanged(nameof(StatusText));
             OnPropertyChanged(nameof(IsModeToggleEnabled));
@@ -224,7 +224,7 @@ namespace XrayUI.ViewModels
             var server = GetSelectedServer();
             if (server is null)
             {
-                await _dialogs.ShowErrorAsync("未选择服务器", "请先从列表中选择服务器");
+                await _dialogs.ShowErrorAsync(L.Error_NoServer, L.Error_NoServerMsg);
                 return false;
             }
 
@@ -247,9 +247,9 @@ namespace XrayUI.ViewModels
             if (!ok)
             {
                 var detail = string.IsNullOrEmpty(_xray.LastError)
-                    ? "xray 启动失败. 请检查服务器配置."
+                    ? L.Error_XrayStartFailed
                     : _xray.LastError;
-                await _dialogs.ShowErrorAsync("启动失败", detail);
+                await _dialogs.ShowErrorAsync(L.Error_StartFailed, detail);
                 return false;
             }
 
@@ -292,7 +292,7 @@ namespace XrayUI.ViewModels
             _activeServer     = null;
             _activeServerName = string.Empty;
             IsRunning = false;
-            await _dialogs.ShowErrorAsync("启动失败", ex.Message);
+            await _dialogs.ShowErrorAsync(L.Error_StartFailed, ex.Message);
         }
 
         /// <summary>
@@ -328,7 +328,7 @@ namespace XrayUI.ViewModels
                     if (!ok)
                     {
                         var detail = string.IsNullOrEmpty(_xray.LastError)
-                            ? "xray 应用新配置失败，已停止。"
+                            ? L.Error_XrayReapplyFailed
                             : _xray.LastError;
                         await HandleReapplyFailureAsync(detail);
                         return;
@@ -385,7 +385,7 @@ namespace XrayUI.ViewModels
             _activeServerName = string.Empty;
             IsRunning = false;
 
-            await _dialogs.ShowErrorAsync("应用新配置失败", detail);
+            await _dialogs.ShowErrorAsync(L.Error_ReapplyFailed, detail);
         }
 
 
@@ -720,7 +720,7 @@ namespace XrayUI.ViewModels
         }
 
         /// <summary>Localized display string for the status bar / mini view.</summary>
-        public string RoutingModeText => _routingMode == "global" ? "全局路由" : "智能分流";
+        public string RoutingModeText => _routingMode == "global" ? L.ControlPanel_RoutingGlobal : L.ControlPanel_RoutingSmart;
 
         [RelayCommand]
         private async Task SetRoutingMode(string mode)
@@ -830,7 +830,7 @@ namespace XrayUI.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogs.ShowErrorAsync("开机启动设置失败", ex.Message);
+                await _dialogs.ShowErrorAsync(L.Startup_SetFailed, ex.Message);
                 return;
             }
 
@@ -893,7 +893,7 @@ namespace XrayUI.ViewModels
         }
 
         public Visibility UpdateBadgeVisibility => _isUpdateAvailable ? Visibility.Visible : Visibility.Collapsed;
-        public string     UpdateMenuText        => $"发现新版本 {_availableUpdate?.NewVersion}";
+        public string     UpdateMenuText        => Loc.Format("ControlPanel_UpdateFound", _availableUpdate?.NewVersion);
 
         /// <summary>Called from MainViewModel after the background check completes.
         /// Pass null to clear (e.g. after a failed update attempt).</summary>
@@ -916,7 +916,7 @@ namespace XrayUI.ViewModels
             UpdateStaging? staging = null;
             try
             {
-                await _dialogs.ShowProgressBarDialogAsync("正在更新 XrayUI",
+                await _dialogs.ShowProgressBarDialogAsync(L.Update_Updating,
                     async (progress, ct) =>
                     {
                         staging = await _update.DownloadVerifyAndExtractAsync(info, proxy, progress, ct);
@@ -929,7 +929,7 @@ namespace XrayUI.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogs.ShowErrorAsync("更新失败", ex.Message);
+                await _dialogs.ShowErrorAsync(L.Error_UpdateFailed, ex.Message);
                 return;
             }
 
@@ -944,7 +944,7 @@ namespace XrayUI.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogs.ShowErrorAsync("更新失败", "无法启动升级器：" + ex.Message);
+                await _dialogs.ShowErrorAsync(L.Error_UpdateFailed, Loc.Format("Error_UpdaterLaunchFailed", ex.Message));
                 return;
             }
 

--- a/ViewModels/CustomRulesViewModel.cs
+++ b/ViewModels/CustomRulesViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using XrayUI.Helpers;
 using XrayUI.Models;
 using XrayUI.Services;
 
@@ -187,7 +188,7 @@ namespace XrayUI.ViewModels
             catch (Exception ex)
             {
                 await _dialogs.ShowErrorAsync(
-                    "无法准备 settings.json",
+                    L.CustomRules_PrepFailedTitle,
                     ex.Message,
                     xamlRoot);
                 return;
@@ -201,8 +202,8 @@ namespace XrayUI.ViewModels
             catch (Exception ex)
             {
                 await _dialogs.ShowErrorAsync(
-                    "无法打开编辑器",
-                    $"未找到 .json 关联程序或启动失败：{ex.Message}",
+                    L.CustomRules_OpenEditorFailedTitle,
+                    Loc.Format("CustomRules_OpenEditorFailedMsg", ex.Message),
                     xamlRoot);
             }
         }
@@ -230,7 +231,7 @@ namespace XrayUI.ViewModels
             try
             {
                 await _dialogs.ShowProgressDialogAsync(
-                    "正在更新路由数据",
+                    L.GeoUpdate_Updating,
                     async (progress, ct) => result = await _geoUpdate.UpdateAsync(progress, proxyUrl, ct),
                     xamlRoot);
             }
@@ -243,7 +244,7 @@ namespace XrayUI.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogs.ShowErrorAsync("更新失败", ex.Message, xamlRoot);
+                await _dialogs.ShowErrorAsync(L.Error_UpdateFailed, ex.Message, xamlRoot);
                 return;
             }
 
@@ -251,8 +252,8 @@ namespace XrayUI.ViewModels
             if (!result.AnyUpdated)
             {
                 await _dialogs.ShowErrorAsync(
-                    "已是最新",
-                    "geoip.dat 和 geosite.dat 都已是最新版本，无需下载。",
+                    L.GeoUpdate_AlreadyLatest,
+                    L.GeoUpdate_AlreadyLatestMsg,
                     xamlRoot);
                 return;
             }
@@ -263,31 +264,31 @@ namespace XrayUI.ViewModels
             {
                 if (_isTunMode?.Invoke() == true)
                 {
-                    message = "已更新。TUN 模式下请手动重启以生效。";
+                    message = L.GeoUpdate_TunRestart;
                 }
                 else if (_reapplyRouting != null)
                 {
                     try
                     {
                         await _reapplyRouting();
-                        message = "已更新并重新加载 xray。";
+                        message = L.GeoUpdate_ReloadedOk;
                     }
                     catch (Exception ex)
                     {
-                        message = $"已更新数据文件，但重启 xray 失败：{ex.Message}";
+                        message = Loc.Format("GeoUpdate_ReloadFailed", ex.Message);
                     }
                 }
                 else
                 {
-                    message = "已更新。请重启 xray 以生效。";
+                    message = L.GeoUpdate_RestartRequired;
                 }
             }
             else
             {
-                message = "已更新。下次启动 xray 时生效。";
+                message = L.GeoUpdate_NextStart;
             }
 
-            await _dialogs.ShowErrorAsync("更新成功", message, xamlRoot);
+            await _dialogs.ShowErrorAsync(L.GeoUpdate_Success, message, xamlRoot);
         }
     }
 }

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -46,7 +46,7 @@ namespace XrayUI.ViewModels
         public string ActiveServerName =>
             (ControlPanel.IsRunning ? _activeServer : ServerList.SelectedServer)?.Name ?? "未选择";
 
-        public string MiniRoutingMode => ControlPanel.RoutingMode;
+        public string MiniRoutingMode => ControlPanel.RoutingModeText;
         public IAsyncRelayCommand MiniStartStopCommand => ControlPanel.StartStopCommand;
         public bool MiniIsRunning => ControlPanel.IsRunning;
         public string MiniStatusText => ControlPanel.IsRunning ? _activeLatencyText : "未连接";
@@ -115,7 +115,7 @@ namespace XrayUI.ViewModels
             // Load settings and apply to ControlPanel
             var s = await _settings.LoadSettingsAsync();
             ControlPanel.LocalPort             = s.LocalMixedPort;
-            ControlPanel.RoutingMode           = s.RoutingMode == "global" ? "全局路由" : "智能分流";
+            ControlPanel.RoutingMode           = s.RoutingMode;
             ControlPanel.IsSystemProxyEnabled  = s.IsSystemProxyEnabled;
             ControlPanel.InitializePersonalize(s);
             Personalize.LoadDisplayOptions(s);

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using XrayUI.Helpers;
 using XrayUI.Models;
 using XrayUI.Services;
 
@@ -44,12 +45,12 @@ namespace XrayUI.ViewModels
         }
 
         public string ActiveServerName =>
-            (ControlPanel.IsRunning ? _activeServer : ServerList.SelectedServer)?.Name ?? "未选择";
+            (ControlPanel.IsRunning ? _activeServer : ServerList.SelectedServer)?.Name ?? L.Main_NoSelection;
 
         public string MiniRoutingMode => ControlPanel.RoutingModeText;
         public IAsyncRelayCommand MiniStartStopCommand => ControlPanel.StartStopCommand;
         public bool MiniIsRunning => ControlPanel.IsRunning;
-        public string MiniStatusText => ControlPanel.IsRunning ? _activeLatencyText : "未连接";
+        public string MiniStatusText => ControlPanel.IsRunning ? _activeLatencyText : L.Main_NotConnected;
         public Visibility MiniDotVisibility => ControlPanel.IsRunning ? Visibility.Visible : Visibility.Collapsed;
 
         public MainViewModel(

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -119,6 +119,7 @@ namespace XrayUI.ViewModels
             ControlPanel.IsSystemProxyEnabled  = s.IsSystemProxyEnabled;
             ControlPanel.InitializePersonalize(s);
             Personalize.LoadDisplayOptions(s);
+            Personalize.LoadLanguage(s);
             ServerDetail.ShowLatencyInDetails = s.ShowLatencyInDetails;
             ServerDetail.ShowAiUnlockInDetails = s.ShowAiUnlockInDetails;
 

--- a/ViewModels/ManageSubscriptionsViewModel.cs
+++ b/ViewModels/ManageSubscriptionsViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
+using XrayUI.Helpers;
 using XrayUI.Models;
 
 namespace XrayUI.ViewModels
@@ -74,7 +75,7 @@ namespace XrayUI.ViewModels
         public bool IsAddPage => SelectedIndex == 0;
         public bool IsManagePage => SelectedIndex == 1;
         public bool CanAddSubscription => IsAddPage && !string.IsNullOrWhiteSpace(SubscriptionUrl);
-        public string DialogTitle => IsAddPage ? "添加订阅" : "管理订阅";
+        public string DialogTitle => IsAddPage ? L.Subscription_DialogTitle_Add : L.Subscription_DialogTitle_Manage;
 
         public Visibility AddPageVisibility => IsAddPage ? Visibility.Visible : Visibility.Collapsed;
         public Visibility ManagePageVisibility => IsManagePage ? Visibility.Visible : Visibility.Collapsed;

--- a/ViewModels/PersonalizeViewModel.cs
+++ b/ViewModels/PersonalizeViewModel.cs
@@ -202,10 +202,10 @@ namespace XrayUI.ViewModels
         public async Task<PresetImportResult?> ConfirmAndImportPresetAsync()
         {
             var confirmed = await _dialogs.ShowConfirmationAsync(
-                "替换当前配置?",
-                "此操作将覆盖您当前的全部节点和路由规则,强烈建议先导出备份。是否继续?",
-                "替换",
-                "取消",
+                L.Confirm_ReplaceTitle,
+                L.Confirm_ReplaceMsg,
+                L.Dialog_Replace,
+                L.Dialog_Cancel,
                 isDanger: true);
             if (!confirmed)
                 return null;

--- a/ViewModels/PersonalizeViewModel.cs
+++ b/ViewModels/PersonalizeViewModel.cs
@@ -20,6 +20,9 @@ namespace XrayUI.ViewModels
 
         private int _selectedThemeIndex;
         private int _selectedBackdropIndex;
+        private int _selectedLanguageIndex;
+        private int _initialLanguageIndex = -1;
+        private bool _showLanguageRestartHint;
         private bool _showLatencyInDetails = true;
         private bool _showAiUnlockInDetails = true;
 
@@ -131,6 +134,42 @@ namespace XrayUI.ViewModels
             }
         }
 
+        // ── Language ──────────────────────────────────────────────────────────
+
+        /// <summary>Bound to the language ComboBox's ItemsSource — single source of truth
+        /// for the dropdown contents. Adding a language is a one-line edit in LanguageHelper.</summary>
+        public LanguageInfo[] SupportedLanguages => LanguageHelper.SupportedLanguages;
+
+        public int SelectedLanguageIndex
+        {
+            get => _selectedLanguageIndex;
+            set
+            {
+                if (!SetProperty(ref _selectedLanguageIndex, value)) return;
+                // Hint visibility tracks divergence from the loaded value, not "has the
+                // user touched the dropdown" — flipping back to the initial choice means
+                // no restart is needed, so the hint should disappear too. The -1 guard
+                // suppresses the side effect during the initial LoadLanguage call.
+                if (_initialLanguageIndex >= 0)
+                    ShowLanguageRestartHint = value != _initialLanguageIndex;
+            }
+        }
+
+        public bool ShowLanguageRestartHint
+        {
+            get => _showLanguageRestartHint;
+            set => SetProperty(ref _showLanguageRestartHint, value);
+        }
+
+        /// <summary>Persist the currently-selected language. Call right before <see cref="App.Restart"/>.</summary>
+        public async Task ApplyLanguageAsync()
+        {
+            var tag = LanguageHelper.TagAt(_selectedLanguageIndex);
+            var s = await _settings.LoadSettingsAsync();
+            s.Language = tag;
+            await _settings.SaveSettingsAsync(s);
+        }
+
         public bool ShowLatencyInDetails
         {
             get => _showLatencyInDetails;
@@ -190,6 +229,10 @@ namespace XrayUI.ViewModels
             s.BackdropSetting = ThemeHelper.CurrentBackdrop;
             s.ShowLatencyInDetails = ShowLatencyInDetails;
             s.ShowAiUnlockInDetails = ShowAiUnlockInDetails;
+            // Language doesn't take effect until the next process start, but Done still
+            // persists it — otherwise the user would have to click the restart hint to
+            // save at all, which is surprising compared to how Theme / Backdrop behave.
+            s.Language = LanguageHelper.TagAt(_selectedLanguageIndex);
             await _settings.SaveSettingsAsync(s);
             CloseRequested?.Invoke(this, EventArgs.Empty);
         }
@@ -226,6 +269,16 @@ namespace XrayUI.ViewModels
         {
             ShowLatencyInDetails = settings.ShowLatencyInDetails;
             ShowAiUnlockInDetails = settings.ShowAiUnlockInDetails;
+        }
+
+        public void LoadLanguage(AppSettings settings)
+        {
+            // Assign through the field to bypass the setter's InfoBar side effect, then
+            // record this as the baseline so divergence-from-baseline drives the hint.
+            var index = LanguageHelper.IndexOf(settings.Language);
+            _selectedLanguageIndex = index;
+            _initialLanguageIndex = index;
+            OnPropertyChanged(nameof(SelectedLanguageIndex));
         }
     }
 }

--- a/ViewModels/ServerDetailViewModel.cs
+++ b/ViewModels/ServerDetailViewModel.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Media;
+using XrayUI.Helpers;
 using XrayUI.Models;
 using XrayUI.Services;
 
@@ -26,7 +27,7 @@ namespace XrayUI.ViewModels
         private AiUnlockStatus? _claudeStatus;
         private AiUnlockStatus? _geminiStatus;
         private ServerEntry? _selectedServer;
-        private string _latencyText = "Not tested";
+        private string _latencyText = string.Empty;
         private bool _isTestingLatency;
         private SolidColorBrush _openAiStatusBrush = null!;
         private SolidColorBrush _claudeStatusBrush = null!;
@@ -38,6 +39,7 @@ namespace XrayUI.ViewModels
         {
             _latencyProbe = latencyProbe;
             _aiUnlockCheck = aiUnlockCheck;
+            _latencyText = L.ServerDetail_NotTested;
             ResetAiUnlockDisplay();
         }
 
@@ -89,22 +91,22 @@ namespace XrayUI.ViewModels
             }
         }
 
-        public string SelectedName => SelectedServer?.Name ?? "未选择服务器";
+        public string SelectedName => SelectedServer?.Name ?? L.ServerDetail_NoServer;
 
         public string SelectedHostLabel
-            => SelectedServer?.IsChain == true ? "入口" : "地址";
+            => SelectedServer?.IsChain == true ? L.ServerDetail_Entry : L.ServerDetail_Address;
 
         public string SelectedHost
             => SelectedServer?.IsChain == true
-                ? ResolveChainServer(SelectedServer.ChainEntryServerId)?.Name ?? "(入口节点缺失)"
+                ? ResolveChainServer(SelectedServer.ChainEntryServerId)?.Name ?? L.ServerDetail_EntryMissing
                 : SelectedServer?.Host ?? "-";
 
         public string SelectedPortLabel
-            => SelectedServer?.IsChain == true ? "出口" : "端口";
+            => SelectedServer?.IsChain == true ? L.ServerDetail_Exit : L.ServerDetail_Port;
 
         public string SelectedPort
             => SelectedServer?.IsChain == true
-                ? ResolveChainServer(SelectedServer.ChainExitServerId)?.Name ?? "(出口节点缺失)"
+                ? ResolveChainServer(SelectedServer.ChainExitServerId)?.Name ?? L.ServerDetail_ExitMissing
                 : SelectedServer?.Port.ToString() ?? "-";
 
         public string SelectedProtocol => SelectedServer?.DisplayProtocol ?? "-";
@@ -112,10 +114,10 @@ namespace XrayUI.ViewModels
         public string SelectedSecurityLabel
             => (SelectedServer?.Protocol?.ToLowerInvariant()) switch
             {
-                "ss" => "加密",
-                "socks" => "认证",
-                "chain" => "链路",
-                _ => "安全"
+                "ss"    => L.ServerDetail_Encryption,
+                "socks" => L.ServerDetail_AuthLabel,
+                "chain" => L.ServerDetail_ChainLabel,
+                _       => L.ServerDetail_Security
             };
 
         public string SelectedEncryption
@@ -128,8 +130,8 @@ namespace XrayUI.ViewModels
                     case "socks":
                         return string.IsNullOrWhiteSpace(SelectedServer.Username)
                                && string.IsNullOrWhiteSpace(SelectedServer.Password)
-                            ? "无认证"
-                            : "用户名/密码";
+                            ? L.ServerDetail_NoAuth
+                            : L.ServerDetail_UserPass;
                     case "chain":
                         var entry = ResolveChainServer(SelectedServer.ChainEntryServerId)?.DisplayProtocol ?? "?";
                         var exit = ResolveChainServer(SelectedServer.ChainExitServerId)?.DisplayProtocol ?? "?";
@@ -356,8 +358,7 @@ namespace XrayUI.ViewModels
 
         private void ResetLatencyDisplay()
         {
-            LatencyText = "未测试";
-            
+            LatencyText = L.ServerDetail_NotTested;
         }
 
         private void ResetAiUnlockDisplay()
@@ -498,7 +499,7 @@ namespace XrayUI.ViewModels
             _latencyTestCts = cts;
 
             IsTestingLatency = true;
-            LatencyText = "测试中...";
+            LatencyText = L.ServerDetail_Testing;
 
             try
             {
@@ -514,9 +515,9 @@ namespace XrayUI.ViewModels
 
                 LatencyText = result.Status switch
                 {
-                    LatencyProbeStatus.Success => $"{result.Milliseconds ?? 0} ms",
-                    LatencyProbeStatus.Timeout => "超时",
-                    _ => "失败"
+                    LatencyProbeStatus.Success => Loc.Format("ServerDetail_LatencyMs", result.Milliseconds ?? 0),
+                    LatencyProbeStatus.Timeout => L.ServerDetail_Timeout,
+                    _                          => L.ServerDetail_Failed
                 };
             }
             catch (OperationCanceledException) when (cts.IsCancellationRequested)

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -27,12 +27,14 @@ namespace XrayUI.ViewModels
         private const string AllChipKey            = "__all__";
         private const string UngroupedChipKey      = "__ungrouped__";
         private const string FavoritesChipKey      = "__favorites__";
-        private const string AllChipName           = "所有服务器";
-        private const string UngroupedName         = "未分组";
-        private const string FavoritesName         = "收藏列表";
-        private const string UnnamedSubLabel       = "(未命名订阅)";
-        private const string OrphanSubLabel        = "(已删除订阅)";
         private const string SubscriptionUserAgent = "v2rayN/7.0";
+
+        // Localized labels — looked up lazily so language changes apply at startup.
+        private static string AllChipName     => L.ServerList_AllServers;
+        private static string UngroupedName   => L.ServerList_Ungrouped;
+        private static string FavoritesName   => L.ServerList_Favorites;
+        private static string UnnamedSubLabel => L.ServerList_UnnamedSub;
+        private static string OrphanSubLabel  => L.ServerList_OrphanSub;
 
         private static readonly HttpClient Http = CreateSubscriptionHttpClient();
 
@@ -613,7 +615,7 @@ namespace XrayUI.ViewModels
 
             if (added == 0)
             {
-                await _dialogs.ShowErrorAsync("解析失败", "无法识别有效的节点链接，请检查后重试。");
+                await _dialogs.ShowErrorAsync(L.Import_ParseFailed, L.Import_ParseFailedMsg);
                 return;
             }
 
@@ -664,7 +666,7 @@ namespace XrayUI.ViewModels
 
             if (entries == null)
             {
-                await _dialogs.ShowErrorAsync("订阅拉取失败", error ?? "未知错误");
+                await _dialogs.ShowErrorAsync(L.Subscription_FetchFailed, error ?? L.Subscription_UnknownError);
             }
         }
 
@@ -699,7 +701,7 @@ namespace XrayUI.ViewModels
             }
 
             if (entries.Count == 0)
-                return (null, "未能从订阅中解析出任何有效节点。");
+                return (null, L.Subscription_NoParsed);
 
             return (entries, null);
         }
@@ -708,7 +710,7 @@ namespace XrayUI.ViewModels
         {
             if (IsSubscriptionLocked(sub.Id))
             {
-                sub.LastError = "请先停止代理后再刷新";
+                sub.LastError = L.Subscription_StopFirst_Refresh;
                 return;
             }
 
@@ -718,7 +720,7 @@ namespace XrayUI.ViewModels
                 var (newEntries, error) = await FetchSubscriptionNodesAsync(sub);
                 if (newEntries == null)
                 {
-                    sub.LastError = $"更新失败: {error}";
+                    sub.LastError = Loc.Format("Subscription_UpdateFailed", error);
                     return;
                 }
 
@@ -803,7 +805,7 @@ namespace XrayUI.ViewModels
         {
             if (IsSubscriptionLocked(sub.Id))
             {
-                sub.LastError = "请先停止代理后再删除";
+                sub.LastError = L.Subscription_StopFirst_Delete;
                 return false;
             }
 
@@ -937,7 +939,7 @@ namespace XrayUI.ViewModels
             var link = NodeLinkSerializer.ToLink(SelectedServer);
             if (string.IsNullOrEmpty(link))
             {
-                await _dialogs.ShowErrorAsync("不支持分享", "该节点协议暂不支持生成分享链接。");
+                await _dialogs.ShowErrorAsync(L.Share_NotSupported, L.Share_NotSupportedMsg);
                 return;
             }
 
@@ -1000,14 +1002,14 @@ namespace XrayUI.ViewModels
 
             var isBatchDelete = selectedServers.Count > 1;
             var message = isBatchDelete
-                ? $"确定要删除当前 {selectedServers.Count} 个项目?"
-                : $"确定要删除 {selectedServers[0].Name}?";
+                ? Loc.Format("Confirm_DeleteBatchMsg", selectedServers.Count)
+                : Loc.Format("Confirm_DeleteMsg", selectedServers[0].Name);
 
             var confirmed = await _dialogs.ShowConfirmationAsync(
-                "确认删除",
+                L.Confirm_DeleteTitle,
                 message,
-                "删除",
-                "取消",
+                L.Dialog_Delete,
+                L.Dialog_Cancel,
                 isDanger: true);
             if (!confirmed) return;
 

--- a/Views/AddChainProxyDialog.xaml
+++ b/Views/AddChainProxyDialog.xaml
@@ -11,18 +11,22 @@
     <StackPanel Spacing="16" MinWidth="340" MaxWidth="400">
 
         <StackPanel Spacing="6">
-            <TextBlock Text="名称"
+            <TextBlock x:Uid="ChainProxy_NameLabel"
+                       Text="名称"
                        FontSize="12"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
             <TextBox x:Name="NameTextBox"
+                     x:Uid="ChainProxy_NameBox"
                      PlaceholderText="链式代理名称" />
         </StackPanel>
 
         <StackPanel Spacing="6">
-            <TextBlock Text="入口代理"
+            <TextBlock x:Uid="ChainProxy_EntryLabel"
+                       Text="入口代理"
                        FontSize="12"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
             <ComboBox x:Name="EntryComboBox"
+                      x:Uid="ChainProxy_EntryBox"
                       HorizontalAlignment="Stretch"
                       PlaceholderText="选择前置节点">
                 <ComboBox.ItemTemplate>
@@ -49,10 +53,12 @@
         </StackPanel>
 
         <StackPanel Spacing="6">
-            <TextBlock Text="出口代理"
+            <TextBlock x:Uid="ChainProxy_ExitLabel"
+                       Text="出口代理"
                        FontSize="12"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
             <ComboBox x:Name="ExitComboBox"
+                      x:Uid="ChainProxy_ExitBox"
                       HorizontalAlignment="Stretch"
                       PlaceholderText="选择落地节点">
                 <ComboBox.ItemTemplate>
@@ -76,7 +82,8 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-            <TextBlock Text="流量经入口代理转发，再由出口代理出站"
+            <TextBlock x:Uid="ChainProxy_Hint"
+                       Text="流量经入口代理转发，再由出口代理出站"
                        FontSize="11"
                        Opacity="0.6"
                        TextWrapping="Wrap" />

--- a/Views/AddChainProxyDialog.xaml.cs
+++ b/Views/AddChainProxyDialog.xaml.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using XrayUI.Helpers;
 using XrayUI.Models;
 
 namespace XrayUI.Views
@@ -39,25 +40,25 @@ namespace XrayUI.Views
             var name = NameTextBox.Text.Trim();
             if (string.IsNullOrWhiteSpace(name))
             {
-                ShowError("请输入链式代理名称。");
+                ShowError(L.ChainProxy_NameRequired);
                 return false;
             }
 
             if (EntryComboBox.SelectedItem is not ServerEntry entryServer)
             {
-                ShowError("请选择入口代理。");
+                ShowError(L.ChainProxy_EntryRequired);
                 return false;
             }
 
             if (ExitComboBox.SelectedItem is not ServerEntry exitServer)
             {
-                ShowError("请选择出口代理。");
+                ShowError(L.ChainProxy_ExitRequired);
                 return false;
             }
 
             if (entryServer.Id == exitServer.Id)
             {
-                ShowError("入口代理和出口代理不能是同一个节点。");
+                ShowError(L.ChainProxy_EntryExitSame);
                 return false;
             }
 

--- a/Views/AddRuleDialog.xaml
+++ b/Views/AddRuleDialog.xaml
@@ -14,20 +14,22 @@
     <StackPanel Spacing="16" MinWidth="320" MaxWidth="380">
 
         <StackPanel Spacing="6">
-            <TextBlock Text="类型"
+            <TextBlock x:Uid="AddRule_TypeLabelText"
+                       Text="类型"
                        FontSize="12"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
             <ComboBox x:Name="TypeComboBox"
                       SelectedIndex="0"
                       HorizontalAlignment="Stretch">
-                <ComboBoxItem Content="域名（Domain）"  Tag="domain" />
-                <ComboBoxItem Content="IP"              Tag="ip" />
-                <ComboBoxItem Content="进程（Process）" Tag="process" />
+                <ComboBoxItem x:Uid="AddRule_TypeDomainItem" Content="域名（Domain）"  Tag="domain" />
+                <ComboBoxItem Content="IP"                                            Tag="ip" />
+                <ComboBoxItem x:Uid="AddRule_TypeProcessItem" Content="进程（Process）" Tag="process" />
             </ComboBox>
         </StackPanel>
 
         <StackPanel Spacing="6">
-            <TextBlock Text="匹配内容"
+            <TextBlock x:Uid="AddRule_MatchLabelText"
+                       Text="匹配内容"
                        FontSize="12"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
             <TextBox x:Name="MatchTextBox"
@@ -47,9 +49,9 @@
                 <ComboBox x:Name="BrowseFormatComboBox"
                           SelectedIndex="0"
                           MinWidth="130">
-                    <ComboBoxItem Content="匹配同名进程" Tag="name" />
-                    <ComboBoxItem Content="匹配完整路径" Tag="path" />
-                    <ComboBoxItem Content="匹配整个目录" Tag="folder" />
+                    <ComboBoxItem x:Uid="AddRule_BrowseNameItem"   Content="匹配同名进程" Tag="name" />
+                    <ComboBoxItem x:Uid="AddRule_BrowsePathItem"   Content="匹配完整路径" Tag="path" />
+                    <ComboBoxItem x:Uid="AddRule_BrowseFolderItem" Content="匹配整个目录" Tag="folder" />
                 </ComboBox>
             </StackPanel>
 
@@ -61,19 +63,21 @@
         </StackPanel>
 
         <StackPanel Spacing="6">
-            <TextBlock Text="出站"
+            <TextBlock x:Uid="AddRule_OutboundLabelText"
+                       Text="出站"
                        FontSize="12"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
             <ComboBox x:Name="OutboundComboBox"
                       SelectedIndex="0"
                       HorizontalAlignment="Stretch">
-                <ComboBoxItem Content="proxy（代理）"  Tag="proxy" />
-                <ComboBoxItem Content="direct（直连）" Tag="direct" />
-                <ComboBoxItem Content="block（阻断）"  Tag="block" />
+                <ComboBoxItem x:Uid="AddRule_OutboundProxyItem"  Content="proxy（代理）"  Tag="proxy" />
+                <ComboBoxItem x:Uid="AddRule_OutboundDirectItem" Content="direct（直连）" Tag="direct" />
+                <ComboBoxItem x:Uid="AddRule_OutboundBlockItem"  Content="block（阻断）"  Tag="block" />
             </ComboBox>
         </StackPanel>
 
         <TextBlock x:Name="ErrorText"
+                   x:Uid="AddRule_ErrorTextElem"
                    Text="请填写匹配内容"
                    Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                    FontSize="11"

--- a/Views/AddRuleDialog.xaml.cs
+++ b/Views/AddRuleDialog.xaml.cs
@@ -19,6 +19,10 @@ namespace XrayUI.Views
             this.InitializeComponent();
             this.RequestedTheme = ThemeHelper.ActualTheme;
 
+            Title             = L.AddRule_Title;
+            PrimaryButtonText = L.Dialog_Add;
+            CloseButtonText   = L.Dialog_Cancel;
+
             // Wire up event handlers in code-behind (NOT via XAML markup).
             // The XAML-compiler-generated Connect path for SelectionChanged on a
             // ContentDialog can fail to fire under AOT in WinUI 3; explicit
@@ -29,8 +33,8 @@ namespace XrayUI.Views
 
             if (existing != null)
             {
-                Title             = "编辑规则";
-                PrimaryButtonText = "保存";
+                Title             = L.AddRule_EditTitle;
+                PrimaryButtonText = L.Dialog_Save;
 
                 TypeComboBox.SelectedIndex = existing.Type switch
                 {
@@ -71,9 +75,9 @@ namespace XrayUI.Views
             {
                 MatchTextBox.PlaceholderText = tag switch
                 {
-                    "ip"      => "192.168.0.0/16 或 geoip:cn",
-                    "process" => "可手填进程名 / 路径 / 文件夹，或点浏览选取",
-                    _         => "youtube.com 或 geosite:cn",
+                    "ip"      => L.AddRule_PlaceholderIp,
+                    "process" => L.AddRule_PlaceholderProcess,
+                    _         => L.AddRule_PlaceholderDomain,
                 };
             }
 
@@ -81,9 +85,9 @@ namespace XrayUI.Views
             {
                 HintTextBlock.Text = tag switch
                 {
-                    "ip"      => "支持 CIDR 与 geoip: 前缀",
-                    "process" => "同名进程：匹配任意路径下的同名 exe；完整路径：只匹配此 exe；整个目录：匹配该目录下所有 exe",
-                    _         => "支持精确匹配、regexp:、geosite: 前缀",
+                    "ip"      => L.AddRule_HintIp,
+                    "process" => L.AddRule_HintProcess,
+                    _         => L.AddRule_HintDomain,
                 };
             }
         }
@@ -97,7 +101,7 @@ namespace XrayUI.Views
         {
             if (BrowseButtonText is null) return;
             var isFolder = GetSelectedBrowseFormat() == "folder";
-            BrowseButtonText.Text = isFolder ? "浏览文件夹..." : "浏览 exe...";
+            BrowseButtonText.Text = isFolder ? L.AddRule_BrowseFolder : L.AddRule_BrowseExe;
             if (BrowseButtonIcon is not null)
             {
                 BrowseButtonIcon.Glyph = isFolder ? "\uE8DA" : "\uE8E5";

--- a/Views/ControlPanelControl.xaml
+++ b/Views/ControlPanelControl.xaml
@@ -61,13 +61,13 @@
                                                      IsChecked="{x:Bind ViewModel.IsGlobalProxyChecked, Mode=OneWay}"
                                                      IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
                                                      Command="{x:Bind ViewModel.SetProxyModeCommand}"
-                                                     CommandParameter="全局代理" />
+                                                     CommandParameter="system" />
                                 <RadioMenuFlyoutItem Text="不接管代理"
                                                      GroupName="ProxyModeGroup"
                                                      IsChecked="{x:Bind ViewModel.IsNoTakeoverChecked, Mode=OneWay}"
                                                      IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
                                                      Command="{x:Bind ViewModel.SetProxyModeCommand}"
-                                                     CommandParameter="不接管代理" />
+                                                     CommandParameter="manual" />
                             </MenuFlyoutSubItem>
                             <MenuFlyoutSeparator/>
                             <MenuFlyoutItem Text="开机启动"
@@ -77,11 +77,11 @@
                                 <MenuFlyoutItem Text="全局路由"
                                                 IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
                                                 Command="{x:Bind ViewModel.SetRoutingModeCommand}"
-                                                CommandParameter="全局路由" />
+                                                CommandParameter="global" />
                                 <MenuFlyoutItem Text="智能分流"
                                                 IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
                                                 Command="{x:Bind ViewModel.SetRoutingModeCommand}"
-                                                CommandParameter="智能分流" />
+                                                CommandParameter="smart" />
                                 <MenuFlyoutSeparator/>
                                 <MenuFlyoutItem Text="自定义规则..."
                                                 IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
@@ -179,7 +179,7 @@
                            FontSize="14"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                            VerticalAlignment="Center" />
-                <TextBlock Text="{x:Bind ViewModel.RoutingMode, Mode=OneWay}"
+                <TextBlock Text="{x:Bind ViewModel.RoutingModeText, Mode=OneWay}"
                            FontSize="14"
                            FontWeight="SemiBold"
                            VerticalAlignment="Center" />

--- a/Views/ControlPanelControl.xaml
+++ b/Views/ControlPanelControl.xaml
@@ -51,18 +51,23 @@
                                             Command="{x:Bind ViewModel.UpdateAppCommand}"
                                             Visibility="{x:Bind ViewModel.UpdateBadgeVisibility, Mode=OneWay}" />
                             <MenuFlyoutSeparator Visibility="{x:Bind ViewModel.UpdateBadgeVisibility, Mode=OneWay}" />
-                            <MenuFlyoutItem Text="编辑本地端口"
+                            <MenuFlyoutItem x:Uid="ControlPanel_EditPortItem"
+                                            Text="编辑本地端口"
                                             Command="{x:Bind ViewModel.EditLocalPortCommand}" />
-                            <MenuFlyoutItem Text="查看日志" 
+                            <MenuFlyoutItem x:Uid="ControlPanel_ViewLogItem"
+                                            Text="查看日志"
                                             Command="{x:Bind ViewModel.ShowLogsCommand}" />
-                            <MenuFlyoutSubItem Text="代理设置">
-                                <RadioMenuFlyoutItem Text="全局代理"
+                            <MenuFlyoutSubItem x:Uid="ControlPanel_ProxySettingsItem"
+                                               Text="代理设置">
+                                <RadioMenuFlyoutItem x:Uid="ControlPanel_GlobalProxyItem"
+                                                     Text="全局代理"
                                                      GroupName="ProxyModeGroup"
                                                      IsChecked="{x:Bind ViewModel.IsGlobalProxyChecked, Mode=OneWay}"
                                                      IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
                                                      Command="{x:Bind ViewModel.SetProxyModeCommand}"
                                                      CommandParameter="system" />
-                                <RadioMenuFlyoutItem Text="不接管代理"
+                                <RadioMenuFlyoutItem x:Uid="ControlPanel_NoProxyItem"
+                                                     Text="不接管代理"
                                                      GroupName="ProxyModeGroup"
                                                      IsChecked="{x:Bind ViewModel.IsNoTakeoverChecked, Mode=OneWay}"
                                                      IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
@@ -70,23 +75,29 @@
                                                      CommandParameter="manual" />
                             </MenuFlyoutSubItem>
                             <MenuFlyoutSeparator/>
-                            <MenuFlyoutItem Text="开机启动"
+                            <MenuFlyoutItem x:Uid="ControlPanel_StartupItem"
+                                            Text="开机启动"
                                             Command="{x:Bind ViewModel.OpenStartupSettingsCommand}"
                                             Icon="{x:Bind ViewModel.StartupMenuIcon, Mode=OneWay}" />
-                            <MenuFlyoutSubItem Text="路由设置" >
-                                <MenuFlyoutItem Text="全局路由"
+                            <MenuFlyoutSubItem x:Uid="ControlPanel_RoutingSettingsItem"
+                                               Text="路由设置" >
+                                <MenuFlyoutItem x:Uid="ControlPanel_RoutingGlobalItem"
+                                                Text="全局路由"
                                                 IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
                                                 Command="{x:Bind ViewModel.SetRoutingModeCommand}"
                                                 CommandParameter="global" />
-                                <MenuFlyoutItem Text="智能分流"
+                                <MenuFlyoutItem x:Uid="ControlPanel_RoutingSmartItem"
+                                                Text="智能分流"
                                                 IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
                                                 Command="{x:Bind ViewModel.SetRoutingModeCommand}"
                                                 CommandParameter="smart" />
                                 <MenuFlyoutSeparator/>
-                                <MenuFlyoutItem Text="自定义规则..."
+                                <MenuFlyoutItem x:Uid="ControlPanel_CustomRulesItem"
+                                                Text="自定义规则..."
                                                 IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
                                                 Command="{x:Bind ViewModel.ShowCustomRulesCommand}" />
-                                <MenuFlyoutItem Text="DNS设置"
+                                <MenuFlyoutItem x:Uid="ControlPanel_DnsItem"
+                                                Text="DNS设置"
                                                 IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
                                                 Command="{x:Bind ViewModel.ShowDnsSettingsCommand}" />
                             </MenuFlyoutSubItem>
@@ -157,7 +168,8 @@
                         Spacing="8"
                         VerticalAlignment="Center"
                         HorizontalAlignment="Center">
-                <TextBlock Text="TUN 模式"
+                <TextBlock x:Uid="ControlPanel_TunModeLabel"
+                           Text="TUN 模式"
                            FontSize="14"
                            FontWeight="SemiBold"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -175,7 +187,8 @@
                         Spacing="4"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center">
-                <TextBlock Text="路由:"
+                <TextBlock x:Uid="ControlPanel_RoutingLbl"
+                           Text="路由:"
                            FontSize="14"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                            VerticalAlignment="Center" />

--- a/Views/ControlPanelControl.xaml
+++ b/Views/ControlPanelControl.xaml
@@ -23,12 +23,12 @@
                         VerticalAlignment="Center"
                         Spacing="2">
 
-                <Button Background="Transparent"
+                <Button x:Name="PersonalizeButton"
+                        Background="Transparent"
                         BorderBrush="Transparent"
                         VerticalAlignment="Center"
                         Padding="8"
-                        Command="{x:Bind ViewModel.ShowPersonalizeCommand}"
-                        ToolTipService.ToolTip="个性化">
+                        Command="{x:Bind ViewModel.ShowPersonalizeCommand}">
                     <FontIcon Glyph="&#xE771;" FontSize="16" />
                 </Button>
 

--- a/Views/ControlPanelControl.xaml.cs
+++ b/Views/ControlPanelControl.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Windows.System;
+using XrayUI.Helpers;
 
 namespace XrayUI.Views
 {
@@ -13,6 +14,7 @@ namespace XrayUI.Views
         public ControlPanelControl()
         {
             this.InitializeComponent();
+            ToolTipService.SetToolTip(PersonalizeButton, L.ControlPanel_Personalize);
         }
 
         // Called by MainWindow after ViewModel is assigned (via x:Bind the property is set before Loaded)

--- a/Views/CustomRulesWindow.xaml
+++ b/Views/CustomRulesWindow.xaml
@@ -24,7 +24,8 @@
         <Grid Grid.Row="0"
               Padding="20,20,20,12"
               ColumnDefinitions="*,Auto">
-            <TextBlock Grid.Column="0"
+            <TextBlock x:Uid="CustomRules_RuleListText"
+                       Grid.Column="0"
                        Text="规则列表"
                        Style="{ThemeResource SubtitleTextBlockStyle}"
                        VerticalAlignment="Center" />
@@ -36,7 +37,6 @@
                         Background="Transparent"
                         BorderThickness="0"
                         VerticalAlignment="Center"
-                        ToolTipService.ToolTip="高级编辑 (用外部编辑器打开 settings.json)"
                         Command="{x:Bind ViewModel.OpenAdvancedEditorCommand}">
                     <FontIcon Glyph="&#xE70F;" FontSize="16" />
                 </Button>
@@ -45,7 +45,6 @@
                         Background="Transparent"
                         BorderThickness="0"
                         VerticalAlignment="Center"
-                        ToolTipService.ToolTip="更新GeoFiles路由数据"
                         Click="UpdateGeoButton_Click">
                     <FontIcon Glyph="&#xE895;"  FontSize="14" />
                 </Button>
@@ -53,7 +52,7 @@
                         Command="{x:Bind ViewModel.AddRuleCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <FontIcon Glyph="&#xE710;" FontSize="14" />
-                        <TextBlock Text="添加" />
+                        <TextBlock x:Uid="CustomRules_AddBtnText" Text="添加" />
                     </StackPanel>
                 </Button>
             </StackPanel>
@@ -73,7 +72,8 @@
                           FontSize="14"
                           Foreground="{ThemeResource SystemFillColorCautionBrush}"
                           VerticalAlignment="Center" />
-                <TextBlock Text="当前为全局路由模式，自定义规则不生效。切回智能分流后自动启用。"
+                <TextBlock x:Uid="CustomRules_NotEffectiveText"
+                           Text="当前为全局路由模式，自定义规则不生效。切回智能分流后自动启用。"
                            FontSize="12"
                            TextWrapping="Wrap"
                            VerticalAlignment="Center" />
@@ -154,14 +154,14 @@
                             <Button Padding="6"
                                     Background="Transparent"
                                     BorderThickness="0"
-                                    ToolTipService.ToolTip="编辑"
+                                    Loaded="EditRuleButton_Loaded"
                                     Click="EditRuleButton_Click">
                                 <FontIcon Glyph="&#xE70F;" FontSize="14" />
                             </Button>
                             <Button Padding="6"
                                     Background="Transparent"
                                     BorderThickness="0"
-                                    ToolTipService.ToolTip="删除"
+                                    Loaded="DeleteRuleButton_Loaded"
                                     Click="DeleteRuleButton_Click">
                                 <FontIcon Glyph="&#xE74D;" FontSize="14" />
                             </Button>
@@ -179,11 +179,13 @@
             <StackPanel Orientation="Horizontal"
                         Spacing="8"
                         HorizontalAlignment="Right">
-                <Button Style="{ThemeResource AccentButtonStyle}"
+                <Button x:Uid="CustomRules_SaveBtn"
+                        Style="{ThemeResource AccentButtonStyle}"
                         MinWidth="80"
                         Content="保存"
                         Command="{x:Bind ViewModel.SaveCommand}" />
-                <Button MinWidth="80"
+                <Button x:Uid="CustomRules_CancelBtn"
+                        MinWidth="80"
                         Content="取消"
                         Command="{x:Bind ViewModel.CancelCommand}" />
             </StackPanel>

--- a/Views/CustomRulesWindow.xaml.cs
+++ b/Views/CustomRulesWindow.xaml.cs
@@ -34,8 +34,11 @@ namespace XrayUI.Views
             AppWindow.Resize(new SizeInt32(
                 (int)Math.Round(620 * scale),
                 (int)Math.Round(460 * scale)));
-            AppWindow.Title = "自定义路由规则";
+            AppWindow.Title = L.CustomRules_Title;
 			AppWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
+
+            ToolTipService.SetToolTip(OpenAdvancedEditorButton, L.CustomRules_AdvancedEditorTooltip);
+            ToolTipService.SetToolTip(UpdateGeoButton,          L.CustomRules_UpdateGeoTooltip);
 
 			var presenter = OverlappedPresenter.CreateForDialog();
 
@@ -118,6 +121,18 @@ namespace XrayUI.Views
                 ViewModel.AddNewRule(dialog.Result);
             else
                 ViewModel.ReplaceRule(existing, dialog.Result);
+        }
+
+        private void EditRuleButton_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement element)
+                ToolTipService.SetToolTip(element, L.CustomRules_EditRowTooltip);
+        }
+
+        private void DeleteRuleButton_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement element)
+                ToolTipService.SetToolTip(element, L.CustomRules_DeleteRowTooltip);
         }
 
         private void EditRuleButton_Click(object sender, RoutedEventArgs e)

--- a/Views/LogWindow.xaml
+++ b/Views/LogWindow.xaml
@@ -61,13 +61,12 @@
                             Orientation="Horizontal"
                             Spacing="8">
                     <Button x:Name="LogPrivacyButton"
-                            Padding="8,5"
-                            ToolTipService.ToolTip="日志隐私设置">
+                            Padding="8,5">
                         <FontIcon Glyph="&#xE72E;"
                                   FontSize="13" />
                         <Button.Flyout>
                             <MenuFlyout>
-                                <MenuFlyoutSubItem Text="IP地址遮罩">
+                                <MenuFlyoutSubItem x:Name="MaskAddressSubMenu" Text="IP地址遮罩">
                                     <RadioMenuFlyoutItem x:Name="MaskOffMenuItem"
                                                          Text="关闭"
                                                          GroupName="LogMaskAddressGroup"
@@ -94,16 +93,13 @@
                     </Button>
                     <ToggleButton x:Name="AutoScrollToggle"
                                   IsChecked="True"
-                                  Content="自动滚动"
                                   FontSize="12"
                                   Padding="10,5" />
                     <Button x:Name="CopyButton"
-                            Content="复制全部"
                             FontSize="12"
                             Padding="10,5"
                             Click="CopyButton_Click" />
                     <Button x:Name="ClearButton"
-                            Content="清除"
                             FontSize="12"
                             Padding="10,5"
                             Click="ClearButton_Click" />

--- a/Views/LogWindow.xaml.cs
+++ b/Views/LogWindow.xaml.cs
@@ -46,7 +46,14 @@ namespace XrayUI.Views
             var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
             var scale = DpiHelper.GetWindowScale(hWnd);
             AppWindow.Resize(new SizeInt32((int)Math.Round(900 * scale), (int)Math.Round(600 * scale)));
-            AppWindow.Title = "代理日志";
+            AppWindow.Title = L.Log_Title;
+
+            ToolTipService.SetToolTip(LogPrivacyButton, L.Log_PrivacyTooltip);
+            MaskAddressSubMenu.Text = L.Log_IpMask;
+            MaskOffMenuItem.Text    = L.Log_MaskOff;
+            AutoScrollToggle.Content = L.Log_AutoScroll;
+            CopyButton.Content       = L.Log_CopyAll;
+            ClearButton.Content      = L.Log_Clear;
 
             _xray.LogReceived     += OnLogReceived;
             _xray.RunningChanged  += OnRunningChanged;
@@ -123,7 +130,7 @@ namespace XrayUI.Views
             // XrayService owns the single source of truth; we just render a snapshot.
             var lines = _xray.GetLogBuffer();
             LogTextBlock.Text = string.Join('\n', lines);
-            LineCountText.Text = $"({lines.Count} 行)";
+            LineCountText.Text = Loc.Format("Log_Lines", lines.Count);
             _prevBufferCount = lines.Count;
         }
 
@@ -151,7 +158,7 @@ namespace XrayUI.Views
         private void UpdateStatus()
         {
             var running = _xray.IsRunning;
-            StatusText.Text = running ? "运行中" : "未运行";
+            StatusText.Text = running ? L.Log_Running : L.Log_NotRunning;
             StatusDot.Fill  = running ? RunningBrush : StoppedBrush;
         }
 
@@ -199,7 +206,7 @@ namespace XrayUI.Views
 
                 if (settings.IsTunMode)
                 {
-                    await ShowInfoAsync("日志隐私设置", "已保存，当前 TUN 会话下次启动时生效。");
+                    await ShowInfoAsync(L.Log_PrivacyTitle, L.Log_PrivacySaved);
                     return;
                 }
 
@@ -207,7 +214,7 @@ namespace XrayUI.Views
             }
             catch (Exception ex)
             {
-                await ShowInfoAsync("日志隐私设置", $"保存失败：{ex.Message}");
+                await ShowInfoAsync(L.Log_PrivacyTitle, Loc.Format("Log_PrivacyFailed", ex.Message));
             }
         }
 
@@ -219,7 +226,7 @@ namespace XrayUI.Views
                 RequestedTheme = ThemeHelper.ActualTheme,
                 Title = title,
                 Content = message,
-                CloseButtonText = "确定"
+                CloseButtonText = L.Dialog_OK
             };
 
             await dialog.ShowAsync();

--- a/Views/ManageSubscriptionsDialog.xaml
+++ b/Views/ManageSubscriptionsDialog.xaml
@@ -26,16 +26,14 @@
                     <SolidColorBrush x:Key="SegmentedItemBackgroundPointerOver" Color="Transparent" />
                     <SolidColorBrush x:Key="SegmentedItemBorderBrushPointerOver" Color="Transparent" />
                 </controls:Segmented.Resources>
-                <controls:SegmentedItem 
-                                        Padding="0"
-                                        ToolTipService.ToolTip="添加订阅">
+                <controls:SegmentedItem x:Name="AddPageSegment"
+                                        Padding="0">
                     <controls:SegmentedItem.Icon>
                         <FontIcon Glyph="&#xED0E;" FontSize="14" />
                     </controls:SegmentedItem.Icon>
                 </controls:SegmentedItem>
-                <controls:SegmentedItem 
-                                        Padding="0"
-                                        ToolTipService.ToolTip="管理订阅">
+                <controls:SegmentedItem x:Name="ManagePageSegment"
+                                        Padding="0">
                     <controls:SegmentedItem.Icon>
                         <FontIcon  Glyph="&#xEBC3;" FontSize="14" />
                     </controls:SegmentedItem.Icon>
@@ -45,20 +43,24 @@
 
         <StackPanel Spacing="14"
                     Visibility="{x:Bind ViewModel.AddPageVisibility, Mode=OneWay}">
-            <TextBox Header="订阅链接"
+            <TextBox x:Uid="Subscription_UrlBox"
+                     Header="订阅链接"
                      PlaceholderText="https://..."
                      TextWrapping="Wrap"
                      Text="{x:Bind ViewModel.SubscriptionUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            <TextBox Header="备注名称（可选）"
+            <TextBox x:Uid="Subscription_NameBox"
+                     Header="备注名称（可选）"
                      PlaceholderText="留空则使用链接域名"
                      Text="{x:Bind ViewModel.SubscriptionName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            <TextBlock Text="将自动解析并导入该订阅中的全部节点"
+            <TextBlock x:Uid="Subscription_AutoImportHintText"
+                       Text="将自动解析并导入该订阅中的全部节点"
                        FontSize="12"
                        Opacity="0.65" />
         </StackPanel>
 
         <Grid Visibility="{x:Bind ViewModel.ManagePageVisibility, Mode=OneWay}">
-            <TextBlock Text="暂无订阅"
+            <TextBlock x:Uid="Subscription_EmptyText"
+                       Text="暂无订阅"
                        HorizontalAlignment="Center"
                        Margin="0,48,0,48"
                        FontSize="14"
@@ -106,8 +108,8 @@
                                             Padding="6"
                                             Background="Transparent"
                                             BorderThickness="0"
-                                            ToolTipService.ToolTip="刷新订阅"
                                             IsEnabled="{x:Bind IsNotBusy, Mode=OneWay}"
+                                            Loaded="RefreshButton_Loaded"
                                             Click="RefreshButton_Click">
                                         <Grid Width="16" Height="16">
                                             <FontIcon Glyph="&#xE895;"
@@ -124,19 +126,22 @@
                                             Padding="6"
                                             Background="Transparent"
                                             BorderThickness="0"
-                                            ToolTipService.ToolTip="删除订阅">
+                                            Loaded="DeleteButton_Loaded">
                                         <FontIcon Glyph="&#xE74D;" FontSize="14" />
                                         <Button.Flyout>
                                             <Flyout Placement="Bottom">
                                                 <StackPanel Spacing="12" MaxWidth="240">
-                                                    <TextBlock Text="删除订阅？"
+                                                    <TextBlock x:Uid="Subscription_DeleteConfirmText"
+                                                               Text="删除订阅？"
                                                                TextWrapping="Wrap"
                                                                FontWeight="SemiBold" />
-                                                    <TextBlock Text="将同时删除该订阅下的所有节点。"
+                                                    <TextBlock x:Uid="Subscription_DeleteDescText"
+                                                               Text="将同时删除该订阅下的所有节点。"
                                                                TextWrapping="Wrap"
                                                                FontSize="12"
                                                                Opacity="0.7" />
-                                                    <Button Click="ConfirmDelete_Click"
+                                                    <Button x:Uid="Subscription_DeleteConfirmBtn"
+                                                            Click="ConfirmDelete_Click"
                                                             Style="{StaticResource DangerAccentButtonStyle}"
                                                             HorizontalAlignment="Right"
                                                             Content="删除" />

--- a/Views/ManageSubscriptionsDialog.xaml.cs
+++ b/Views/ManageSubscriptionsDialog.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
+using XrayUI.Helpers;
 using XrayUI.Models;
 
 namespace XrayUI.Views
@@ -12,6 +13,21 @@ namespace XrayUI.Views
         {
             ViewModel = vm;
             InitializeComponent();
+
+            ToolTipService.SetToolTip(AddPageSegment,    L.Subscription_AddTooltip);
+            ToolTipService.SetToolTip(ManagePageSegment, L.Subscription_ManageTooltip);
+        }
+
+        private void RefreshButton_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement element)
+                ToolTipService.SetToolTip(element, L.Subscription_Refresh);
+        }
+
+        private void DeleteButton_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement element)
+                ToolTipService.SetToolTip(element, L.Subscription_DeleteTooltip);
         }
 
         private void RefreshButton_Click(object sender, RoutedEventArgs e)

--- a/Views/PersonalizeControl.xaml
+++ b/Views/PersonalizeControl.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+             xmlns:helpers="using:XrayUI.Helpers"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
@@ -70,6 +71,64 @@
                     <ComboBoxItem Content="Mica" />
                     <ComboBoxItem Content="亚克力" />
                 </ComboBox>
+            </StackPanel>
+            <!-- ── Language ────────────────────────────────────────────────── -->
+            <StackPanel Spacing="10">
+                <TextBlock Text="语言"
+                           FontSize="15"
+                           FontWeight="SemiBold" />
+
+                <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="{ThemeResource OverlayCornerRadius}">
+                    <Grid Padding="16,13"
+                          ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <FontIcon Grid.Column="0"
+                                  Glyph="&#xF2B7;"
+                                  FontSize="16"
+                                  VerticalAlignment="Center"
+                                  Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+
+                        <StackPanel Grid.Column="1"
+                                    VerticalAlignment="Center"
+                                    Spacing="2">
+                            <TextBlock Text="应用语言"
+                                       FontSize="14" />
+                            <TextBlock Text="选择应用界面的显示语言"
+                                       FontSize="12"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        </StackPanel>
+
+                        <ComboBox Grid.Column="2"
+                                  MinWidth="160"
+                                  VerticalAlignment="Center"
+                                  ItemsSource="{x:Bind ViewModel.SupportedLanguages, Mode=OneTime}"
+                                  SelectedIndex="{x:Bind ViewModel.SelectedLanguageIndex, Mode=TwoWay}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate x:DataType="helpers:LanguageInfo">
+                                    <TextBlock Text="{x:Bind DisplayName}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                    </Grid>
+                </Border>
+
+                <InfoBar IsOpen="{x:Bind ViewModel.ShowLanguageRestartHint, Mode=TwoWay}"
+                         Severity="Informational"
+                         Title="重启应用以应用语言更改"
+                         IsClosable="False">
+                    <InfoBar.ActionButton>
+                        <Button Content="重启"
+                                Click="LanguageRestartButton_Click" />
+                    </InfoBar.ActionButton>
+                </InfoBar>
             </StackPanel>
             <!-- ── Protocol Colors ─────────────────────────────────────────── -->
             <StackPanel Spacing="10">

--- a/Views/PersonalizeControl.xaml
+++ b/Views/PersonalizeControl.xaml
@@ -15,19 +15,21 @@
                     Padding="0,0,12,24">
 
             <!-- ── Header ──────────────────────────────────────────────────── -->
-            <TextBlock Text="个性化设置"
+            <TextBlock x:Uid="Personalize_Header"
+                       Text="个性化设置"
                        FontSize="20"
                        FontWeight="SemiBold"
                        Margin="0,0,0,4" />
 
             <!-- ── Theme ───────────────────────────────────────────────────── -->
             <StackPanel Spacing="10">
-                
-                    <TextBlock Text="主题"
+
+                    <TextBlock x:Uid="Personalize_Theme"
+                               Text="主题"
                                FontSize="15"
                                FontWeight="SemiBold" />
-                    
-                
+
+
 
                 <controls:Segmented HorizontalAlignment="Left"
                                     SelectedIndex="{x:Bind ViewModel.SelectedThemeIndex, Mode=TwoWay}">
@@ -36,21 +38,24 @@
                         <SolidColorBrush x:Key="SegmentedItemBackgroundPointerOver" Color="Transparent" />
                         <SolidColorBrush x:Key="SegmentedItemBorderBrushPointerOver" Color="Transparent" />
                     </controls:Segmented.Resources>
-                    <controls:SegmentedItem Content="浅色"
+                    <controls:SegmentedItem x:Uid="Personalize_Light"
+                                            Content="浅色"
                                             FontSize="14"
                                             Padding="14,6">
                         <controls:SegmentedItem.Icon>
                             <FontIcon Glyph="&#xE706;" FontSize="16" />
                         </controls:SegmentedItem.Icon>
                     </controls:SegmentedItem>
-                    <controls:SegmentedItem Content="深色"
+                    <controls:SegmentedItem x:Uid="Personalize_Dark"
+                                            Content="深色"
                                             FontSize="14"
                                             Padding="14,6">
                         <controls:SegmentedItem.Icon>
                             <FontIcon Glyph="&#xE708;" FontSize="16" />
                         </controls:SegmentedItem.Icon>
                     </controls:SegmentedItem>
-                    <controls:SegmentedItem Content="跟随系统"
+                    <controls:SegmentedItem x:Uid="Personalize_FollowSystem"
+                                            Content="跟随系统"
                                             FontSize="14"
                                             Padding="14,6">
                         <controls:SegmentedItem.Icon>
@@ -61,20 +66,22 @@
             </StackPanel>
             <!-- ── Backdrop ────────────────────────────────────────────────── -->
             <StackPanel Spacing="10">
-                <TextBlock Text="背景效果"
+                <TextBlock x:Uid="Personalize_Backdrop"
+                               Text="背景效果"
                                FontSize="15"
                                FontWeight="SemiBold" />
-                    
+
                 <ComboBox HorizontalAlignment="Left"
                           MinWidth="160"
                           SelectedIndex="{x:Bind ViewModel.SelectedBackdropIndex, Mode=TwoWay}">
                     <ComboBoxItem Content="Mica" />
-                    <ComboBoxItem Content="亚克力" />
+                    <ComboBoxItem x:Uid="Personalize_Acrylic" Content="亚克力" />
                 </ComboBox>
             </StackPanel>
             <!-- ── Language ────────────────────────────────────────────────── -->
             <StackPanel Spacing="10">
-                <TextBlock Text="语言"
+                <TextBlock x:Uid="Personalize_LanguageLbl"
+                           Text="语言"
                            FontSize="15"
                            FontWeight="SemiBold" />
 
@@ -99,9 +106,11 @@
                         <StackPanel Grid.Column="1"
                                     VerticalAlignment="Center"
                                     Spacing="2">
-                            <TextBlock Text="应用语言"
+                            <TextBlock x:Uid="Personalize_AppLanguageTitle"
+                                       Text="应用语言"
                                        FontSize="14" />
-                            <TextBlock Text="选择应用界面的显示语言"
+                            <TextBlock x:Uid="Personalize_AppLanguageDesc"
+                                       Text="选择应用界面的显示语言"
                                        FontSize="12"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                         </StackPanel>
@@ -120,12 +129,14 @@
                     </Grid>
                 </Border>
 
-                <InfoBar IsOpen="{x:Bind ViewModel.ShowLanguageRestartHint, Mode=TwoWay}"
+                <InfoBar x:Uid="Personalize_LangRestartBar"
+                         IsOpen="{x:Bind ViewModel.ShowLanguageRestartHint, Mode=TwoWay}"
                          Severity="Informational"
                          Title="重启应用以应用语言更改"
                          IsClosable="False">
                     <InfoBar.ActionButton>
-                        <Button Content="重启"
+                        <Button x:Uid="Personalize_LangRestartBtn"
+                                Content="重启"
                                 Click="LanguageRestartButton_Click" />
                     </InfoBar.ActionButton>
                 </InfoBar>
@@ -140,10 +151,12 @@
 
                     <StackPanel Grid.Column="0"
                                 Spacing="2">
-                        <TextBlock Text="协议颜色"
+                        <TextBlock x:Uid="Personalize_ProtocolColors"
+                                   Text="协议颜色"
                                    FontSize="15"
                                    FontWeight="SemiBold" />
-                        <TextBlock Text="自定义不同协议的颜色标识"
+                        <TextBlock x:Uid="Personalize_ProtocolColorsDesc"
+                                   Text="自定义不同协议的颜色标识"
                                    FontSize="13"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                     </StackPanel>
@@ -159,7 +172,8 @@
                             <FontIcon Glyph="&#xE72C;"
                                       FontSize="13"
                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                            <TextBlock Text="重置"
+                            <TextBlock x:Uid="Personalize_Reset"
+                                       Text="重置"
                                        FontSize="13"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                         </StackPanel>
@@ -396,9 +410,11 @@
                         <StackPanel Grid.Column="1"
                                     VerticalAlignment="Center"
                                     Spacing="2">
-                            <TextBlock Text="其他协议"
+                            <TextBlock x:Uid="Personalize_OtherProtocol"
+                                       Text="其他协议"
                                        FontSize="14" />
-                            <TextBlock Text="未匹配的协议将使用此颜色"
+                            <TextBlock x:Uid="Personalize_OtherProtocolDesc"
+                                       Text="未匹配的协议将使用此颜色"
                                        FontSize="12"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                         </StackPanel>
@@ -436,7 +452,8 @@
 
             <!-- Detail settings -->
             <StackPanel Spacing="10">
-                <TextBlock Text="详情设置"
+                <TextBlock x:Uid="Personalize_DetailSettings"
+                           Text="详情设置"
                            FontSize="15"
                            FontWeight="SemiBold" />
 
@@ -461,9 +478,11 @@
                             <StackPanel Grid.Column="1"
                                         VerticalAlignment="Center"
                                         Spacing="2">
-                                <TextBlock Text="服务器信息显示"
+                                <TextBlock x:Uid="Personalize_DetailsHeader"
+                                           Text="服务器信息显示"
                                            FontSize="14" />
-                                <TextBlock Text="选择详情卡片上的信息展示"
+                                <TextBlock x:Uid="Personalize_DetailsDesc"
+                                           Text="选择详情卡片上的信息展示"
                                            FontSize="12"
                                            TextWrapping="Wrap"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -479,9 +498,11 @@
                               Margin="42,10,16,10">
                         <StackPanel VerticalAlignment="Center"
                                     Spacing="2">
-                            <TextBlock Text="延迟"
+                            <TextBlock x:Uid="Personalize_DetailLatency"
+                                       Text="延迟"
                                        FontSize="14" />
-                            <TextBlock Text="节点卡片上展示延迟"
+                            <TextBlock x:Uid="Personalize_DetailLatencyDesc"
+                                       Text="节点卡片上展示延迟"
                                        FontSize="12"
                                        TextWrapping="Wrap"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -498,9 +519,11 @@
                               Margin="42,10,16,10">
                         <StackPanel VerticalAlignment="Center"
                                     Spacing="2">
-                            <TextBlock Text="AI 解锁"
+                            <TextBlock x:Uid="Personalize_DetailAiUnlock"
+                                       Text="AI 解锁"
                                        FontSize="14" />
-                            <TextBlock Text="节点卡片上展示AI的解锁状态"
+                            <TextBlock x:Uid="Personalize_DetailAiUnlockDesc"
+                                       Text="节点卡片上展示AI的解锁状态"
                                        FontSize="12"
                                        TextWrapping="Wrap"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -512,7 +535,8 @@
 
             <!-- Data management -->
             <StackPanel Spacing="10">
-                <TextBlock Text="数据管理"
+                <TextBlock x:Uid="Personalize_DataManagement"
+                               Text="数据管理"
                                FontSize="15"
                                FontWeight="SemiBold" />
 
@@ -537,9 +561,11 @@
                             <StackPanel Grid.Column="1"
                                         VerticalAlignment="Center"
                                         Spacing="2">
-                            <TextBlock Text="配置导入与导出"
+                            <TextBlock x:Uid="Personalize_ImportExportTitle"
+                                           Text="配置导入与导出"
                                            FontSize="14" />
-                            <TextBlock Text="将当前的节点和路由规则备份到本地，或从已有文件中恢复"
+                            <TextBlock x:Uid="Personalize_ImportExportDesc"
+                                           Text="将当前的节点和路由规则备份到本地，或从已有文件中恢复"
                                            FontSize="12"
                                            TextWrapping="Wrap"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -549,15 +575,15 @@
                                         Orientation="Horizontal"
                                         Spacing="8"
                                         VerticalAlignment="Center">
-                                <Button 
+                                <Button x:Name="ExportPresetButton"
+                                        x:Uid="Personalize_ExportBtn"
                                         Padding="12,6"
                                         Content="导出"
-                                        AutomationProperties.Name="导出预置配置"
                                         Click="ExportPresetButton_Click" />
-                                <Button 
+                                <Button x:Name="ImportPresetButton"
+                                        x:Uid="Personalize_ImportBtn"
                                         Padding="12,6"
                                         Content="导入"
-                                        AutomationProperties.Name="导入预置配置"
                                         Click="ImportPresetButton_Click" />
                             </StackPanel>
                         </Grid>
@@ -570,7 +596,8 @@
             </StackPanel>
 
             <!-- ── Footer ──────────────────────────────────────────────────── -->
-            <Button HorizontalAlignment="Right"
+            <Button x:Uid="Personalize_Done"
+                    HorizontalAlignment="Right"
                     Style="{StaticResource AccentButtonStyle}"
                     Command="{x:Bind ViewModel.DoneCommand}"
                     MinWidth="88"

--- a/Views/PersonalizeControl.xaml.cs
+++ b/Views/PersonalizeControl.xaml.cs
@@ -56,5 +56,11 @@ namespace XrayUI.Views
             OperationInfoBar.Message = message;
             OperationInfoBar.IsOpen = true;
         }
+
+        private async void LanguageRestartButton_Click(object sender, RoutedEventArgs e)
+        {
+            await ViewModel.ApplyLanguageAsync();
+            App.Restart();
+        }
     }
 }

--- a/Views/PersonalizeControl.xaml.cs
+++ b/Views/PersonalizeControl.xaml.cs
@@ -1,4 +1,6 @@
 using System;
+using Microsoft.UI.Xaml.Automation;
+using XrayUI.Helpers;
 using XrayUI.Services;
 
 namespace XrayUI.Views
@@ -10,6 +12,9 @@ namespace XrayUI.Views
         public PersonalizeControl()
         {
             this.InitializeComponent();
+
+            AutomationProperties.SetName(ExportPresetButton, L.Personalize_ExportTooltip);
+            AutomationProperties.SetName(ImportPresetButton, L.Personalize_ImportTooltip);
         }
 
         private async void ExportPresetButton_Click(object sender, RoutedEventArgs e)
@@ -17,11 +22,13 @@ namespace XrayUI.Views
             try
             {
                 var exportDir = await ViewModel.ExportPresetAsync();
-                ShowInfo(InfoBarSeverity.Success, "导出成功", $"已导出至 {exportDir}");
+                ShowInfo(InfoBarSeverity.Success,
+                    L.Personalize_ExportSuccess,
+                    Loc.Format("Personalize_ExportSuccessMsgFmt", exportDir));
             }
             catch (Exception ex)
             {
-                ShowInfo(InfoBarSeverity.Error, "导出失败", ex.Message);
+                ShowInfo(InfoBarSeverity.Error, L.Error_ExportFailed, ex.Message);
             }
         }
 
@@ -31,21 +38,27 @@ namespace XrayUI.Views
             {
                 if (!PersonalizeViewModel.PresetExists())
                 {
-                    ShowInfo(InfoBarSeverity.Warning, "未找到预置文件",
-                        "请先准备 Import 文件夹下的 servers.json / settings.json。");
+                    ShowInfo(InfoBarSeverity.Warning,
+                        L.Personalize_PresetMissingTitle,
+                        L.Personalize_PresetMissingMsg);
                     return;
                 }
 
                 var result = await ViewModel.ConfirmAndImportPresetAsync();
                 if (result is null) return;
 
-                var advanced = result.ImportedAdvancedRouting ? "、含高级路由" : "";
-                ShowInfo(InfoBarSeverity.Success, "导入成功",
-                    $"已导入 {result.ImportedServers} 个节点、{result.ImportedSubscriptions} 条订阅、{result.ImportedCustomRules} 条规则{advanced}。");
+                var advanced = result.ImportedAdvancedRouting ? L.Personalize_ImportAdvancedSuffix : "";
+                ShowInfo(InfoBarSeverity.Success,
+                    L.Personalize_ImportSuccess,
+                    Loc.Format("Personalize_ImportSuccessMsg",
+                        result.ImportedServers,
+                        result.ImportedSubscriptions,
+                        result.ImportedCustomRules,
+                        advanced));
             }
             catch (Exception ex)
             {
-                ShowInfo(InfoBarSeverity.Error, "导入失败", ex.Message);
+                ShowInfo(InfoBarSeverity.Error, L.Personalize_ImportFailed, ex.Message);
             }
         }
 

--- a/Views/ServerDetailControl.xaml
+++ b/Views/ServerDetailControl.xaml
@@ -18,7 +18,8 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         
-            <TextBlock Grid.Row="0"
+            <TextBlock x:Uid="ServerDetail_HeaderText"
+                   Grid.Row="0"
                    Text="服务器详情"
                    FontSize="20"
                    FontWeight="SemiBold"
@@ -59,7 +60,8 @@
                             </Grid.RowDefinitions>
 
                             <!-- Row 0: name -->
-                            <TextBlock Text="名称"
+                            <TextBlock x:Uid="ServerDetail_NameLabel"
+                                       Text="名称"
                                        Grid.Row="0"
                                        Grid.Column="0"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -72,7 +74,8 @@
                                        TextWrapping="WrapWholeWords" />
 
                             <!-- Row 1: protocol (new) -->
-                            <TextBlock Text="协议"
+                            <TextBlock x:Uid="ServerDetail_ProtocolLabel"
+                                       Text="协议"
                                        Grid.Row="1"
                                        Grid.Column="0"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -116,7 +119,8 @@
                                        Grid.Column="1"
                                        Text="{x:Bind ViewModel.SelectedEncryption, Mode=OneWay}"
                                        FontSize="16" />
-                            <TextBlock Grid.Row="5"
+                            <TextBlock x:Uid="ServerDetail_TransportLabel"
+                                       Grid.Row="5"
                                        Grid.Column="0"
                                        Text="传输"
                                        Visibility="{x:Bind ViewModel.SelectedTransportVisibility, Mode=OneWay}"
@@ -136,8 +140,9 @@
                                     Margin="0,2,0,0"
                                     Visibility="{x:Bind ViewModel.AiUnlockVisibility, Mode=OneWay}">
                             <Grid x:Name="AIShadowCastGrid" />
-                            <TextBlock Text="AI 访问解锁"
-                                           FontSize="13"                                          
+                            <TextBlock x:Uid="ServerDetail_AiUnlockLabel"
+                                           Text="AI 访问解锁"
+                                           FontSize="13"
                                            CharacterSpacing="80"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            VerticalAlignment="Center" />
@@ -188,11 +193,10 @@
                                                        FontSize="12"
                                                        FontWeight="SemiBold"
                                                        VerticalAlignment="Center" />
-                                            <Button Grid.Column="1"
+                                            <Button x:Name="OpenAiLinkButton"
+                                                    Grid.Column="1"
                                                     Click="AiLinkButton_Click"
                                                     Tag="https://chatgpt.com/"
-                                                    ToolTipService.ToolTip="在浏览器中打开 OpenAI"
-                                                    AutomationProperties.Name="在浏览器中打开 OpenAI"
                                                     Background="Transparent"
                                                     BorderBrush="Transparent"
                                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -255,11 +259,10 @@
                        FontSize="12"
                        FontWeight="SemiBold"
                        VerticalAlignment="Center" />
-                                            <Button Grid.Column="1"
+                                            <Button x:Name="ClaudeLinkButton"
+                    Grid.Column="1"
                     Click="AiLinkButton_Click"
                     Tag="https://claude.ai/"
-                    ToolTipService.ToolTip="在浏览器中打开 Claude"
-                    AutomationProperties.Name="在浏览器中打开 Claude"
                     Background="Transparent"
                     BorderBrush="Transparent"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -352,11 +355,10 @@
                                                        FontSize="12"
                                                        FontWeight="SemiBold"
                                                        VerticalAlignment="Center" />
-                                            <Button Grid.Column="1"
+                                            <Button x:Name="GeminiLinkButton"
+                                                    Grid.Column="1"
                                                     Click="AiLinkButton_Click"
                                                     Tag="https://gemini.google.com/"
-                                                    ToolTipService.ToolTip="在浏览器中打开 Gemini"
-                                                    AutomationProperties.Name="在浏览器中打开 Gemini"
                                                     Background="Transparent"
                                                     BorderBrush="Transparent"
                                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -385,7 +387,8 @@
                               ColumnSpacing="12"
                               VerticalAlignment="Center"
                               Visibility="{x:Bind ViewModel.LatencyVisibility, Mode=OneWay}">
-                            <TextBlock Text="网络延迟"
+                            <TextBlock x:Uid="ServerDetail_LatencyLabel"
+                                       Text="网络延迟"
                                        FontSize="13"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        VerticalAlignment="Center" />
@@ -397,13 +400,13 @@
                                        VerticalAlignment="Center"
                                        Margin="0,0,8,0" />
 
-                            <Button Grid.Column="2"
+                            <Button x:Name="RetestLatencyButton"
+                                    Grid.Column="2"
                                     Command="{x:Bind ViewModel.TestLatencyCommand}"
                                     IsEnabled="{x:Bind ViewModel.CanTestLatency, Mode=OneWay}"
                                     Background="Transparent"
                                     BorderBrush="Transparent"
                                     Padding="8"
-                                    ToolTipService.ToolTip="重新测试延迟"
                                     VerticalAlignment="Center">
                                 <FontIcon Glyph="&#xE895;"
                                           FontSize="16" />
@@ -411,14 +414,13 @@
                         </Grid>
 
                     </StackPanel>
-                    <controls:CopyButton HorizontalAlignment="Right"
+                    <controls:CopyButton x:Name="CopyShareLinkButton"
+                                         HorizontalAlignment="Right"
                                          VerticalAlignment="Top"
                                          Padding="7,6,7,6"
                                          MinWidth="32"
                                          MinHeight="32"
                                          Content="&#xE8C8;"
-                                         AutomationProperties.Name="复制分享链接"
-                                         ToolTipService.ToolTip="复制分享链接"
                                          IsEnabled="{x:Bind ViewModel.CanCopyShareLink, Mode=OneWay}"
                                          TextToCopy="{x:Bind ViewModel.SelectedShareLink, Mode=OneWay}" />
                 </Grid>

--- a/Views/ServerDetailControl.xaml.cs
+++ b/Views/ServerDetailControl.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Microsoft.UI.Xaml.Automation;
 using Windows.System;
+using XrayUI.Helpers;
 
 namespace XrayUI.Views
 {
@@ -15,6 +17,22 @@ namespace XrayUI.Views
         public ServerDetailControl()
         {
             this.InitializeComponent();
+            ApplyLocalizedAttachedProperties();
+        }
+
+        private void ApplyLocalizedAttachedProperties()
+        {
+            void SetTooltipAndName(FrameworkElement element, string text)
+            {
+                ToolTipService.SetToolTip(element, text);
+                AutomationProperties.SetName(element, text);
+            }
+
+            SetTooltipAndName(OpenAiLinkButton,    Loc.Format("ServerDetail_OpenInBrowser", "OpenAI"));
+            SetTooltipAndName(ClaudeLinkButton,    Loc.Format("ServerDetail_OpenInBrowser", "Claude"));
+            SetTooltipAndName(GeminiLinkButton,    Loc.Format("ServerDetail_OpenInBrowser", "Gemini"));
+            ToolTipService.SetToolTip(RetestLatencyButton,  L.ServerDetail_RetestLatency);
+            SetTooltipAndName(CopyShareLinkButton, L.ServerDetail_CopyShareLink);
         }
 
         private void ShadowRect_Loaded(object sender, RoutedEventArgs e)

--- a/Views/ServerListControl.xaml
+++ b/Views/ServerListControl.xaml
@@ -20,7 +20,8 @@
 
         <StackPanel Grid.Row="0"
                     Orientation="Vertical">
-            <TextBlock Text="服务器列表"
+            <TextBlock x:Uid="ServerList_HeaderText"
+                       Text="服务器列表"
                        FontSize="20"
                        FontWeight="SemiBold" />
             <StackPanel Orientation="Horizontal"
@@ -31,33 +32,37 @@
                                 Padding="12,6">
                     <DropDownButton.Content>
                         <StackPanel Orientation="Horizontal" Spacing="6">
-                            <TextBlock Text="添加" VerticalAlignment="Center" />
+                            <TextBlock x:Uid="ServerList_AddBtnText" Text="添加" VerticalAlignment="Center" />
                         </StackPanel>
                     </DropDownButton.Content>
                     <DropDownButton.Flyout>
                         <MenuFlyout Placement="BottomEdgeAlignedLeft">
-                            <MenuFlyoutItem Text="导入节点"
+                            <MenuFlyoutItem x:Uid="ServerList_ImportNodeItem"
+                                            Text="导入节点"
                                             Command="{x:Bind ViewModel.ImportFromLinkCommand}"
                                             FontWeight="Normal">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xE77F;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="添加订阅"
+                            <MenuFlyoutItem x:Uid="ServerList_AddSubscriptionItem"
+                                            Text="添加订阅"
                                             Command="{x:Bind ViewModel.OpenSubscriptionsCommand}"
                                             FontWeight="Normal">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xED11;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="手动添加"
+                            <MenuFlyoutItem x:Uid="ServerList_AddManualItem"
+                                            Text="手动添加"
                                             Command="{x:Bind ViewModel.AddManualCommand}"
                                             FontWeight="Normal">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xE710;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="链式代理"
+                            <MenuFlyoutItem x:Uid="ServerList_AddChainProxyItem"
+                                            Text="链式代理"
                                             Command="{x:Bind ViewModel.AddChainProxyCommand}"
                                             FontWeight="Normal">
                                 <MenuFlyoutItem.Icon>
@@ -74,7 +79,7 @@
                     <StackPanel Orientation="Horizontal">
                         <FontIcon Glyph="&#xE70F;"
                                   Margin="0,0,5,0" />
-                        <TextBlock Text="编辑" />
+                        <TextBlock x:Uid="ServerList_EditText" Text="编辑" />
                     </StackPanel>
                 </Button>
                 <Button x:Name="BtnRemove"
@@ -84,7 +89,7 @@
                     <StackPanel Orientation="Horizontal">
                         <FontIcon Glyph="&#xE74D;"
                                   Margin="0,0,5,0" />
-                        <TextBlock Text="删除" />
+                        <TextBlock x:Uid="ServerList_DeleteText" Text="删除" />
                     </StackPanel>
                 </Button>
             </StackPanel>
@@ -99,6 +104,7 @@
             </Grid.ColumnDefinitions>
 
             <AutoSuggestBox x:Name="ServerSearchBox"
+                            x:Uid="ServerList_SearchBox"
                             Grid.Column="0"
                             Width="350"
                             PlaceholderText="搜索服务器"
@@ -116,14 +122,14 @@
                 </AutoSuggestBox.ItemTemplate>
             </AutoSuggestBox>
 
-            <ToggleButton Grid.Column="1"
+            <ToggleButton x:Name="FilterToggle"
+                          Grid.Column="1"
                           Background="Transparent"
                           BorderBrush="Transparent"
                           Padding="6"
                           IsChecked="{x:Bind ViewModel.IsFilterPanelOpen, Mode=TwoWay}"
                           Visibility="{x:Bind ViewModel.IsChipBarVisible, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
-                          VerticalAlignment="Center"
-                          AutomationProperties.Name="筛选">
+                          VerticalAlignment="Center">
                 <FontIcon Glyph="&#xE8A9;"
                           FontSize="16" />
             </ToggleButton>
@@ -146,7 +152,8 @@
                 <FontIcon Glyph="&#xEA37;"
                           FontSize="12"
                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                <TextBlock Text="筛选条件:"
+                <TextBlock x:Uid="ServerList_FilterLabelText"
+                           Text="筛选条件:"
                            FontSize="14"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                            VerticalAlignment="Center" />
@@ -163,24 +170,27 @@
                 </ComboBox.ItemTemplate>
             </ComboBox>
 
-            <DropDownButton Grid.Column="2"
+            <DropDownButton x:Name="SortButton"
+                            Grid.Column="2"
                             Background="Transparent"
-                            BorderBrush="Transparent"
-                            AutomationProperties.Name="排序">
+                            BorderBrush="Transparent">
                 <DropDownButton.Content>
                     <FontIcon Glyph="&#xE8CB;" FontSize="16" />
                 </DropDownButton.Content>
                 <DropDownButton.Flyout>
                     <MenuFlyout Placement="Bottom">
-                        <RadioMenuFlyoutItem Text="默认"
+                        <RadioMenuFlyoutItem x:Uid="ServerList_SortDefaultItem"
+                                             Text="默认"
                                              GroupName="ServerSortMode"
                                              IsChecked="{x:Bind ViewModel.IsSortDefault, Mode=TwoWay}" />
-                        <RadioMenuFlyoutItem Text="当前连接"
+                        <RadioMenuFlyoutItem x:Name="SortActiveItem"
+                                             x:Uid="ServerList_SortActiveItem"
+                                             Text="当前连接"
                                              GroupName="ServerSortMode"
                                              IsChecked="{x:Bind ViewModel.IsSortActive, Mode=TwoWay}"
-                                             IsEnabled="{x:Bind ViewModel.CanSortByActive, Mode=OneWay}"
-                                             ToolTipService.ToolTip="只在筛选为「所有服务器」时可用" />
-                        <RadioMenuFlyoutItem Text="协议"
+                                             IsEnabled="{x:Bind ViewModel.CanSortByActive, Mode=OneWay}" />
+                        <RadioMenuFlyoutItem x:Uid="ServerList_SortProtocolItem"
+                                             Text="协议"
                                              GroupName="ServerSortMode"
                                              IsChecked="{x:Bind ViewModel.IsSortProtocol, Mode=TwoWay}" />
                     </MenuFlyout>
@@ -227,7 +237,8 @@
                                         Visibility="{x:Bind IsActive, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
                                         Grid.Column="1"
                                         Margin="8,0,0,0">
-                                    <TextBlock Text="● Activated"
+                                    <TextBlock x:Uid="ServerList_ActivatedBadge"
+                                               Text="● Activated"
                                                FontSize="12"
                                                FontWeight="SemiBold"
                                                Foreground="White" />
@@ -248,7 +259,8 @@
                                            FontWeight="SemiBold"
                                            Foreground="{x:Bind Protocol, Mode=OneWay, Converter={StaticResource ProtocolToBrushConverter}}" />
                             </StackPanel>
-                            <TextBlock Text="ProxyChain"
+                            <TextBlock x:Uid="ServerList_ChainBadgeText"
+                                       Text="ProxyChain"
                                        Visibility="{x:Bind IsChain, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
                                        FontSize="13"
                                        FontWeight="SemiBold"

--- a/Views/ServerListControl.xaml.cs
+++ b/Views/ServerListControl.xaml.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Windows.Foundation;
+using XrayUI.Helpers;
 using XrayUI.Models;
 
 namespace XrayUI.Views
@@ -15,6 +17,11 @@ namespace XrayUI.Views
         public ServerListControl()
         {
             this.InitializeComponent();
+
+            // Localize attached properties that x:Uid does not address cleanly.
+            AutomationProperties.SetName(FilterToggle, L.ServerList_FilterTooltip);
+            AutomationProperties.SetName(SortButton,   L.ServerList_SortTooltip);
+            ToolTipService.SetToolTip(SortActiveItem,  L.ServerList_SortActiveHint);
         }
 
         private void ServerSearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
@@ -138,21 +145,21 @@ namespace XrayUI.Views
         {
             var flyout = new MenuFlyout();
 
-            var editItem = CreateMenuItem("编辑", "\uE70F");
+            var editItem = CreateMenuItem(L.ServerList_Edit, "");
             editItem.IsEnabled = ViewModel.CanEditSelectedServer;
             editItem.Click += (_, _) => ViewModel.EditServerCommand.Execute(null);
 
             var isFavorite = ViewModel.SelectedServer?.IsFavorite == true;
             var favoriteItem = CreateMenuItem(
-                isFavorite ? "取消收藏" : "加入收藏",
+                isFavorite ? L.ServerList_RemoveFavorite : L.ServerList_AddFavorite,
                 isFavorite ? "\uE8D9" : "\uE734");
             favoriteItem.Click += (_, _) => ViewModel.ToggleFavoriteCommand.Execute(null);
 
-            var deleteItem = CreateMenuItem("删除", "\uE74D");
+            var deleteItem = CreateMenuItem(L.ServerList_Delete, "");
             deleteItem.IsEnabled = ViewModel.CanRemoveSelectedServer;
             deleteItem.Click += (_, _) => ViewModel.RemoveServerCommand.Execute(null);
 
-            var shareItem = CreateMenuItem("分享", "\uE72D");
+            var shareItem = CreateMenuItem(L.ServerList_Share, "");
             shareItem.Click += (_, _) => ViewModel.ShareServerCommand.Execute(null);
 
             flyout.Items.Add(editItem);

--- a/Views/TunConfirmationDialog.xaml
+++ b/Views/TunConfirmationDialog.xaml
@@ -10,9 +10,11 @@
     <StackPanel Spacing="12" Width="280">
         <!-- 核心警告提示 -->
         <TextBlock Text="TUN 模式需要管理员权限，程序将会重启，是否继续？"
+                   x:Uid="Tun_EnableMsg"
                    TextWrapping="Wrap" />
 
         <HyperlinkButton x:Name="MoreOptionsButton"
+                         x:Uid="Tun_MoreOptionsBtn"
                          Content="更多选项"
                          HorizontalAlignment="Left"
                          Padding="0"
@@ -30,7 +32,8 @@
                 <StackPanel Spacing="6">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <FontIcon Glyph="&#xE946;" FontSize="16" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <TextBlock Text="最大传输单元"
+                        <TextBlock x:Uid="Tun_MtuLabel"
+                                   Text="最大传输单元"
                                    FontSize="15"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                     </StackPanel>
@@ -46,7 +49,8 @@
                 <StackPanel Spacing="6">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <FontIcon Glyph="&#xE839;" FontSize="16" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <TextBlock Text="出口网卡"
+                        <TextBlock x:Uid="Tun_InterfaceLabel"
+                                   Text="出口网卡"
                                    FontSize="15"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                     </StackPanel>
@@ -54,8 +58,7 @@
                     <ComboBox x:Name="InterfaceComboBox"
                               Grid.Column="0"
                               HorizontalAlignment="Stretch"
-                              SelectedIndex="0"
-                              ToolTipService.ToolTip="默认使用 Xray 自动选择；只有自动模式不可用时才手动指定。" />
+                              SelectedIndex="0" />
                 </StackPanel>
             </StackPanel>
         </Border>

--- a/Views/TunConfirmationDialog.xaml.cs
+++ b/Views/TunConfirmationDialog.xaml.cs
@@ -4,17 +4,20 @@ using System.Linq;
 using System.Net.NetworkInformation;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using XrayUI.Helpers;
 using XrayUI.Services;
 
 namespace XrayUI.Views
 {
     public sealed partial class TunConfirmationDialog : UserControl
     {
-        private const string AutoInterfaceLabel = "auto（推荐）";
+        // Localized at construction so the resource loader is already initialized.
+        private static string AutoInterfaceLabel => L.Tun_AutoInterfaceLabel;
 
         public TunConfirmationDialog(int currentMtu, string currentInterface)
         {
             this.InitializeComponent();
+            ToolTipService.SetToolTip(InterfaceComboBox, L.Tun_InterfaceTooltip);
             MtuNumberBox.Value = currentMtu;
             PopulateInterfaceComboBox(currentInterface);
         }
@@ -31,7 +34,7 @@ namespace XrayUI.Views
             if (AdvancedSettingsPanel.Visibility == Visibility.Visible)
             {
                 AdvancedSettingsPanel.Visibility = Visibility.Collapsed;
-                MoreOptionsButton.Content = "更多选项";
+                MoreOptionsButton.Content = L.Tun_MoreOptions;
             }
             else
             {

--- a/XrayUI-dev.csproj
+++ b/XrayUI-dev.csproj
@@ -76,11 +76,14 @@
          strip their runtime assets (DirectML.dll / onnxruntime.dll / Microsoft.Windows.AI.MachineLearning.dll).
          IncludeAssets=compile keeps the reference assemblies for compile-time use; PrivateAssets=all
          prevents them from flowing to consumers. -->
-    <PackageReference Include="Microsoft.WindowsAppSDK.AI" Version="2.0.*">
+    <!-- Pinned exact: floating "2.0.*" caused intermittent restore-time mismatches with
+         Microsoft.WindowsAppSDK 2.0.1's transitive Foundation/InteractiveExperiences
+         expectations. Bump deliberately when WindowsAppSDK itself is upgraded. -->
+    <PackageReference Include="Microsoft.WindowsAppSDK.AI" Version="2.0.185">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>compile</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.AI.MachineLearning" Version="2.0.*">
+    <PackageReference Include="Microsoft.Windows.AI.MachineLearning" Version="2.0.300">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>compile</IncludeAssets>
     </PackageReference>

--- a/XrayUI-dev.csproj
+++ b/XrayUI-dev.csproj
@@ -11,6 +11,10 @@
     <UseWinUI>true</UseWinUI>
     <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <!-- PRI fallback target when the system locale has no matching Strings/{lang}/Resources.resw.
+         Keeps non-zh/en users (ko/ja/ru/...) on English rather than relying on PRI's
+         alphabetical default. -->
+    <DefaultLanguage>en-US</DefaultLanguage>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <WindowsPackageType>None</WindowsPackageType>


### PR DESCRIPTION
## Summary

- Add WinAppSDK resource localization infrastructure with `Strings/en-US` and `Strings/zh-CN`.
- Add typed string helpers and persisted language selection, including “Follow System”.
- Localize main views, windows, dialogs, tooltips, and accessibility labels.
- Decouple routing/proxy business values from localized display strings.
- Pin WindowsAppSDK AI package versions to avoid restore-time mismatches.