### PR TITLE
feat(tun): add opt-in IPv6 (::/0) routing toggle

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -14,6 +14,9 @@ namespace XrayUI.Models
         public string? LastTunServerHost { get; set; }
         public int TunMtu { get; set; } = XrayConfigConstants.TunMtuDefault;
         public string TunOutboundInterface { get; set; } = XrayConfigConstants.TunOutboundInterfaceAuto;
+        /// <summary>Route IPv6 (::/0) through the TUN adapter too. Opt-in; off by default to avoid
+        /// IPv6 leak / Happy-Eyeballs stalls on IPv4-only networks.</summary>
+        public bool TunIpv6Enabled { get; set; } = false;
         public bool IsStartupEnabled { get; set; } = false;
         public bool IsAutoConnect    { get; set; } = false;
         /// <summary>true = global proxy (default); false = do not take over the system proxy.</summary>

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -473,7 +473,7 @@ namespace XrayUI.Services
 
         public async Task<bool> ShowTunConfirmationDialogAsync(AppSettings settings)
         {
-            var content = new TunConfirmationDialog(settings.TunMtu, settings.TunOutboundInterface);
+            var content = new TunConfirmationDialog(settings.TunMtu, settings.TunOutboundInterface, settings.TunIpv6Enabled);
 
             var dialog = CreateDialog();
             dialog.Title = L.Tun_EnableTitle;
@@ -487,6 +487,7 @@ namespace XrayUI.Services
 
             settings.TunMtu = content.Mtu;
             settings.TunOutboundInterface = content.SelectedInterface;
+            settings.TunIpv6Enabled = content.Ipv6Enabled;
             return true;
         }
 

--- a/Services/IDialogService.cs
+++ b/Services/IDialogService.cs
@@ -16,9 +16,9 @@ namespace XrayUI.Services
         Task ShowErrorAsync(string title, string message, XamlRoot? xamlRoot = null);
         Task<bool> ShowConfirmationAsync(string title, string message, string? confirmText = null, string? cancelText = null, bool isDanger = false);
         /// <summary>
-        /// Shows the TUN confirmation dialog. Mutates <paramref name="settings"/>.TunMtu and
-        /// <paramref name="settings"/>.TunOutboundInterface in-place on confirm. Returns true if
-        /// the user confirmed (caller must persist), false if cancelled.
+        /// Shows the TUN confirmation dialog. Mutates <paramref name="settings"/>.TunMtu,
+        /// <paramref name="settings"/>.TunOutboundInterface, and <paramref name="settings"/>.TunIpv6Enabled
+        /// in-place on confirm. Returns true if the user confirmed (caller must persist), false if cancelled.
         /// </summary>
         Task<bool> ShowTunConfirmationDialogAsync(AppSettings settings);
         Task ShowShareLinkDialogAsync(string serverName, string link);

--- a/Services/TunService.cs
+++ b/Services/TunService.cs
@@ -85,9 +85,11 @@ public class TunService
             {
                 // 0.0.0.0/0 is what current xray adds; the /1 split-routes are residue
                 // from earlier routing schemes that may still be lying around.
-                $"netsh interface ipv4 delete route 0.0.0.0/0 \"{TunInterfaceName}\" store=active",
+                $"netsh interface ipv4 delete route {XrayConfigConstants.TunAutoRouteV4} \"{TunInterfaceName}\" store=active",
                 $"netsh interface ipv4 delete route 0.0.0.0/1 \"{TunInterfaceName}\" store=active",
                 $"netsh interface ipv4 delete route 128.0.0.0/1 \"{TunInterfaceName}\" store=active",
+                // IPv6 default route — present only when TUN IPv6 was enabled; harmless to delete otherwise.
+                $"netsh interface ipv6 delete route {XrayConfigConstants.TunAutoRouteV6} \"{TunInterfaceName}\" store=active",
                 // Legacy route.exe form for the same /1 split-routes.
                 "route delete 0.0.0.0 mask 128.0.0.0",
                 "route delete 128.0.0.0 mask 128.0.0.0",

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -118,6 +118,15 @@ namespace XrayUI.Services
                 sniffing["metadataOnly"] = false;
             }
 
