### PR TITLE
i18n: localize service-layer user-facing strings

### DIFF
--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -259,4 +259,14 @@ public static class L
     public static string Dns_Strategy_V4Only    => Loc.GetString("Dns_Strategy_V4Only");
     public static string Dns_Strategy_V6Only    => Loc.GetString("Dns_Strategy_V6Only");
     public static string Dns_Strategy_Auto      => Loc.GetString("Dns_Strategy_Auto");
+
+    // ── Xray engine / chain / TUN preflight (parameterless; parameterized keys
+    //    like Xray_ExeNotFound / XrayLog_Started use Loc.Format at the call site) ──
+    public static string XrayLog_Stopped         => Loc.GetString("XrayLog_Stopped");
+    public static string XrayLog_ProcessExited   => Loc.GetString("XrayLog_ProcessExited");
+    public static string XrayLog_Shutdown        => Loc.GetString("XrayLog_Shutdown");
+    public static string Chain_NeedServerList    => Loc.GetString("Chain_NeedServerList");
+    public static string Chain_EndpointMissing   => Loc.GetString("Chain_EndpointMissing");
+    public static string Chain_NoNesting         => Loc.GetString("Chain_NoNesting");
+    public static string Tun_PreflightErrorTitle => Loc.GetString("Tun_PreflightErrorTitle");
 }

--- a/Services/GeoDataUpdateService.cs
+++ b/Services/GeoDataUpdateService.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using XrayUI.Helpers;
 
 namespace XrayUI.Services
 {
@@ -38,7 +39,7 @@ namespace XrayUI.Services
             {
                 handler.Proxy    = new WebProxy(proxyUrl);
                 handler.UseProxy = true;
-                progress.Report($"通过本地代理下载（{proxyUrl}）…");
+                progress.Report(Loc.Format("GeoUpdate_ViaProxy", proxyUrl));
             }
             else
             {
@@ -64,7 +65,7 @@ namespace XrayUI.Services
                 var sumUrl = url + ".sha256sum";
                 var target = Path.Combine(XrayService.RulesDir, $"{name}.dat");
 
-                progress.Report($"正在检查 {name}.dat …");
+                progress.Report(Loc.Format("GeoUpdate_Checking", name));
 
                 // If the hash fetch fails (404, network), fall through to unconditional download — v2rayN parity.
                 string? remoteHash = await TryFetchRemoteHashAsync(client, sumUrl, ct);
@@ -74,7 +75,7 @@ namespace XrayUI.Services
                     var localHash = await ComputeSha256Async(target, ct);
                     if (string.Equals(localHash, remoteHash, StringComparison.OrdinalIgnoreCase))
                     {
-                        progress.Report($"{name}.dat 已是最新");
+                        progress.Report(Loc.Format("GeoUpdate_UpToDate", name));
                         skipped++;
                         continue;
                     }
@@ -91,7 +92,7 @@ namespace XrayUI.Services
                         if (!string.Equals(downloadedHash, remoteHash, StringComparison.OrdinalIgnoreCase))
                         {
                             throw new InvalidDataException(
-                                $"{name}.dat 校验失败：下载文件的 SHA256 与服务器公布的不一致。");
+                                Loc.Format("GeoUpdate_ChecksumFailed", name));
                         }
                     }
 
@@ -201,8 +202,8 @@ namespace XrayUI.Services
         {
             var mbReceived = received / 1024.0 / 1024.0;
             return total.HasValue
-                ? $"正在下载 {name} … {mbReceived:0.0} / {total.Value / 1024.0 / 1024.0:0.0} MB"
-                : $"正在下载 {name} … {mbReceived:0.0} MB";
+                ? Loc.Format("GeoUpdate_Downloading", name, mbReceived, total.Value / 1024.0 / 1024.0)
+                : Loc.Format("GeoUpdate_DownloadingNoTotal", name, mbReceived);
         }
     }
 }

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using XrayUI.Helpers;
 using XrayUI.Models;
 
 namespace XrayUI.Services
@@ -223,7 +224,7 @@ namespace XrayUI.Services
         {
             if (availableServers is null)
             {
-                throw new InvalidOperationException("链式代理需要服务器列表才能解析入口和出口节点。");
+                throw new InvalidOperationException(L.Chain_NeedServerList);
             }
 
             ServerEntry? entryServer = null;
@@ -237,12 +238,12 @@ namespace XrayUI.Services
 
             if (entryServer is null || exitServer is null)
             {
-                throw new InvalidOperationException("链式代理引用的入口或出口节点不存在，请重新编辑该链式代理。");
+                throw new InvalidOperationException(L.Chain_EndpointMissing);
             }
 
             if (entryServer.IsChain || exitServer.IsChain)
             {
-                throw new InvalidOperationException("链式代理不能嵌套链式代理，请重新选择入口和出口节点。");
+                throw new InvalidOperationException(L.Chain_NoNesting);
             }
 
             return (entryServer, exitServer);

--- a/Services/XrayService.cs
+++ b/Services/XrayService.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using XrayUI.Helpers;
 
 namespace XrayUI.Services
 {
@@ -158,8 +159,8 @@ namespace XrayUI.Services
 
             if (!File.Exists(ExePath))
             {
-                LastError = $"找不到 xray.exe\n路径：{ExePath}";
-                AppendLog("[错误] " + LastError);
+                LastError = Loc.Format("Xray_ExeNotFound", ExePath);
+                AppendLog(Loc.Format("XrayLog_Error", LastError));
                 return false;
             }
 
@@ -204,8 +205,8 @@ namespace XrayUI.Services
                 _process.BeginOutputReadLine();
                 _process.BeginErrorReadLine();
 
-                AppendLog($"[启动] {ExePath}");
-                AppendLog($"[配置] {ConfigPath}");
+                AppendLog(Loc.Format("XrayLog_Started", ExePath));
+                AppendLog(Loc.Format("XrayLog_Config", ConfigPath));
 
                 await Task.Delay(800);
 
@@ -214,8 +215,8 @@ namespace XrayUI.Services
                     var startupLog = StopStartupLogCaptureAndRead();
                     LastError = startupLog.Length > 0
                         ? startupLog
-                        : $"xray 立即退出（退出码 {_process.ExitCode}）";
-                    AppendLog("[错误] 启动失败：" + LastError);
+                        : Loc.Format("Xray_ExitedImmediately", _process.ExitCode);
+                    AppendLog(Loc.Format("XrayLog_StartFailed", LastError));
                     return false;
                 }
 
@@ -227,7 +228,7 @@ namespace XrayUI.Services
             {
                 StopStartupLogCapture();
                 LastError = ex.Message;
-                AppendLog("[异常] " + ex.Message);
+                AppendLog(Loc.Format("XrayLog_Exception", ex.Message));
                 return false;
             }
         }
@@ -270,7 +271,7 @@ namespace XrayUI.Services
                 _process = null;
             }
 
-            AppendLog("[已停止]");
+            AppendLog(L.XrayLog_Stopped);
             RunningChanged?.Invoke(this, false);
         }
 
@@ -327,13 +328,13 @@ namespace XrayUI.Services
                 process.Dispose();
             }
 
-            AppendLog("[shutdown] xray stopped");
+            AppendLog(L.XrayLog_Shutdown);
             RunningChanged?.Invoke(this, false);
         }
 
         private void OnProcessExited(object? sender, EventArgs e)
         {
-            AppendLog("[xray 进程已退出]");
+            AppendLog(L.XrayLog_ProcessExited);
             RunningChanged?.Invoke(this, false);
         }
 