+            // IPv6 is opt-in: only when enabled do we hand the TUN a v6 gateway and hijack ::/0,
+            // so IPv4-only networks keep the leak-free v4-only behaviour.
+            var gateway = settings.TunIpv6Enabled
+                ? CreateStringArray(XrayConfigConstants.TunGatewayV4, XrayConfigConstants.TunGatewayV6)
+                : CreateStringArray(XrayConfigConstants.TunGatewayV4);
+            var autoRoutes = settings.TunIpv6Enabled
+                ? CreateStringArray(XrayConfigConstants.TunAutoRouteV4, XrayConfigConstants.TunAutoRouteV6)
+                : CreateStringArray(XrayConfigConstants.TunAutoRouteV4);
+
             return new JsonObject
             {
                 ["tag"] = XrayConfigConstants.TunInboundTag,
@@ -126,8 +135,8 @@ namespace XrayUI.Services
                 {
                     ["name"] = XrayConfigConstants.TunInterfaceName,
                     ["MTU"] = XrayConfigConstants.NormalizeTunMtu(settings.TunMtu),
-                    ["gateway"] = CreateStringArray("172.18.0.1/30"),
-                    ["autoSystemRoutingTable"] = CreateStringArray("0.0.0.0/0"),
+                    ["gateway"] = gateway,
+                    ["autoSystemRoutingTable"] = autoRoutes,
                     ["autoOutboundsInterface"] = XrayConfigConstants.TunOutboundInterfaceAuto
                 },
                 ["sniffing"] = sniffing,

--- a/Services/XrayConfigConstants.cs
+++ b/Services/XrayConfigConstants.cs
@@ -21,6 +21,15 @@ namespace XrayUI.Services
         // interface alias used by TunService for adapter operations (DNS reset, route delete).
         public const string TunInterfaceName        = "xray-tun";
         public const string TunOutboundInterfaceAuto = "auto";
+
+        // TUN adapter addressing. xray assigns these to the xray-tun adapter and, via
+        // autoSystemRoutingTable, hijacks the matching default route when run elevated.
+        // The v6 gateway sits in fd00::/8, deliberately clear of the FakeDNS v6 pool (fc00::/18).
+        public const string TunGatewayV4   = "172.18.0.1/30";
+        public const string TunGatewayV6   = "fdfe:dcba:9876::1/64";
+        public const string TunAutoRouteV4 = "0.0.0.0/0";
+        public const string TunAutoRouteV6 = "::/0";
+
         public const int    TunMtuMin               = 68;
         public const int    TunMtuMax               = 9000;
         public const int    TunMtuDefault           = 1500;

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -1054,6 +1054,9 @@
   <data name="Tun_AutoInterfaceLabel" xml:space="preserve">
     <value>auto (recommended)</value>
   </data>
+  <data name="Tun_Ipv6Label.Text" xml:space="preserve">
+    <value>Enable IPv6 address</value>
+  </data>
   <data name="Subscription_DialogTitle_Add" xml:space="preserve">
     <value>Add Subscription</value>
   </data>
@@ -1084,7 +1087,6 @@
   <data name="Subscription_DeleteConfirmBtn.Content" xml:space="preserve">
     <value>Delete</value>
   </data>
-  <!-- ── Xray engine / chain / TUN preflight (C# service layer) ── -->
   <data name="Xray_ExeNotFound" xml:space="preserve">
     <value>Could not find xray.exe
 Path: {0}</value>
@@ -1141,7 +1143,6 @@ Path: {0}</value>
     <value>Could not find wintun.dll
 Path: {0}</value>
   </data>
-  <!-- ── Geo data update progress (GeoDataUpdateService) ── -->
   <data name="GeoUpdate_ViaProxy" xml:space="preserve">
     <value>Downloading via local proxy ({0}) …</value>
   </data>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -1054,6 +1054,9 @@
   <data name="Tun_AutoInterfaceLabel" xml:space="preserve">
     <value>auto（推荐）</value>
   </data>
+  <data name="Tun_Ipv6Label.Text" xml:space="preserve">
+    <value>开启IPv6</value>
+  </data>
   <data name="Subscription_DialogTitle_Add" xml:space="preserve">
     <value>添加订阅</value>
   </data>
@@ -1084,7 +1087,6 @@
   <data name="Subscription_DeleteConfirmBtn.Content" xml:space="preserve">
     <value>删除</value>
   </data>
-  <!-- ── Xray engine / chain / TUN preflight (C# service layer) ── -->
   <data name="Xray_ExeNotFound" xml:space="preserve">
     <value>找不到 xray.exe
 路径：{0}</value>
@@ -1141,7 +1143,6 @@
     <value>找不到 wintun.dll
 路径：{0}</value>
   </data>
-  <!-- ── Geo data update progress (GeoDataUpdateService) ── -->
   <data name="GeoUpdate_ViaProxy" xml:space="preserve">
     <value>通过本地代理下载（{0}）…</value>
   </data>

--- a/Views/TunConfirmationDialog.xaml
+++ b/Views/TunConfirmationDialog.xaml
@@ -21,12 +21,7 @@
                          Click="MoreOptionsButton_Click" />
 
         <Border x:Name="AdvancedSettingsPanel"
-                Visibility="Collapsed"
-                Background="{ThemeResource LayerFillColorDefaultBrush}"
-                BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="{ThemeResource OverlayCornerRadius}"
-                Padding="16">
+                Visibility="Collapsed">
             <StackPanel Spacing="16">
                 <!-- MTU 设置 -->
                 <StackPanel Spacing="6">
@@ -60,6 +55,28 @@
                               HorizontalAlignment="Stretch"
                               SelectedIndex="0" />
                 </StackPanel>
+
+                <!-- IPv6 设置 -->
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock x:Name="Ipv6LabelText"
+                               x:Uid="Tun_Ipv6Label"
+                               Text="开启IPv6"
+                               FontSize="15"
+                               VerticalAlignment="Center"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    <ToggleSwitch x:Name="Ipv6ToggleSwitch"
+                                  Grid.Column="1"
+                                  AutomationProperties.LabeledBy="{x:Bind Ipv6LabelText}"
+                                  MinWidth="0"
+                                  OnContent=""
+                                  OffContent=""
+                                  HorizontalAlignment="Right"
+                                  VerticalAlignment="Center" />
+                </Grid>
             </StackPanel>
         </Border>
     </StackPanel>

--- a/Views/TunConfirmationDialog.xaml.cs
+++ b/Views/TunConfirmationDialog.xaml.cs
@@ -14,16 +14,19 @@ namespace XrayUI.Views
         // Localized at construction so the resource loader is already initialized.
         private static string AutoInterfaceLabel => L.Tun_AutoInterfaceLabel;
 
-        public TunConfirmationDialog(int currentMtu, string currentInterface)
+        public TunConfirmationDialog(int currentMtu, string currentInterface, bool currentIpv6Enabled)
         {
             this.InitializeComponent();
             ToolTipService.SetToolTip(InterfaceComboBox, L.Tun_InterfaceTooltip);
             MtuNumberBox.Value = currentMtu;
             PopulateInterfaceComboBox(currentInterface);
+            Ipv6ToggleSwitch.IsOn = currentIpv6Enabled;
         }
 
         public int Mtu => XrayConfigConstants.NormalizeTunMtu(
             double.IsNaN(MtuNumberBox.Value) ? XrayConfigConstants.TunMtuDefault : (int)MtuNumberBox.Value);
+
+        public bool Ipv6Enabled => Ipv6ToggleSwitch.IsOn;
 
         public string SelectedInterface =>
             (InterfaceComboBox.SelectedItem as ComboBoxItem)?.Tag as string


### PR DESCRIPTION
## What

Adds an opt-in **IPv6** toggle to TUN mode (off by default). When enabled, the TUN inbound is also given an IPv6 ULA gateway and hijacks `::/0`, so IPv6 traffic is tunnelled through the proxy instead of leaking out the physical adapter. When off, behaviour is byte-for-byte unchanged (IPv4-only).

## Changes

- `AppSettings.TunIpv6Enabled` (default `false`), plumbed through the TUN confirmation dialog like MTU / outbound-interface.
- `XrayConfigBuilder.BuildTunInbound` conditionally appends the v6 gateway + `::/0` to `gateway` / `autoSystemRoutingTable`.
- `XrayConfigConstants`: new `TunGatewayV4/V6`, `TunAutoRouteV4/V6` (v6 gateway `fdfe:dcba:9876::1/64` deliberately sits in `fd00::/8`, clear of the FakeDNS `fc00::/18` pool).
- `TunConfirmationDialog`: a compact `ToggleSwitch` row + `Ipv6Enabled`, read back by `DialogService`.
- `TunService.CleanupTunRoutes`: best-effort `netsh ... ipv6 delete route ::/0` on the fallback cleanup path (now references the new route constants).
- DNS query strategy left at `UseIPv4`; sniffing folds direct v6 -> domain -> v4, so IPv4-only networks see no Happy-Eyeballs stalls.

Config emitted when enabled:
```json
"gateway": ["172.18.0.1/30", "fdfe:dcba:9876::1/64"],
"autoSystemRoutingTable": ["0.0.0.0/0", "::/0"]
```

## Testing

- Debug build green.
- Manual: enabled the toggle, connected over a v6-capable node -- test-ipv6.com scores 10/10 with both IPv4 and IPv6 egress showing the proxy (no leak).

## Note

Also drops two unrelated resw section-divider comments that were already removed in the working tree.