@@ -403,19 +404,19 @@ namespace XrayUI.Services
                     _jobHandle = CreateKillOnCloseJob();
                     if (_jobHandle == IntPtr.Zero)
                     {
-                        AppendLog($"[警告] CreateJobObject 失败 (err={Marshal.GetLastWin32Error()})，孤儿进程兜底已禁用");
+                        AppendLog(Loc.Format("XrayLog_JobCreateFailed", Marshal.GetLastWin32Error()));
                         return;
                     }
                 }
 
                 if (!AssignProcessToJobObject(_jobHandle, process.Handle))
                 {
-                    AppendLog($"[警告] AssignProcessToJobObject 失败 (err={Marshal.GetLastWin32Error()})，孤儿进程兜底未生效");
+                    AppendLog(Loc.Format("XrayLog_JobAssignFailed", Marshal.GetLastWin32Error()));
                 }
             }
             catch (Exception ex)
             {
-                AppendLog($"[警告] Job Object 绑定异常：{ex.Message}");
+                AppendLog(Loc.Format("XrayLog_JobBindException", ex.Message));
             }
         }
 

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -1084,4 +1084,80 @@
   <data name="Subscription_DeleteConfirmBtn.Content" xml:space="preserve">
     <value>Delete</value>
   </data>
+  <!-- ── Xray engine / chain / TUN preflight (C# service layer) ── -->
+  <data name="Xray_ExeNotFound" xml:space="preserve">
+    <value>Could not find xray.exe
+Path: {0}</value>
+  </data>
+  <data name="Xray_ExitedImmediately" xml:space="preserve">
+    <value>xray exited immediately (exit code {0})</value>
+  </data>
+  <data name="XrayLog_Started" xml:space="preserve">
+    <value>[Started] {0}</value>
+  </data>
+  <data name="XrayLog_Config" xml:space="preserve">
+    <value>[Config] {0}</value>
+  </data>
+  <data name="XrayLog_Error" xml:space="preserve">
+    <value>[Error] {0}</value>
+  </data>
+  <data name="XrayLog_StartFailed" xml:space="preserve">
+    <value>[Error] Start failed: {0}</value>
+  </data>
+  <data name="XrayLog_Exception" xml:space="preserve">
+    <value>[Exception] {0}</value>
+  </data>
+  <data name="XrayLog_Stopped" xml:space="preserve">
+    <value>[Stopped]</value>
+  </data>
+  <data name="XrayLog_Shutdown" xml:space="preserve">
+    <value>[shutdown] xray stopped</value>
+  </data>
+  <data name="XrayLog_ProcessExited" xml:space="preserve">
+    <value>[xray process exited]</value>
+  </data>
+  <data name="XrayLog_JobCreateFailed" xml:space="preserve">
+    <value>[Warning] CreateJobObject failed (err={0}); orphan-process safety net disabled</value>
+  </data>
+  <data name="XrayLog_JobAssignFailed" xml:space="preserve">
+    <value>[Warning] AssignProcessToJobObject failed (err={0}); orphan-process safety net inactive</value>
+  </data>
+  <data name="XrayLog_JobBindException" xml:space="preserve">
+    <value>[Warning] Job Object bind exception: {0}</value>
+  </data>
+  <data name="Chain_NeedServerList" xml:space="preserve">
+    <value>Chain proxy needs the server list to resolve entry/exit nodes.</value>
+  </data>
+  <data name="Chain_EndpointMissing" xml:space="preserve">
+    <value>The chain proxy's entry or exit node no longer exists. Please edit the chain proxy again.</value>
+  </data>
+  <data name="Chain_NoNesting" xml:space="preserve">
+    <value>A chain proxy cannot nest another chain proxy. Please choose different entry/exit nodes.</value>
+  </data>
+  <data name="Tun_PreflightErrorTitle" xml:space="preserve">
+    <value>TUN mode error</value>
+  </data>
+  <data name="Tun_WintunNotFound" xml:space="preserve">
+    <value>Could not find wintun.dll
+Path: {0}</value>
+  </data>
+  <!-- ── Geo data update progress (GeoDataUpdateService) ── -->
+  <data name="GeoUpdate_ViaProxy" xml:space="preserve">
+    <value>Downloading via local proxy ({0}) …</value>
+  </data>
+  <data name="GeoUpdate_Checking" xml:space="preserve">
+    <value>Checking {0}.dat …</value>
+  </data>
+  <data name="GeoUpdate_UpToDate" xml:space="preserve">
+    <value>{0}.dat is up to date</value>
+  </data>
+  <data name="GeoUpdate_ChecksumFailed" xml:space="preserve">
+    <value>{0}.dat checksum failed: the downloaded file's SHA256 does not match the server's.</value>
+  </data>
+  <data name="GeoUpdate_Downloading" xml:space="preserve">
+    <value>Downloading {0} … {1:0.0} / {2:0.0} MB</value>
+  </data>
+  <data name="GeoUpdate_DownloadingNoTotal" xml:space="preserve">
+    <value>Downloading {0} … {1:0.0} MB</value>
+  </data>
 </root>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -1084,4 +1084,80 @@
   <data name="Subscription_DeleteConfirmBtn.Content" xml:space="preserve">
     <value>删除</value>
   </data>
+  <!-- ── Xray engine / chain / TUN preflight (C# service layer) ── -->
+  <data name="Xray_ExeNotFound" xml:space="preserve">
+    <value>找不到 xray.exe
+路径：{0}</value>
+  </data>
+  <data name="Xray_ExitedImmediately" xml:space="preserve">
+    <value>xray 立即退出（退出码 {0}）</value>
+  </data>
+  <data name="XrayLog_Started" xml:space="preserve">
+    <value>[启动] {0}</value>
+  </data>
+  <data name="XrayLog_Config" xml:space="preserve">
+    <value>[配置] {0}</value>
+  </data>
+  <data name="XrayLog_Error" xml:space="preserve">
+    <value>[错误] {0}</value>
+  </data>
+  <data name="XrayLog_StartFailed" xml:space="preserve">
+    <value>[错误] 启动失败：{0}</value>
+  </data>
+  <data name="XrayLog_Exception" xml:space="preserve">
+    <value>[异常] {0}</value>
+  </data>
+  <data name="XrayLog_Stopped" xml:space="preserve">
+    <value>[已停止]</value>
+  </data>
+  <data name="XrayLog_Shutdown" xml:space="preserve">
+    <value>[关机] xray 已停止</value>
+  </data>
+  <data name="XrayLog_ProcessExited" xml:space="preserve">
+    <value>[xray 进程已退出]</value>
+  </data>
+  <data name="XrayLog_JobCreateFailed" xml:space="preserve">
+    <value>[警告] CreateJobObject 失败 (err={0})，孤儿进程兜底已禁用</value>
+  </data>
+  <data name="XrayLog_JobAssignFailed" xml:space="preserve">
+    <value>[警告] AssignProcessToJobObject 失败 (err={0})，孤儿进程兜底未生效</value>
+  </data>
+  <data name="XrayLog_JobBindException" xml:space="preserve">
+    <value>[警告] Job Object 绑定异常：{0}</value>
+  </data>
+  <data name="Chain_NeedServerList" xml:space="preserve">
+    <value>链式代理需要服务器列表才能解析入口和出口节点。</value>
+  </data>
+  <data name="Chain_EndpointMissing" xml:space="preserve">
+    <value>链式代理引用的入口或出口节点不存在，请重新编辑该链式代理。</value>
+  </data>
+  <data name="Chain_NoNesting" xml:space="preserve">
+    <value>链式代理不能嵌套链式代理，请重新选择入口和出口节点。</value>
+  </data>
+  <data name="Tun_PreflightErrorTitle" xml:space="preserve">
+    <value>TUN 模式错误</value>
+  </data>
+  <data name="Tun_WintunNotFound" xml:space="preserve">
+    <value>找不到 wintun.dll
+路径：{0}</value>
+  </data>
+  <!-- ── Geo data update progress (GeoDataUpdateService) ── -->
+  <data name="GeoUpdate_ViaProxy" xml:space="preserve">
+    <value>通过本地代理下载（{0}）…</value>
+  </data>
+  <data name="GeoUpdate_Checking" xml:space="preserve">
+    <value>正在检查 {0}.dat …</value>
+  </data>
+  <data name="GeoUpdate_UpToDate" xml:space="preserve">
+    <value>{0}.dat 已是最新</value>
+  </data>
+  <data name="GeoUpdate_ChecksumFailed" xml:space="preserve">
+    <value>{0}.dat 校验失败：下载文件的 SHA256 与服务器公布的不一致。</value>
+  </data>
+  <data name="GeoUpdate_Downloading" xml:space="preserve">
+    <value>正在下载 {0} … {1:0.0} / {2:0.0} MB</value>
+  </data>
+  <data name="GeoUpdate_DownloadingNoTotal" xml:space="preserve">
+    <value>正在下载 {0} … {1:0.0} MB</value>
+  </data>
 </root>

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -237,7 +237,7 @@ namespace XrayUI.ViewModels
 
             if (IsTunMode)
             {
-                if (!await RunTunPreflightAsync("TUN mode error")) return false;
+                if (!await RunTunPreflightAsync()) return false;
                 await CleanupPersistedTunRoutesAsync(appSettings);
             }
 
@@ -394,12 +394,12 @@ namespace XrayUI.ViewModels
         /// Runs the shared TUN-mode preflight: wintun availability and system-proxy clearing.
         /// Xray-core handles outbound interface selection through autoOutboundsInterface="auto".
         /// </summary>
-        private async Task<bool> RunTunPreflightAsync(string errorTitle)
+        private async Task<bool> RunTunPreflightAsync()
         {
             if (!_tunService.IsWintunAvailable())
             {
-                await _dialogs.ShowErrorAsync(errorTitle,
-                    $"Could not find wintun.dll\nPath: {_tunService.GetExpectedWintunPath()}");
+                await _dialogs.ShowErrorAsync(L.Tun_PreflightErrorTitle,
+                    Loc.Format("Tun_WintunNotFound", _tunService.GetExpectedWintunPath()));
                 return false;
             }
 


### PR DESCRIPTION
## What

Routes the remaining hardcoded user-facing strings in the service layer through the resource system (`L.*` / `Loc.Format`), so they follow the active UI language instead of being fixed to one locale.

Localized:
- **XrayService** — `LastError` (shown via `ShowErrorAsync`) and the LogWindow annotations (`[Started]` / `[Config]` / `[Stopped]` / `[Warning] …`, etc.)
- **XrayConfigBuilder** — the three chain-proxy `InvalidOperationException` messages, which bubble up to `ShowErrorAsync(ex.Message)`
- **ControlPanelViewModel** — the TUN preflight title + wintun-not-found message (these were hardcoded **English**)
- **GeoDataUpdateService** — geo-data update progress / checksum-failure strings

## Why

The service layer predated the project's "no hardcoded literals" i18n rule (CLAUDE.md). These strings reached the user (error dialogs, log window, progress dialog) in the wrong language regardless of the selected UI locale.

## How

- Added **24 keys** to both `Strings/en-US/Resources.resw` and `Strings/zh-CN/Resources.resw` (key-set parity verified)
- Parameterless keys also get `L.*` accessors; parameterized ones use `Loc.Format` at the call site — matching the existing `UpdateService` pattern
- Dropped the now-unused `errorTitle` parameter of `RunTunPreflightAsync`

## Out of scope (left as-is, by design)
- `Debug.WriteLine` diagnostics (debugger-only, never shown to users)
- xray-core's own piped stdout/stderr
- `SystemProxyService`'s registry-open `throw`, which is caught one frame up and logged via `Debug.WriteLine`

## Verification
- `BuildAndRun.ps1 -SkipRun` → clean build, no new warnings
- Residual-CJK sweep of `Services/` + `ViewModels/` → only the intended exclusions remain
- en-US / zh-CN key sets confirmed identical
