### PR TITLE
Add real latency test mode and  temporarily recover allowinsecure option

### DIFF
--- a/Helpers/JobObjectGuard.cs
+++ b/Helpers/JobObjectGuard.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace XrayUI.Helpers
+{
+    /// <summary>
+    /// Wraps a child process in a kill-on-close Job Object: when this guard is disposed — or the
+    /// host process dies for any reason (taskkill /F, AV crash, OOM) — the kernel kills the
+    /// assigned process. Orphan-safety net for short-lived helper cores such as the real-delay
+    /// speed-test core. Mirrors the job-object net <see cref="XrayUI.Services.XrayService"/> uses
+    /// for the main core, factored out so both can share it.
+    /// </summary>
+    public sealed partial class JobObjectGuard : IDisposable
+    {
+        private IntPtr _handle;
+
+        private JobObjectGuard(IntPtr handle) => _handle = handle;
+
+        /// <summary>Creates an empty kill-on-close job. Returns null if the job can't be created.</summary>
+        public static JobObjectGuard? Create()
+        {
+            var handle = CreateKillOnCloseJob();
+            return handle == IntPtr.Zero ? null : new JobObjectGuard(handle);
+        }
+
+        /// <summary>Assigns <paramref name="process"/> to this job. Returns false on failure.</summary>
+        public bool TryAssign(Process process)
+            => _handle != IntPtr.Zero && AssignProcessToJobObject(_handle, process.Handle);
+
+        /// <summary>
+        /// Convenience for one-shot helper cores: create a kill-on-close job and assign a single
+        /// process to it. Returns null on failure (the caller should still terminate the process
+        /// explicitly on teardown).
+        /// </summary>
+        public static JobObjectGuard? Assign(Process process)
+        {
+            var guard = Create();
+            if (guard is null)
+                return null;
+
+            if (!guard.TryAssign(process))
+            {
+                guard.Dispose();
+                return null;
+            }
+
+            return guard;
+        }
+
+        public void Dispose()
+        {
+            if (_handle != IntPtr.Zero)
+            {
+                // KILL_ON_JOB_CLOSE: closing the last job handle kills every assigned process.
+                _ = CloseHandle(_handle);
+                _handle = IntPtr.Zero;
+            }
+        }
+
+        private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
+        private const int JobObjectExtendedLimitInformation = 9;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+        {
+            public long PerProcessUserTimeLimit;
+            public long PerJobUserTimeLimit;
+            public uint LimitFlags;
+            public UIntPtr MinimumWorkingSetSize;
+            public UIntPtr MaximumWorkingSetSize;
+            public uint ActiveProcessLimit;
+            public UIntPtr Affinity;
+            public uint PriorityClass;
+            public uint SchedulingClass;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct IO_COUNTERS
+        {
+            public ulong ReadOperationCount;
+            public ulong WriteOperationCount;
+            public ulong OtherOperationCount;
+            public ulong ReadTransferCount;
+            public ulong WriteTransferCount;
+            public ulong OtherTransferCount;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+            public IO_COUNTERS IoInfo;
+            public UIntPtr ProcessMemoryLimit;
+            public UIntPtr JobMemoryLimit;
+            public UIntPtr PeakProcessMemoryUsed;
+            public UIntPtr PeakJobMemoryUsed;
+        }
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        private static partial IntPtr CreateJobObjectW(IntPtr lpJobAttributes, IntPtr lpName);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool SetInformationJobObject(
+            IntPtr hJob, int jobObjectInfoClass, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool CloseHandle(IntPtr hObject);
+
+        private static IntPtr CreateKillOnCloseJob()
+        {
+            var handle = CreateJobObjectW(IntPtr.Zero, IntPtr.Zero);
+            if (handle == IntPtr.Zero)
+                return IntPtr.Zero;
+
+            var info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+            {
+                BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
+                {
+                    LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+                }
+            };
+
+            int size = Marshal.SizeOf<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>();
+            IntPtr buf = Marshal.AllocHGlobal(size);
+            try
+            {
+                Marshal.StructureToPtr(info, buf, fDeleteOld: false);
+                if (!SetInformationJobObject(handle, JobObjectExtendedLimitInformation, buf, (uint)size))
+                {
+                    _ = CloseHandle(handle);
+                    return IntPtr.Zero;
+                }
+                return handle;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buf);
+            }
+        }
+    }
+}

--- a/Services/RealLatencyProbeService.cs
+++ b/Services/RealLatencyProbeService.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using XrayUI.Helpers;
+using XrayUI.Models;
+
+namespace XrayUI.Services
+{
+    /// <summary>
+    /// "Real delay" latency test (v2rayN-style): routes a real HTTP request through each server
+    /// and times the round trip. Spins up a dedicated throwaway xray core with its own ports and
+    /// config — completely separate from the live connection owned by <see cref="XrayService"/> —
+    /// so it works even when nothing is connected and never disturbs the user's active session.
+    ///
+    /// Chain servers are not supported here (they need a second outbound + proxySettings); the
+    /// caller must filter them out before calling.
+    /// </summary>
+    public sealed class RealLatencyProbeService
+    {
+        private const string TestUrl = "http://www.gstatic.com/generate_204";
+
+        // Overall budget for one server's whole warm-up-then-measure cycle (matches v2rayN's 10s).
+        private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(10);
+
+        // Probe each server twice on a *reused* (keep-alive) connection and keep the fastest:
+        // the first request pays the one-time tunnel + TLS handshake (very pricey for reality),
+        // the second rides the warm connection and reflects steady-state RTT (≈ a TCP ping).
+        // This is exactly what v2rayN's GetRealPingTime does, so the numbers line up with it.
+        private const int ProbeIterations = 2;
+        private const int InterProbeDelayMs = 100;
+        private const int MaxConcurrency = 16;
+
+        // Give the throwaway core a moment to bind every socks inbound before we probe.
+        private const int CoreReadyDelayMs = 800;
+
+        // Dedicated config path, separate from XrayService's xray_config.json so a test never
+        // clobbers the live session's config file.
+        private static readonly string ConfigPath = Path.Combine(AppPaths.LocalAppDataDir, "xray_speedtest.json");
+
+        /// <summary>Populated when the test core fails to start; empty on success.</summary>
+        public string LastError { get; private set; } = string.Empty;
+
+        /// <summary>
+        /// Probes every server in <paramref name="servers"/> and reports each result through
+        /// <paramref name="onResult"/> (latency in ms, or -1 for timeout/failure) as it lands.
+        /// The HTTP timing runs off the UI thread for accuracy; <paramref name="onResult"/> is
+        /// marshalled back to the calling (UI) thread, so it may touch bound state directly.
+        /// </summary>
+        public async Task ProbeAllAsync(
+            IReadOnlyList<ServerEntry> servers,
+            Action<ServerEntry, int> onResult,
+            CancellationToken ct = default)
+        {
+            LastError = string.Empty;
+            if (servers.Count == 0)
+                return;
+
+            // Capture the caller's context (the UI thread) so results marshal back to it for safe
+            // binding updates, while the timing itself runs off-thread (ConfigureAwait(false)) —
+            // UI-thread scheduling delay must not inflate the measured RTT.
+            var ui = SynchronizationContext.Current;
+            void Report(ServerEntry s, int ms)
+            {
+                if (ui is not null)
+                    ui.Post(_ => onResult(s, ms), null);
+                else
+                    onResult(s, ms);
+            }
+
+            if (!File.Exists(XrayService.ExePath))
+            {
+                LastError = Loc.Format("Xray_ExeNotFound", XrayService.ExePath);
+                foreach (var s in servers)
+                    Report(s, -1);
+                return;
+            }
+
+            // 1. Allocate one free loopback port per server.
+            var entries = new List<(ServerEntry server, int port)>(servers.Count);
+            foreach (var s in servers)
+                entries.Add((s, GetFreeLoopbackPort()));
+
+            // 2. Build + write the dedicated multi-inbound speed-test config.
+            string configJson = XrayConfigBuilder.BuildSpeedtestConfig(entries);
+            Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
+            await File.WriteAllTextAsync(ConfigPath, configJson, ct).ConfigureAwait(false);
+
+            Process? process = null;
+            JobObjectGuard? jobGuard = null;
+            var output = new StringBuilder();
+
+            try
+            {
+                // 3. Launch the throwaway core.
+                var psi = new ProcessStartInfo
+                {
+                    FileName = XrayService.ExePath,
+                    Arguments = $"run -config \"{ConfigPath}\"",
+                    WorkingDirectory = Path.GetDirectoryName(XrayService.ExePath)!,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
+                psi.EnvironmentVariables["XRAY_LOCATION_ASSET"] = XrayService.RulesDir;
+
+                process = new Process { StartInfo = psi };
+                // xray logs to both stdout and stderr; capture both so a failed start has a reason.
+                void Capture(string? line)
+                {
+                    if (line is null) return;
+                    lock (output) output.AppendLine(line);
+                }
+                process.OutputDataReceived += (_, e) => Capture(e.Data);
+                process.ErrorDataReceived += (_, e) => Capture(e.Data);
+
+                process.Start();
+                jobGuard = JobObjectGuard.Assign(process);
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+
+                // 4. Wait for the inbounds to come up.
+                await Task.Delay(CoreReadyDelayMs, ct).ConfigureAwait(false);
+
+                if (process.HasExited)
+                {
+                    string log;
+                    lock (output) log = output.ToString().Trim();
+                    LastError = log.Length > 0
+                        ? log
+                        : Loc.Format("Xray_ExitedImmediately", process.ExitCode);
+                    foreach (var s in servers)
+                        Report(s, -1);
+                    return;
+                }
+
+                // 5. Probe each server through its own socks port (capped concurrency).
+                using var throttle = new SemaphoreSlim(MaxConcurrency);
+                var tasks = new List<Task>(entries.Count);
+                foreach (var (server, port) in entries)
+                    tasks.Add(ProbeOneAsync(server, port, throttle, Report, ct));
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                LastError = ex.Message;
+                foreach (var s in servers)
+                    Report(s, -1);
+            }
+            finally
+            {
+                // 6. Tear down the throwaway core and its temp config.
+                try
+                {
+                    if (process is not null && !process.HasExited)
+                        process.Kill(entireProcessTree: true);
+                }
+                catch { }
+
+                jobGuard?.Dispose();
+                process?.Dispose();
+
+                try
+                {
+                    if (File.Exists(ConfigPath))
+                        File.Delete(ConfigPath);
+                }
+                catch { }
+            }
+        }
+
+        private static async Task ProbeOneAsync(
+            ServerEntry server,
+            int port,
+            SemaphoreSlim throttle,
+            Action<ServerEntry, int> report,
+            CancellationToken ct)
+        {
+            await throttle.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                using var handler = new SocketsHttpHandler
+                {
+                    Proxy = new WebProxy($"socks5://127.0.0.1:{port}"),
+                    UseProxy = true
+                };
+                using var client = new HttpClient(handler);
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                timeoutCts.CancelAfter(ProbeTimeout);
+
+                // Warm up, then measure: reuse the same client so later requests ride the
+                // kept-alive connection (no repeated tunnel/TLS handshake). Keep the fastest —
+                // that's the steady-state RTT, mirroring v2rayN's real-ping.
+                var best = -1;
+                for (var i = 0; i < ProbeIterations; i++)
+                {
+                    var stopwatch = Stopwatch.StartNew();
+                    using (await client.GetAsync(TestUrl, timeoutCts.Token).ConfigureAwait(false))
+                    {
+                        stopwatch.Stop();
+                    }
+
+                    var ms = (int)Math.Round(stopwatch.Elapsed.TotalMilliseconds);
+                    if (ms >= 0 && (best < 0 || ms < best))
+                        best = ms;
+
+                    if (i < ProbeIterations - 1)
+                        await Task.Delay(InterProbeDelayMs, timeoutCts.Token).ConfigureAwait(false);
+                }
+
+                report(server, best);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch
+            {
+                // Timeout, connection refused, proxy/handshake failure → unreachable.
+                report(server, -1);
+            }
+            finally
+            {
+                throttle.Release();
+            }
+        }
+
+        /// <summary>
+        /// Asks the OS for a free loopback TCP port by binding to port 0 and reading the assigned
+        /// port back. There is a tiny race between releasing it here and xray binding it, but it is
+        /// the standard ephemeral-port allocation trick and good enough for a short-lived test.
+        /// </summary>
+        private static int GetFreeLoopbackPort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            try
+            {
+                return ((IPEndPoint)listener.LocalEndpoint).Port;
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+    }
+}

--- a/Services/RealLatencyProbeService.cs
+++ b/Services/RealLatencyProbeService.cs
@@ -35,7 +35,12 @@ namespace XrayUI.Services
         // This is exactly what v2rayN's GetRealPingTime does, so the numbers line up with it.
         private const int ProbeIterations = 2;
         private const int InterProbeDelayMs = 100;
-        private const int MaxConcurrency = 16;
+
+        // Up to 32 in-flight probes through the single test core. Comfortably safe — still more
+        // conservative than v2rayN (which runs a whole page concurrently with no per-item cap),
+        // and xray (Go) / .NET handle it trivially; the warm-up-take-min above keeps measurements
+        // stable even under brief contention. Halves the wave count vs 16 for dozens of nodes.
+        private const int MaxConcurrency = 32;
 
         // Give the throwaway core a moment to bind every socks inbound before we probe.
         private const int CoreReadyDelayMs = 800;

--- a/Services/RealLatencyProbeService.cs
+++ b/Services/RealLatencyProbeService.cs
@@ -26,8 +26,10 @@ namespace XrayUI.Services
     {
         private const string TestUrl = "http://www.gstatic.com/generate_204";
 
-        // Overall budget for one server's whole warm-up-then-measure cycle (matches v2rayN's 10s).
-        private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(10);
+        // Overall budget for one server's whole warm-up-then-measure cycle. 7s (vs v2rayN's 10s):
+        // a usable node returns its 204 well under this, and the shorter ceiling caps how long
+        // silent black-hole nodes stall the batch tail.
+        private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(7);
 
         // Probe each server twice on a *reused* (keep-alive) connection and keep the fastest:
         // the first request pays the one-time tunnel + TLS handshake (very pricey for reality),

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -831,5 +831,72 @@ namespace XrayUI.Services
         {
             array.Add((JsonNode?)JsonValue.Create(value));
         }
+
+        /// <summary>
+        /// Builds a dedicated speed-test config for the "real delay" latency test: one socks
+        /// inbound + one proxy outbound per server, paired 1:1 via routing (in-{i} → out-{i}).
+        /// Run in a throwaway core separate from the live connection. No TUN/DNS/fakedns — just
+        /// enough to route an HTTP probe through each server. Chain servers are not supported;
+        /// the caller must filter them out.
+        /// </summary>
+        /// <param name="entries">Each server paired with the local socks port it should listen on.</param>
+        public static string BuildSpeedtestConfig(
+            IReadOnlyList<(ServerEntry server, int port)> entries)
+        {
+            var inbounds = new JsonArray();
+            var outbounds = new JsonArray();
+            var rules = new JsonArray();
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                var (server, port) = entries[i];
+                var inTag = $"in-{i}";
+                var outTag = $"out-{i}";
+
+                AddNode(inbounds, new JsonObject
+                {
+                    ["tag"] = inTag,
+                    ["protocol"] = "socks",
+                    ["listen"] = "127.0.0.1",
+                    ["port"] = port,
+                    ["settings"] = new JsonObject
+                    {
+                        ["auth"] = "noauth",
+                        ["udp"] = false
+                    }
+                });
+
+                AddNode(outbounds, BuildProxyOutbound(server, outTag));
+
+                AddNode(rules, new JsonObject
+                {
+                    ["type"] = "field",
+                    ["inboundTag"] = CreateStringArray(inTag),
+                    ["outboundTag"] = outTag
+                });
+            }
+
+            // Freedom fallback so any unmatched traffic inside the core has somewhere to go.
+            AddNode(outbounds, new JsonObject
+            {
+                ["tag"] = DirectOutboundTag,
+                ["protocol"] = "freedom",
+                ["settings"] = new JsonObject()
+            });
+
+            var config = new JsonObject
+            {
+                ["log"] = new JsonObject { ["loglevel"] = "warning" },
+                ["inbounds"] = inbounds,
+                ["outbounds"] = outbounds,
+                ["routing"] = new JsonObject
+                {
+                    ["domainStrategy"] = "AsIs",
+                    ["rules"] = rules
+                }
+            };
+
+            return config.ToJsonString(JsonOpts);
+        }
     }
 }

--- a/Services/XrayService.cs
+++ b/Services/XrayService.cs
@@ -12,7 +12,9 @@ namespace XrayUI.Services
 {
     public partial class XrayService
     {
-        private static readonly string ExePath = Path.Combine(
+        // Public so helper cores (e.g. RealLatencyProbeService's throwaway speed-test core) can
+        // launch the same engine without duplicating the path.
+        public static readonly string ExePath = Path.Combine(
             AppContext.BaseDirectory, "Assets", "engine", "xray.exe");
 
         public static readonly string RulesDir = Path.Combine(
@@ -26,11 +28,10 @@ namespace XrayUI.Services
 
         private Process? _process;
 
-        // Kernel-level safety net: xray.exe is assigned to this Job Object with
-        // KillOnJobClose, so if the UI process dies any way (taskkill /F, AV
-        // crash, OOM), the kernel kills xray.exe synchronously. Lifetime = this
-        // XrayService instance; reused across Start/Stop cycles.
-        private IntPtr _jobHandle = IntPtr.Zero;
+        // Kernel-level safety net: xray.exe is assigned to a kill-on-close Job Object, so if the
+        // UI process dies any way (taskkill /F, AV crash, OOM) the kernel kills xray.exe too.
+        // Created lazily on first start and reused across Start/Stop cycles.
+        private JobObjectGuard? _jobGuard;
 
         private StringBuilder _startupLog = new();
         private bool _collectStartupLog;
@@ -339,77 +340,22 @@ namespace XrayUI.Services
         }
 
         // ─────────── Job Object: orphan-xray safety net ───────────
-
-        private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
-        private const int JobObjectExtendedLimitInformation = 9;
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
-        {
-            public long PerProcessUserTimeLimit;
-            public long PerJobUserTimeLimit;
-            public uint LimitFlags;
-            public UIntPtr MinimumWorkingSetSize;
-            public UIntPtr MaximumWorkingSetSize;
-            public uint ActiveProcessLimit;
-            public UIntPtr Affinity;
-            public uint PriorityClass;
-            public uint SchedulingClass;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct IO_COUNTERS
-        {
-            public ulong ReadOperationCount;
-            public ulong WriteOperationCount;
-            public ulong OtherOperationCount;
-            public ulong ReadTransferCount;
-            public ulong WriteTransferCount;
-            public ulong OtherTransferCount;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
-        {
-            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
-            public IO_COUNTERS IoInfo;
-            public UIntPtr ProcessMemoryLimit;
-            public UIntPtr JobMemoryLimit;
-            public UIntPtr PeakProcessMemoryUsed;
-            public UIntPtr PeakJobMemoryUsed;
-        }
-
-        [LibraryImport("kernel32.dll", SetLastError = true)]
-        private static partial IntPtr CreateJobObjectW(IntPtr lpJobAttributes, IntPtr lpName);
-
-        [LibraryImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static partial bool SetInformationJobObject(
-            IntPtr hJob, int jobObjectInfoClass, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
-
-        [LibraryImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static partial bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
-
-        [LibraryImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static partial bool CloseHandle(IntPtr hObject);
+        // The kill-on-close Job Object interop lives in Helpers/JobObjectGuard (shared with the
+        // real-delay speed-test core). The guard is created lazily and reused across Start/Stop
+        // cycles; each launched process is assigned to it.
 
         private void AttachToJobObject(Process process)
         {
             try
             {
-                if (_jobHandle == IntPtr.Zero)
+                _jobGuard ??= JobObjectGuard.Create();
+                if (_jobGuard is null)
                 {
-                    _jobHandle = CreateKillOnCloseJob();
-                    if (_jobHandle == IntPtr.Zero)
-                    {
-                        AppendLog(Loc.Format("XrayLog_JobCreateFailed", Marshal.GetLastWin32Error()));
-                        return;
-                    }
+                    AppendLog(Loc.Format("XrayLog_JobCreateFailed", Marshal.GetLastWin32Error()));
+                    return;
                 }
 
-                if (!AssignProcessToJobObject(_jobHandle, process.Handle))
+                if (!_jobGuard.TryAssign(process))
                 {
                     AppendLog(Loc.Format("XrayLog_JobAssignFailed", Marshal.GetLastWin32Error()));
                 }
@@ -417,37 +363,6 @@ namespace XrayUI.Services
             catch (Exception ex)
             {
                 AppendLog(Loc.Format("XrayLog_JobBindException", ex.Message));
-            }
-        }
-
-        private static IntPtr CreateKillOnCloseJob()
-        {
-            var handle = CreateJobObjectW(IntPtr.Zero, IntPtr.Zero);
-            if (handle == IntPtr.Zero) return IntPtr.Zero;
-
-            var info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
-            {
-                BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
-                {
-                    LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-                }
-            };
-
-            int size = Marshal.SizeOf<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>();
-            IntPtr buf = Marshal.AllocHGlobal(size);
-            try
-            {
-                Marshal.StructureToPtr(info, buf, fDeleteOld: false);
-                if (!SetInformationJobObject(handle, JobObjectExtendedLimitInformation, buf, (uint)size))
-                {
-                    _ = CloseHandle(handle);
-                    return IntPtr.Zero;
-                }
-                return handle;
-            }
-            finally
-            {
-                Marshal.FreeHGlobal(buf);
             }
         }
     }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -1161,4 +1161,10 @@ Path: {0}</value>
   <data name="GeoUpdate_DownloadingNoTotal" xml:space="preserve">
     <value>Downloading {0} … {1:0.0} MB</value>
   </data>
+  <data name="ServerList_TestModeConnect.Text" xml:space="preserve">
+    <value>Connection latency</value>
+  </data>
+  <data name="ServerList_TestModeReal.Text" xml:space="preserve">
+    <value>Test real delay</value>
+  </data>
 </root>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -1161,4 +1161,10 @@
   <data name="GeoUpdate_DownloadingNoTotal" xml:space="preserve">
     <value>正在下载 {0} … {1:0.0} MB</value>
   </data>
+  <data name="ServerList_TestModeConnect.Text" xml:space="preserve">
+    <value>一键测试延迟</value>
+  </data>
+  <data name="ServerList_TestModeReal.Text" xml:space="preserve">
+    <value>真连接测试</value>
+  </data>
 </root>

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -71,11 +71,12 @@ namespace XrayUI.ViewModels
             var latencyProbe = new LatencyProbeService(
                 new TcpConnectProbeService(),
                 new PingProbeService());
+            var realLatencyProbe = new RealLatencyProbeService();
             var aiUnlockCheck = new AiUnlockCheckService();
 
             Title = "Proxy Console";
 
-            ServerList   = new ServerListViewModel(dialogs, settings, latencyProbe);
+            ServerList   = new ServerListViewModel(dialogs, settings, latencyProbe, realLatencyProbe);
             ServerDetail = new ServerDetailViewModel(latencyProbe, aiUnlockCheck);
             ControlPanel = new ControlPanelViewModel(dialogs, settings, xray, tunService, startupService, updateService);
             Personalize  = new PersonalizeViewModel(dialogs, settings);

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -48,6 +48,7 @@ namespace XrayUI.ViewModels
         private readonly IDialogService     _dialogs;
         private readonly SettingsService    _settings;
         private readonly LatencyProbeService _latencyProbe;
+        private readonly RealLatencyProbeService _realLatencyProbe;
         private readonly SemaphoreSlim      _settingsWriteLock = new(1, 1);
         private const int MaxConcurrentProbes = 16;
         private ObservableCollection<ServerEntry> _servers = new();
@@ -67,11 +68,12 @@ namespace XrayUI.ViewModels
         public ObservableCollection<ServerGroupChip> GroupChips { get; } = new();
         public ObservableCollection<ServerEntry>     VisibleServers { get; } = new();
 
-        public ServerListViewModel(IDialogService dialogs, SettingsService settings, LatencyProbeService latencyProbe)
+        public ServerListViewModel(IDialogService dialogs, SettingsService settings, LatencyProbeService latencyProbe, RealLatencyProbeService realLatencyProbe)
         {
             _dialogs  = dialogs;
             _settings = settings;
             _latencyProbe = latencyProbe;
+            _realLatencyProbe = realLatencyProbe;
 
             ProtocolColorStore.ColorsChanged += OnProtocolColorsChanged;
             _servers.CollectionChanged += OnServersCollectionChanged;
@@ -641,11 +643,22 @@ namespace XrayUI.ViewModels
             private set => SetProperty(ref _isTestingLatencies, value);
         }
 
-        // Probes every server's latency in parallel (capped concurrency) and writes the
-        // result onto each ServerEntry: the round-trip ms on success, or -1 for any
-        // failure (timeout/unreachable, shown as a single red label). The async command
-        // auto-disables while running, so the button is inert until the sweep finishes;
-        // results stream into the rows as each probe completes.
+        private string _latencyTestMode = "connect";
+        // Business code (CLAUDE.md convention), set from the test button's right-click menu:
+        //   "connect" → TCP handshake to the server endpoint (no core needed)
+        //   "real"    → HTTP round-trip routed through a throwaway xray core (v2rayN "real delay")
+        public string LatencyTestMode
+        {
+            get => _latencyTestMode;
+            set => SetProperty(ref _latencyTestMode, value);
+        }
+
+        // Probes every server's latency and writes the result onto each ServerEntry: the
+        // round-trip ms on success, or -1 for any failure (timeout/unreachable, shown as a
+        // single red label). The async command auto-disables while running, so the button is
+        // inert until the sweep finishes; results stream into the rows as each probe completes.
+        // LatencyTestMode picks the probe: "connect" = direct TCP handshake to the endpoint;
+        // "real" = a real HTTP round-trip through a throwaway xray core (v2rayN "real delay").
         [RelayCommand]
         private async Task TestAllLatencies()
         {
@@ -653,54 +666,78 @@ namespace XrayUI.ViewModels
             if (servers.Count == 0) return;
 
             IsTestingLatencies = true;
+            _latencySortUnlocked = false;
             try
             {
-                using var throttle = new SemaphoreSlim(MaxConcurrentProbes);
-                var timeout = TimeSpan.FromSeconds(3);
-
-                // The latency sort only needs unlocking once (the first result flips
-                // CanSortByLatency false→true); continuations resume serially on the UI
-                // thread, so this flag needs no synchronization.
-                var sortUnlockNotified = false;
-
-                var tasks = servers.Select(async server =>
-                {
-                    await throttle.WaitAsync();
-                    try
-                    {
-                        // ProbeAsync is already async I/O, so it's awaited directly (no
-                        // Task.Run thread hop). No ConfigureAwait(false) either: the
-                        // continuation resumes on the UI thread (WinUI sync context), so the
-                        // bound ServerEntry update is safe — same as the detail panel's TestLatency.
-                        var result = await _latencyProbe.ProbeAsync(server, timeout);
-                        server.LatencyMs = result.Status == LatencyProbeStatus.Success
-                            ? result.Milliseconds
-                            : -1;
-
-                        // First result unlocks the latency sort option (fire once, not per probe).
-                        if (!sortUnlockNotified)
-                        {
-                            sortUnlockNotified = true;
-                            OnPropertyChanged(nameof(CanSortByLatency));
-                        }
-
-                        // If latency sort is already active, restream so rows reorder live
-                        // as probes land.
-                        if (_sortMode == ServerSortMode.Latency)
-                            RebuildGroupedView();
-                    }
-                    finally
-                    {
-                        throttle.Release();
-                    }
-                });
-
-                await Task.WhenAll(tasks);
+                if (LatencyTestMode == "real")
+                    await TestRealLatenciesAsync(servers);
+                else
+                    await TestConnectLatenciesAsync(servers);
             }
             finally
             {
                 IsTestingLatencies = false;
             }
+        }
+
+        // "connect" mode: direct TCP-handshake probe to each server endpoint, in parallel
+        // (capped concurrency). No proxy core involved.
+        private async Task TestConnectLatenciesAsync(List<ServerEntry> servers)
+        {
+            using var throttle = new SemaphoreSlim(MaxConcurrentProbes);
+            var timeout = TimeSpan.FromSeconds(3);
+
+            var tasks = servers.Select(async server =>
+            {
+                await throttle.WaitAsync();
+                try
+                {
+                    // ProbeAsync is already async I/O, awaited directly (no Task.Run hop). No
+                    // ConfigureAwait(false): the continuation resumes on the UI thread (WinUI
+                    // sync context), so ApplyLatencyResult's bound updates are safe.
+                    var result = await _latencyProbe.ProbeAsync(server, timeout);
+                    ApplyLatencyResult(server, result.Status == LatencyProbeStatus.Success
+                        ? result.Milliseconds ?? -1
+                        : -1);
+                }
+                finally
+                {
+                    throttle.Release();
+                }
+            });
+
+            await Task.WhenAll(tasks);
+        }
+
+        // "real" mode: route a real HTTP request through each server via a dedicated throwaway
+        // xray core. Works even when nothing is connected and never touches the live session.
+        // Chain nodes aren't supported by the speed-test core yet, so they're skipped.
+        private Task TestRealLatenciesAsync(List<ServerEntry> servers)
+        {
+            var testable = servers.Where(s => !s.IsChain).ToList();
+            if (testable.Count == 0) return Task.CompletedTask;
+
+            // ProbeAllAsync marshals ApplyLatencyResult back onto the UI thread.
+            return _realLatencyProbe.ProbeAllAsync(testable, ApplyLatencyResult);
+        }
+
+        // Per-result bookkeeping shared by both probe modes (always invoked on the UI thread,
+        // serially): record the latency, unlock the latency-sort option once the first result
+        // lands, and restream the grouped view live if latency sort is already active. The
+        // _latencySortUnlocked flag is reset at the start of each TestAllLatencies run.
+        private bool _latencySortUnlocked;
+        private void ApplyLatencyResult(ServerEntry server, int latencyMs)
+        {
+            server.LatencyMs = latencyMs;
+
+            if (!_latencySortUnlocked)
+            {
+                _latencySortUnlocked = true;
+                OnPropertyChanged(nameof(CanSortByLatency));
+            }
+
+            if (_sortMode == ServerSortMode.Latency)
+                RebuildGroupedView();
         }
 
         // ── Import via link ───────────────────────────────────────────────────

--- a/Views/AddChainProxyDialog.xaml
+++ b/Views/AddChainProxyDialog.xaml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <UserControl
     x:Class="XrayUI.Views.AddChainProxyDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/Views/AddRuleDialog.xaml
+++ b/Views/AddRuleDialog.xaml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <ContentDialog
     x:Class="XrayUI.Views.AddRuleDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -21,8 +22,8 @@
             <ComboBox x:Name="TypeComboBox"
                       SelectedIndex="0"
                       HorizontalAlignment="Stretch">
-                <ComboBoxItem x:Uid="AddRule_TypeDomainItem" Content="域名（Domain）"  Tag="domain" />
-                <ComboBoxItem Content="IP"                                            Tag="ip" />
+                <ComboBoxItem x:Uid="AddRule_TypeDomainItem" Content="域名（Domain）" Tag="domain" />
+                <ComboBoxItem Content="IP" Tag="ip" />
                 <ComboBoxItem x:Uid="AddRule_TypeProcessItem" Content="进程（Process）" Tag="process" />
             </ComboBox>
         </StackPanel>
@@ -49,8 +50,8 @@
                 <ComboBox x:Name="BrowseFormatComboBox"
                           SelectedIndex="0"
                           MinWidth="130">
-                    <ComboBoxItem x:Uid="AddRule_BrowseNameItem"   Content="匹配同名进程" Tag="name" />
-                    <ComboBoxItem x:Uid="AddRule_BrowsePathItem"   Content="匹配完整路径" Tag="path" />
+                    <ComboBoxItem x:Uid="AddRule_BrowseNameItem" Content="匹配同名进程" Tag="name" />
+                    <ComboBoxItem x:Uid="AddRule_BrowsePathItem" Content="匹配完整路径" Tag="path" />
                     <ComboBoxItem x:Uid="AddRule_BrowseFolderItem" Content="匹配整个目录" Tag="folder" />
                 </ComboBox>
             </StackPanel>
@@ -70,9 +71,9 @@
             <ComboBox x:Name="OutboundComboBox"
                       SelectedIndex="0"
                       HorizontalAlignment="Stretch">
-                <ComboBoxItem x:Uid="AddRule_OutboundProxyItem"  Content="proxy（代理）"  Tag="proxy" />
+                <ComboBoxItem x:Uid="AddRule_OutboundProxyItem" Content="proxy（代理）" Tag="proxy" />
                 <ComboBoxItem x:Uid="AddRule_OutboundDirectItem" Content="direct（直连）" Tag="direct" />
-                <ComboBoxItem x:Uid="AddRule_OutboundBlockItem"  Content="block（阻断）"  Tag="block" />
+                <ComboBoxItem x:Uid="AddRule_OutboundBlockItem" Content="block（阻断）" Tag="block" />
             </ComboBox>
         </StackPanel>
 

--- a/Views/ControlPanelControl.xaml
+++ b/Views/ControlPanelControl.xaml
@@ -74,13 +74,13 @@
                                                      Command="{x:Bind ViewModel.SetProxyModeCommand}"
                                                      CommandParameter="manual" />
                             </MenuFlyoutSubItem>
-                            <MenuFlyoutSeparator/>
+                            <MenuFlyoutSeparator />
                             <MenuFlyoutItem x:Uid="ControlPanel_StartupItem"
                                             Text="开机启动"
                                             Command="{x:Bind ViewModel.OpenStartupSettingsCommand}"
                                             Icon="{x:Bind ViewModel.StartupMenuIcon, Mode=OneWay}" />
                             <MenuFlyoutSubItem x:Uid="ControlPanel_RoutingSettingsItem"
-                                               Text="路由设置" >
+                                               Text="路由设置">
                                 <MenuFlyoutItem x:Uid="ControlPanel_RoutingGlobalItem"
                                                 Text="全局路由"
                                                 IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
@@ -91,7 +91,7 @@
                                                 IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
                                                 Command="{x:Bind ViewModel.SetRoutingModeCommand}"
                                                 CommandParameter="smart" />
-                                <MenuFlyoutSeparator/>
+                                <MenuFlyoutSeparator />
                                 <MenuFlyoutItem x:Uid="ControlPanel_CustomRulesItem"
                                                 Text="自定义规则..."
                                                 IsEnabled="{x:Bind ViewModel.IsModeToggleEnabled, Mode=OneWay}"
@@ -144,10 +144,10 @@
                             VerticalAlignment="Center"
                             Spacing="6">
                     <Grid>
-                        <FontIcon Glyph="&#xECCC;" 
+                        <FontIcon Glyph="&#xECCC;"
                                   Foreground="{ThemeResource SystemFillColorSuccessBrush}"
                                   Visibility="{x:Bind ViewModel.IsRunning, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                        <FontIcon Glyph="&#xECCC;" 
+                        <FontIcon Glyph="&#xECCC;"
                                   Foreground="{ThemeResource SystemFillColorNeutralBrush}"
                                   Visibility="{x:Bind ViewModel.IsRunning, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
                     </Grid>
@@ -157,8 +157,9 @@
                                TextTrimming="CharacterEllipsis"
                                VerticalAlignment="Center">
                         <ToolTipService.ToolTip>
-        <ToolTip Content="{x:Bind ViewModel.StatusText, Mode=OneWay}" Visibility="{x:Bind ViewModel.IsRunning, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-    </ToolTipService.ToolTip>
+                            <ToolTip Content="{x:Bind ViewModel.StatusText, Mode=OneWay}"
+                                     Visibility="{x:Bind ViewModel.IsRunning, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        </ToolTipService.ToolTip>
                     </TextBlock>
                 </StackPanel>
             </StackPanel>

--- a/Views/CustomRulesWindow.xaml
+++ b/Views/CustomRulesWindow.xaml
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <Window x:Class="XrayUI.Views.CustomRulesWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -46,7 +47,7 @@
                         BorderThickness="0"
                         VerticalAlignment="Center"
                         Click="UpdateGeoButton_Click">
-                    <FontIcon Glyph="&#xE895;"  FontSize="14" />
+                    <FontIcon Glyph="&#xE895;" FontSize="14" />
                 </Button>
                 <Button Style="{ThemeResource AccentButtonStyle}"
                         Command="{x:Bind ViewModel.AddRuleCommand}">

--- a/Views/LogWindow.xaml
+++ b/Views/LogWindow.xaml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <Window x:Class="XrayUI.Views.LogWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Views/ManageSubscriptionsDialog.xaml
+++ b/Views/ManageSubscriptionsDialog.xaml
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <UserControl x:Class="XrayUI.Views.ManageSubscriptionsDialog"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -35,7 +36,7 @@
                 <controls:SegmentedItem x:Name="ManagePageSegment"
                                         Padding="0">
                     <controls:SegmentedItem.Icon>
-                        <FontIcon  Glyph="&#xEBC3;" FontSize="14" />
+                        <FontIcon Glyph="&#xEBC3;" FontSize="14" />
                     </controls:SegmentedItem.Icon>
                 </controls:SegmentedItem>
             </controls:Segmented>

--- a/Views/PersonalizeControl.xaml
+++ b/Views/PersonalizeControl.xaml
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <UserControl x:Class="XrayUI.Views.PersonalizeControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -24,11 +25,10 @@
             <!-- ── Theme ───────────────────────────────────────────────────── -->
             <StackPanel Spacing="10">
 
-                    <TextBlock x:Uid="Personalize_Theme"
-                               Text="主题"
-                               FontSize="15"
-                               FontWeight="SemiBold" />
-
+                <TextBlock x:Uid="Personalize_Theme"
+                           Text="主题"
+                           FontSize="15"
+                           FontWeight="SemiBold" />
 
 
                 <controls:Segmented HorizontalAlignment="Left"
@@ -67,9 +67,9 @@
             <!-- ── Backdrop ────────────────────────────────────────────────── -->
             <StackPanel Spacing="10">
                 <TextBlock x:Uid="Personalize_Backdrop"
-                               Text="背景效果"
-                               FontSize="15"
-                               FontWeight="SemiBold" />
+                           Text="背景效果"
+                           FontSize="15"
+                           FontWeight="SemiBold" />
 
                 <ComboBox HorizontalAlignment="Left"
                           MinWidth="160"
@@ -226,11 +226,12 @@
                                         </Flyout>
                                     </Button.Flyout>
                                 </Button>
-                                <TextBlock Text="{x:Bind ViewModel.SsColor, Mode=OneWay, Converter={StaticResource ColorToHexStringConverter}}"
-                                           FontSize="13"
-                                           FontFamily="Consolas"
-                                           VerticalAlignment="Center"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                <TextBlock
+                                    Text="{x:Bind ViewModel.SsColor, Mode=OneWay, Converter={StaticResource ColorToHexStringConverter}}"
+                                    FontSize="13"
+                                    FontFamily="Consolas"
+                                    VerticalAlignment="Center"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                             </StackPanel>
                         </Grid>
 
@@ -277,11 +278,12 @@
                                         </Flyout>
                                     </Button.Flyout>
                                 </Button>
-                                <TextBlock Text="{x:Bind ViewModel.VlessColor, Mode=OneWay, Converter={StaticResource ColorToHexStringConverter}}"
-                                           FontSize="13"
-                                           FontFamily="Consolas"
-                                           VerticalAlignment="Center"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                <TextBlock
+                                    Text="{x:Bind ViewModel.VlessColor, Mode=OneWay, Converter={StaticResource ColorToHexStringConverter}}"
+                                    FontSize="13"
+                                    FontFamily="Consolas"
+                                    VerticalAlignment="Center"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                             </StackPanel>
                         </Grid>
 
@@ -328,11 +330,12 @@
                                         </Flyout>
                                     </Button.Flyout>
                                 </Button>
-                                <TextBlock Text="{x:Bind ViewModel.VmessColor, Mode=OneWay, Converter={StaticResource ColorToHexStringConverter}}"
-                                           FontSize="13"
-                                           FontFamily="Consolas"
-                                           VerticalAlignment="Center"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                <TextBlock
+                                    Text="{x:Bind ViewModel.VmessColor, Mode=OneWay, Converter={StaticResource ColorToHexStringConverter}}"
+                                    FontSize="13"
+                                    FontFamily="Consolas"
+                                    VerticalAlignment="Center"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                             </StackPanel>
                         </Grid>
 
@@ -379,11 +382,12 @@
                                         </Flyout>
                                     </Button.Flyout>
                                 </Button>
-                                <TextBlock Text="{x:Bind ViewModel.Hysteria2Color, Mode=OneWay, Converter={StaticResource ColorToHexStringConverter}}"
-                                           FontSize="13"
-                                           FontFamily="Consolas"
-                                           VerticalAlignment="Center"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                <TextBlock
+                                    Text="{x:Bind ViewModel.Hysteria2Color, Mode=OneWay, Converter={StaticResource ColorToHexStringConverter}}"
+                                    FontSize="13"
+                                    FontFamily="Consolas"
+                                    VerticalAlignment="Center"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                             </StackPanel>
                         </Grid>
 
@@ -440,11 +444,12 @@
                                     </Flyout>
                                 </Button.Flyout>
                             </Button>
-                            <TextBlock Text="{x:Bind ViewModel.FallbackColor, Mode=OneWay, Converter={StaticResource ColorToHexStringConverter}}"
-                                       FontSize="13"
-                                       FontFamily="Consolas"
-                                       VerticalAlignment="Center"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            <TextBlock
+                                Text="{x:Bind ViewModel.FallbackColor, Mode=OneWay, Converter={StaticResource ColorToHexStringConverter}}"
+                                FontSize="13"
+                                FontFamily="Consolas"
+                                VerticalAlignment="Center"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                         </StackPanel>
                     </Grid>
                 </Border>
@@ -490,104 +495,104 @@
                         </Grid>
                     </Expander.Header>
 
-                <StackPanel Margin="-16,-12,-16,-12">
-                    <!-- Delay Display -->
-                    <CheckBox IsChecked="{x:Bind ViewModel.ShowLatencyInDetails, Mode=TwoWay}"
-                              HorizontalAlignment="Stretch"
-                              HorizontalContentAlignment="Stretch"
-                              Margin="42,10,16,10">
-                        <StackPanel VerticalAlignment="Center"
-                                    Spacing="2">
-                            <TextBlock x:Uid="Personalize_DetailLatency"
-                                       Text="延迟"
-                                       FontSize="14" />
-                            <TextBlock x:Uid="Personalize_DetailLatencyDesc"
-                                       Text="节点卡片上展示延迟"
-                                       FontSize="12"
-                                       TextWrapping="Wrap"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        </StackPanel>
-                    </CheckBox>
+                    <StackPanel Margin="-16,-12,-16,-12">
+                        <!-- Delay Display -->
+                        <CheckBox IsChecked="{x:Bind ViewModel.ShowLatencyInDetails, Mode=TwoWay}"
+                                  HorizontalAlignment="Stretch"
+                                  HorizontalContentAlignment="Stretch"
+                                  Margin="42,10,16,10">
+                            <StackPanel VerticalAlignment="Center"
+                                        Spacing="2">
+                                <TextBlock x:Uid="Personalize_DetailLatency"
+                                           Text="延迟"
+                                           FontSize="14" />
+                                <TextBlock x:Uid="Personalize_DetailLatencyDesc"
+                                           Text="节点卡片上展示延迟"
+                                           FontSize="12"
+                                           TextWrapping="Wrap"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                        </CheckBox>
 
-                    <Rectangle Height="1"
-                               Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
+                        <Rectangle Height="1"
+                                   Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
 
-                    <!-- AI Unlock Display -->
-                    <CheckBox IsChecked="{x:Bind ViewModel.ShowAiUnlockInDetails, Mode=TwoWay}"
-                              HorizontalAlignment="Stretch"
-                              HorizontalContentAlignment="Stretch"
-                              Margin="42,10,16,10">
-                        <StackPanel VerticalAlignment="Center"
-                                    Spacing="2">
-                            <TextBlock x:Uid="Personalize_DetailAiUnlock"
-                                       Text="AI 解锁"
-                                       FontSize="14" />
-                            <TextBlock x:Uid="Personalize_DetailAiUnlockDesc"
-                                       Text="节点卡片上展示AI的解锁状态"
-                                       FontSize="12"
-                                       TextWrapping="Wrap"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        </StackPanel>
-                    </CheckBox>
-                </StackPanel>
-            </Expander>
+                        <!-- AI Unlock Display -->
+                        <CheckBox IsChecked="{x:Bind ViewModel.ShowAiUnlockInDetails, Mode=TwoWay}"
+                                  HorizontalAlignment="Stretch"
+                                  HorizontalContentAlignment="Stretch"
+                                  Margin="42,10,16,10">
+                            <StackPanel VerticalAlignment="Center"
+                                        Spacing="2">
+                                <TextBlock x:Uid="Personalize_DetailAiUnlock"
+                                           Text="AI 解锁"
+                                           FontSize="14" />
+                                <TextBlock x:Uid="Personalize_DetailAiUnlockDesc"
+                                           Text="节点卡片上展示AI的解锁状态"
+                                           FontSize="12"
+                                           TextWrapping="Wrap"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                        </CheckBox>
+                    </StackPanel>
+                </Expander>
             </StackPanel>
 
             <!-- Data management -->
             <StackPanel Spacing="10">
                 <TextBlock x:Uid="Personalize_DataManagement"
-                               Text="备份和还原"
-                               FontSize="15"
-                               FontWeight="SemiBold" />
+                           Text="备份和还原"
+                           FontSize="15"
+                           FontWeight="SemiBold" />
 
-                    <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
-                            BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
-                            BorderThickness="1"
-                            CornerRadius="{ThemeResource OverlayCornerRadius}">
-                        <Grid Padding="16,13"
-                              ColumnSpacing="12">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
+                <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="{ThemeResource OverlayCornerRadius}">
+                    <Grid Padding="16,13"
+                          ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
 
-                            <FontIcon Grid.Column="0"
-                                      Glyph="&#xE8F1;"
-                                      FontSize="16"
-                                      VerticalAlignment="Center"
-                                      Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <FontIcon Grid.Column="0"
+                                  Glyph="&#xE8F1;"
+                                  FontSize="16"
+                                  VerticalAlignment="Center"
+                                  Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
 
-                            <StackPanel Grid.Column="1"
-                                        VerticalAlignment="Center"
-                                        Spacing="2">
+                        <StackPanel Grid.Column="1"
+                                    VerticalAlignment="Center"
+                                    Spacing="2">
                             <TextBlock x:Uid="Personalize_ImportExportTitle"
-                                           Text="配置导入与导出"
-                                           FontSize="14" />
+                                       Text="配置导入与导出"
+                                       FontSize="14" />
                             <TextBlock x:Uid="Personalize_ImportExportDesc"
-                                           Text="将当前的节点和路由规则备份到本地，或从已有文件中恢复"
-                                           FontSize="12"
-                                           TextWrapping="Wrap"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                            </StackPanel>
+                                       Text="将当前的节点和路由规则备份到本地，或从已有文件中恢复"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        </StackPanel>
 
-                            <StackPanel Grid.Column="2"
-                                        Orientation="Horizontal"
-                                        Spacing="8"
-                                        VerticalAlignment="Center">
-                                <Button x:Name="ExportPresetButton"
-                                        x:Uid="Personalize_ExportBtn"
-                                        Padding="12,6"
-                                        Content="导出"
-                                        Click="ExportPresetButton_Click" />
-                                <Button x:Name="ImportPresetButton"
-                                        x:Uid="Personalize_ImportBtn"
-                                        Padding="12,6"
-                                        Content="导入"
-                                        Click="ImportPresetButton_Click" />
-                            </StackPanel>
-                        </Grid>
-                    </Border>
+                        <StackPanel Grid.Column="2"
+                                    Orientation="Horizontal"
+                                    Spacing="8"
+                                    VerticalAlignment="Center">
+                            <Button x:Name="ExportPresetButton"
+                                    x:Uid="Personalize_ExportBtn"
+                                    Padding="12,6"
+                                    Content="导出"
+                                    Click="ExportPresetButton_Click" />
+                            <Button x:Name="ImportPresetButton"
+                                    x:Uid="Personalize_ImportBtn"
+                                    Padding="12,6"
+                                    Content="导入"
+                                    Click="ImportPresetButton_Click" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
 
                 <InfoBar x:Name="OperationInfoBar"
                          IsOpen="False"

--- a/Views/ServerDetailControl.xaml
+++ b/Views/ServerDetailControl.xaml
@@ -9,16 +9,16 @@
              mc:Ignorable="d"
              d:DesignWidth="500"
              d:DesignHeight="600">
-    
 
-    <Grid >
-        
+
+    <Grid>
+
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        
-            <TextBlock x:Uid="ServerDetail_HeaderText"
+
+        <TextBlock x:Uid="ServerDetail_HeaderText"
                    Grid.Row="0"
                    Text="服务器详情"
                    FontSize="20"
@@ -27,25 +27,24 @@
 
         <StackPanel Orientation="Vertical"
                     Grid.Row="1"
-                Padding="0,0,12,40"    >
+                    Padding="0,0,12,40">
 
 
-            <Border 
-                        Background="{ThemeResource LayerFillColorDefaultBrush}"
-                        BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
-                        BorderThickness="1"
-                        CornerRadius="{ThemeResource OverlayCornerRadius}"
-                        Padding="20"
-                        >
+            <Border
+                Background="{ThemeResource LayerFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="{ThemeResource OverlayCornerRadius}"
+                Padding="20">
 
 
                 <Grid>
                     <StackPanel Orientation="Vertical"
                                 Spacing="12">
 
-                        <Grid 
-                              ColumnSpacing="12"
-                              RowSpacing="10">
+                        <Grid
+                            ColumnSpacing="12"
+                            RowSpacing="10">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
@@ -141,13 +140,13 @@
                                     Visibility="{x:Bind ViewModel.AiUnlockVisibility, Mode=OneWay}">
                             <Grid x:Name="AIShadowCastGrid" />
                             <TextBlock x:Uid="ServerDetail_AiUnlockLabel"
-                                           Text="AI 访问解锁"
-                                           FontSize="13"
-                                           CharacterSpacing="80"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           VerticalAlignment="Center" />
+                                       Text="AI 访问解锁"
+                                       FontSize="13"
+                                       CharacterSpacing="80"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       VerticalAlignment="Center" />
 
-                                <Grid ColumnSpacing="12" 
+                            <Grid ColumnSpacing="12"
                                   HorizontalAlignment="Center">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
@@ -157,14 +156,14 @@
 
                                 <!-- OpenAI -->
                                 <Border Grid.Column="0"
-                                        Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"                                      
+                                        Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
                                         BorderThickness="0.8"
                                         CornerRadius="{ThemeResource OverlayCornerRadius}"
                                         Translation="0,0,16" Loaded="ShadowRect_Loaded"
                                         Width="110"
                                         Padding="14,12">
                                     <Border.Shadow>
-                                        <ThemeShadow x:Name="Shadow1"/>
+                                        <ThemeShadow x:Name="Shadow1" />
                                     </Border.Shadow>
 
                                     <Grid RowDefinitions="Auto,*,Auto"
@@ -175,8 +174,9 @@
                                                      Width="22"
                                                      Height="22"
                                                      HorizontalAlignment="Left">
-                                                <PathIcon Data="M9.205 8.658v-2.26c0-.19.072-.333.238-.428l4.543-2.616c.619-.357 1.356-.523 2.117-.523 2.854 0 4.662 2.212 4.662 4.566 0 .167 0 .357-.024.547l-4.71-2.759a.797.797 0 00-.856 0l-5.97 3.473zm10.609 8.8V12.06c0-.333-.143-.57-.429-.737l-5.97-3.473 1.95-1.118a.433.433 0 01.476 0l4.543 2.617c1.309.76 2.189 2.378 2.189 3.948 0 1.808-1.07 3.473-2.76 4.163zM7.802 12.703l-1.95-1.142c-.167-.095-.239-.238-.239-.428V5.899c0-2.545 1.95-4.472 4.591-4.472 1 0 1.927.333 2.712.928L8.23 5.067c-.285.166-.428.404-.428.737v6.898zM12 15.128l-2.795-1.57v-3.33L12 8.658l2.795 1.57v3.33L12 15.128zm1.796 7.23c-1 0-1.927-.332-2.712-.927l4.686-2.712c.285-.166.428-.404.428-.737v-6.898l1.974 1.142c.167.095.238.238.238.428v5.233c0 2.545-1.974 4.472-4.614 4.472zm-5.637-5.303l-4.544-2.617c-1.308-.761-2.188-2.378-2.188-3.948A4.482 4.482 0 014.21 6.327v5.423c0 .333.143.571.428.738l5.947 3.449-1.95 1.118a.432.432 0 01-.476 0zm-.262 3.9c-2.688 0-4.662-2.021-4.662-4.519 0-.19.024-.38.047-.57l4.686 2.71c.286.167.571.167.856 0l5.97-3.448v2.26c0 .19-.07.333-.237.428l-4.543 2.616c-.619.357-1.356.523-2.117.523zm5.899 2.83a5.947 5.947 0 005.827-4.756C22.287 18.339 24 15.84 24 13.296c0-1.665-.713-3.282-1.998-4.448.119-.5.19-.999.19-1.498 0-3.401-2.759-5.947-5.946-5.947-.642 0-1.26.095-1.88.31A5.962 5.962 0 0010.205 0a5.947 5.947 0 00-5.827 4.757C1.713 5.447 0 7.945 0 10.49c0 1.666.713 3.283 1.998 4.448-.119.5-.19 1-.19 1.499 0 3.401 2.759 5.946 5.946 5.946.642 0 1.26-.095 1.88-.309a5.96 5.96 0 004.162 1.713z"
-                                                          Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                                                <PathIcon
+                                                    Data="M9.205 8.658v-2.26c0-.19.072-.333.238-.428l4.543-2.616c.619-.357 1.356-.523 2.117-.523 2.854 0 4.662 2.212 4.662 4.566 0 .167 0 .357-.024.547l-4.71-2.759a.797.797 0 00-.856 0l-5.97 3.473zm10.609 8.8V12.06c0-.333-.143-.57-.429-.737l-5.97-3.473 1.95-1.118a.433.433 0 01.476 0l4.543 2.617c1.309.76 2.189 2.378 2.189 3.948 0 1.808-1.07 3.473-2.76 4.163zM7.802 12.703l-1.95-1.142c-.167-.095-.239-.238-.239-.428V5.899c0-2.545 1.95-4.472 4.591-4.472 1 0 1.927.333 2.712.928L8.23 5.067c-.285.166-.428.404-.428.737v6.898zM12 15.128l-2.795-1.57v-3.33L12 8.658l2.795 1.57v3.33L12 15.128zm1.796 7.23c-1 0-1.927-.332-2.712-.927l4.686-2.712c.285-.166.428-.404.428-.737v-6.898l1.974 1.142c.167.095.238.238.238.428v5.233c0 2.545-1.974 4.472-4.614 4.472zm-5.637-5.303l-4.544-2.617c-1.308-.761-2.188-2.378-2.188-3.948A4.482 4.482 0 014.21 6.327v5.423c0 .333.143.571.428.738l5.947 3.449-1.95 1.118a.432.432 0 01-.476 0zm-.262 3.9c-2.688 0-4.662-2.021-4.662-4.519 0-.19.024-.38.047-.57l4.686 2.71c.286.167.571.167.856 0l5.97-3.448v2.26c0 .19-.07.333-.237.428l-4.543 2.616c-.619.357-1.356.523-2.117.523zm5.899 2.83a5.947 5.947 0 005.827-4.756C22.287 18.339 24 15.84 24 13.296c0-1.665-.713-3.282-1.998-4.448.119-.5.19-.999.19-1.498 0-3.401-2.759-5.947-5.946-5.947-.642 0-1.26.095-1.88.31A5.962 5.962 0 0010.205 0a5.947 5.947 0 00-5.827 4.757C1.713 5.447 0 7.945 0 10.49c0 1.666.713 3.283 1.998 4.448-.119.5-.19 1-.19 1.499 0 3.401 2.759 5.946 5.946 5.946.642 0 1.26-.095 1.88-.309a5.96 5.96 0 004.162 1.713z"
+                                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
                                             </Viewbox>
                                             <Ellipse Grid.Column="2"
                                                      Width="6"
@@ -221,64 +221,64 @@
                                 <!-- Claude -->
 
                                 <Border Grid.Column="1"
-        Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
-        CornerRadius="{ThemeResource OverlayCornerRadius}"
-        BorderThickness="0.8"
-        Translation="0,0,16" Loaded="ShadowRect_Loaded"
-        Width="110"
-        Padding="14,12">
+                                        Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
+                                        CornerRadius="{ThemeResource OverlayCornerRadius}"
+                                        BorderThickness="0.8"
+                                        Translation="0,0,16" Loaded="ShadowRect_Loaded"
+                                        Width="110"
+                                        Padding="14,12">
                                     <Border.Shadow>
-                                        <ThemeShadow x:Name="Shadow2"/>
+                                        <ThemeShadow x:Name="Shadow2" />
                                     </Border.Shadow>
                                     <Grid RowDefinitions="Auto,*,Auto"
-          MinHeight="52">
+                                          MinHeight="52">
                                         <Grid Grid.Row="0"
-              ColumnDefinitions="Auto,*,Auto">
+                                              ColumnDefinitions="Auto,*,Auto">
                                             <Viewbox Grid.Column="0"
-                     Width="22"
-                     Height="22"
-                     HorizontalAlignment="Left">
+                                                     Width="22"
+                                                     Height="22"
+                                                     HorizontalAlignment="Left">
                                                 <Grid Width="24"
-                      Height="24">
+                                                      Height="24">
                                                     <Path Fill="#D97757"
-                          Data="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.364-.462-.158-1.008.656-.722.881.06.225.061.893.686 1.908 1.476 2.491 1.833.365.304.145-.103.019-.073-.164-.274-1.355-2.446-1.446-2.49-.644-1.032-.17-.619a2.97 2.97 0 01-.104-.729L6.283.134 6.696 0l.996.134.42.364.62 1.414 1.002 2.229 1.555 3.03.456.898.243.832.091.255h.158V9.01l.128-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.584.28.48.685-.067.444-.286 1.851-.559 2.903-.364 1.942h.212l.243-.242.985-1.306 1.652-2.064.73-.82.85-.904.547-.431h1.033l.76 1.129-.34 1.166-1.064 1.347-.881 1.142-1.264 1.7-.79 1.36.073.11.188-.02 2.856-.606 1.543-.28 1.841-.315.833.388.091.395-.328.807-1.969.486-2.309.462-3.439.813-.042.03.049.061 1.549.146.662.036h1.622l3.02.225.79.522.474.638-.079.485-1.215.62-1.64-.389-3.829-.91-1.312-.329h-.182v.11l1.093 1.068 2.006 1.81 2.509 2.33.127.578-.322.455-.34-.049-2.205-1.657-.851-.747-1.926-1.62h-.128v.17l.444.649 2.345 3.521.122 1.08-.17.353-.608.213-.668-.122-1.374-1.925-1.415-2.167-1.143-1.943-.14.08-.674 7.254-.316.37-.729.28-.607-.461-.322-.747.322-1.476.389-1.924.315-1.53.286-1.9.17-.632-.012-.042-.14.018-1.434 1.967-2.18 2.945-1.726 1.845-.414.164-.717-.37.067-.662.401-.589 2.388-3.036 1.44-1.882.93-1.086-.006-.158h-.055L4.132 18.56l-1.13.146-.487-.456.061-.746.231-.243 1.908-1.312-.006.006z" />
+                                                          Data="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.364-.462-.158-1.008.656-.722.881.06.225.061.893.686 1.908 1.476 2.491 1.833.365.304.145-.103.019-.073-.164-.274-1.355-2.446-1.446-2.49-.644-1.032-.17-.619a2.97 2.97 0 01-.104-.729L6.283.134 6.696 0l.996.134.42.364.62 1.414 1.002 2.229 1.555 3.03.456.898.243.832.091.255h.158V9.01l.128-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.584.28.48.685-.067.444-.286 1.851-.559 2.903-.364 1.942h.212l.243-.242.985-1.306 1.652-2.064.73-.82.85-.904.547-.431h1.033l.76 1.129-.34 1.166-1.064 1.347-.881 1.142-1.264 1.7-.79 1.36.073.11.188-.02 2.856-.606 1.543-.28 1.841-.315.833.388.091.395-.328.807-1.969.486-2.309.462-3.439.813-.042.03.049.061 1.549.146.662.036h1.622l3.02.225.79.522.474.638-.079.485-1.215.62-1.64-.389-3.829-.91-1.312-.329h-.182v.11l1.093 1.068 2.006 1.81 2.509 2.33.127.578-.322.455-.34-.049-2.205-1.657-.851-.747-1.926-1.62h-.128v.17l.444.649 2.345 3.521.122 1.08-.17.353-.608.213-.668-.122-1.374-1.925-1.415-2.167-1.143-1.943-.14.08-.674 7.254-.316.37-.729.28-.607-.461-.322-.747.322-1.476.389-1.924.315-1.53.286-1.9.17-.632-.012-.042-.14.018-1.434 1.967-2.18 2.945-1.726 1.845-.414.164-.717-.37.067-.662.401-.589 2.388-3.036 1.44-1.882.93-1.086-.006-.158h-.055L4.132 18.56l-1.13.146-.487-.456.061-.746.231-.243 1.908-1.312-.006.006z" />
                                                 </Grid>
                                             </Viewbox>
                                             <Ellipse Grid.Column="2"
-                     Width="6"
-                     Height="6"
-                     Fill="{x:Bind ViewModel.ClaudeStatusBrush, Mode=OneWay}"
-                     VerticalAlignment="Top"
-                     Margin="0,2,0,0" />
+                                                     Width="6"
+                                                     Height="6"
+                                                     Fill="{x:Bind ViewModel.ClaudeStatusBrush, Mode=OneWay}"
+                                                     VerticalAlignment="Top"
+                                                     Margin="0,2,0,0" />
                                         </Grid>
                                         <Grid Grid.Row="2"
-              ColumnDefinitions="*,Auto"
-              Margin="0,10,0,0"
-              VerticalAlignment="Bottom">
+                                              ColumnDefinitions="*,Auto"
+                                              Margin="0,10,0,0"
+                                              VerticalAlignment="Bottom">
                                             <TextBlock Text="Claude"
-                       FontSize="12"
-                       FontWeight="SemiBold"
-                       VerticalAlignment="Center" />
+                                                       FontSize="12"
+                                                       FontWeight="SemiBold"
+                                                       VerticalAlignment="Center" />
                                             <Button x:Name="ClaudeLinkButton"
-                    Grid.Column="1"
-                    Click="AiLinkButton_Click"
-                    Tag="https://claude.ai/"
-                    Background="Transparent"
-                    BorderBrush="Transparent"
-                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                    Padding="0"
-                    Width="16"
-                    Height="16"
-                    MinWidth="16"
-                    MinHeight="16"
-                    Margin="0,0,-4,0"
-                    HorizontalContentAlignment="Right"
-                    VerticalContentAlignment="Center"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Bottom">
+                                                    Grid.Column="1"
+                                                    Click="AiLinkButton_Click"
+                                                    Tag="https://claude.ai/"
+                                                    Background="Transparent"
+                                                    BorderBrush="Transparent"
+                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                    Padding="0"
+                                                    Width="16"
+                                                    Height="16"
+                                                    MinWidth="16"
+                                                    MinHeight="16"
+                                                    Margin="0,0,-4,0"
+                                                    HorizontalContentAlignment="Right"
+                                                    VerticalContentAlignment="Center"
+                                                    HorizontalAlignment="Right"
+                                                    VerticalAlignment="Bottom">
                                                 <FontIcon Glyph="&#xE8A7;"
-                          Margin="0,0,-2,0"
-                          FontSize="12" />
+                                                          Margin="0,0,-2,0"
+                                                          FontSize="12" />
                                             </Button>
                                         </Grid>
                                     </Grid>
@@ -294,7 +294,7 @@
                                         Width="110"
                                         Padding="14,12">
                                     <Border.Shadow>
-                                        <ThemeShadow x:Name="Shadow3"/>
+                                        <ThemeShadow x:Name="Shadow3" />
                                     </Border.Shadow>
                                     <Grid RowDefinitions="Auto,*,Auto"
                                           MinHeight="52">
@@ -306,33 +306,37 @@
                                                      HorizontalAlignment="Left">
                                                 <Grid Width="24"
                                                       Height="24">
-                                                    <Path Data="M20.616 10.835a14.147 14.147 0 01-4.45-3.001 14.111 14.111 0 01-3.678-6.452.503.503 0 00-.975 0 14.134 14.134 0 01-3.679 6.452 14.155 14.155 0 01-4.45 3.001c-.65.28-1.318.505-2.002.678a.502.502 0 000 .975c.684.172 1.35.397 2.002.677a14.147 14.147 0 014.45 3.001 14.112 14.112 0 013.679 6.453.502.502 0 00.975 0c.172-.685.397-1.351.677-2.003a14.145 14.145 0 013.001-4.45 14.113 14.113 0 016.453-3.678.503.503 0 000-.975 13.245 13.245 0 01-2.003-.678z"
-                                                          Fill="#3186FF" />
-                                                    <Path Data="M20.616 10.835a14.147 14.147 0 01-4.45-3.001 14.111 14.111 0 01-3.678-6.452.503.503 0 00-.975 0 14.134 14.134 0 01-3.679 6.452 14.155 14.155 0 01-4.45 3.001c-.65.28-1.318.505-2.002.678a.502.502 0 000 .975c.684.172 1.35.397 2.002.677a14.147 14.147 0 014.45 3.001 14.112 14.112 0 013.679 6.453.502.502 0 00.975 0c.172-.685.397-1.351.677-2.003a14.145 14.145 0 013.001-4.45 14.113 14.113 0 016.453-3.678.503.503 0 000-.975 13.245 13.245 0 01-2.003-.678z">
+                                                    <Path
+                                                        Data="M20.616 10.835a14.147 14.147 0 01-4.45-3.001 14.111 14.111 0 01-3.678-6.452.503.503 0 00-.975 0 14.134 14.134 0 01-3.679 6.452 14.155 14.155 0 01-4.45 3.001c-.65.28-1.318.505-2.002.678a.502.502 0 000 .975c.684.172 1.35.397 2.002.677a14.147 14.147 0 014.45 3.001 14.112 14.112 0 013.679 6.453.502.502 0 00.975 0c.172-.685.397-1.351.677-2.003a14.145 14.145 0 013.001-4.45 14.113 14.113 0 016.453-3.678.503.503 0 000-.975 13.245 13.245 0 01-2.003-.678z"
+                                                        Fill="#3186FF" />
+                                                    <Path
+                                                        Data="M20.616 10.835a14.147 14.147 0 01-4.45-3.001 14.111 14.111 0 01-3.678-6.452.503.503 0 00-.975 0 14.134 14.134 0 01-3.679 6.452 14.155 14.155 0 01-4.45 3.001c-.65.28-1.318.505-2.002.678a.502.502 0 000 .975c.684.172 1.35.397 2.002.677a14.147 14.147 0 014.45 3.001 14.112 14.112 0 013.679 6.453.502.502 0 00.975 0c.172-.685.397-1.351.677-2.003a14.145 14.145 0 013.001-4.45 14.113 14.113 0 016.453-3.678.503.503 0 000-.975 13.245 13.245 0 01-2.003-.678z">
                                                         <Path.Fill>
                                                             <LinearGradientBrush StartPoint="7,15.5"
-                                                                                 EndPoint="11,12"
-                                                                                 MappingMode="Absolute">
+                                                                    EndPoint="11,12"
+                                                                    MappingMode="Absolute">
                                                                 <GradientStop Color="#FF08B962" Offset="0" />
                                                                 <GradientStop Color="#0008B962" Offset="1" />
                                                             </LinearGradientBrush>
                                                         </Path.Fill>
                                                     </Path>
-                                                    <Path Data="M20.616 10.835a14.147 14.147 0 01-4.45-3.001 14.111 14.111 0 01-3.678-6.452.503.503 0 00-.975 0 14.134 14.134 0 01-3.679 6.452 14.155 14.155 0 01-4.45 3.001c-.65.28-1.318.505-2.002.678a.502.502 0 000 .975c.684.172 1.35.397 2.002.677a14.147 14.147 0 014.45 3.001 14.112 14.112 0 013.679 6.453.502.502 0 00.975 0c.172-.685.397-1.351.677-2.003a14.145 14.145 0 013.001-4.45 14.113 14.113 0 016.453-3.678.503.503 0 000-.975 13.245 13.245 0 01-2.003-.678z">
+                                                    <Path
+                                                        Data="M20.616 10.835a14.147 14.147 0 01-4.45-3.001 14.111 14.111 0 01-3.678-6.452.503.503 0 00-.975 0 14.134 14.134 0 01-3.679 6.452 14.155 14.155 0 01-4.45 3.001c-.65.28-1.318.505-2.002.678a.502.502 0 000 .975c.684.172 1.35.397 2.002.677a14.147 14.147 0 014.45 3.001 14.112 14.112 0 013.679 6.453.502.502 0 00.975 0c.172-.685.397-1.351.677-2.003a14.145 14.145 0 013.001-4.45 14.113 14.113 0 016.453-3.678.503.503 0 000-.975 13.245 13.245 0 01-2.003-.678z">
                                                         <Path.Fill>
                                                             <LinearGradientBrush StartPoint="8,5.5"
-                                                                                 EndPoint="11.5,11"
-                                                                                 MappingMode="Absolute">
+                                                                    EndPoint="11.5,11"
+                                                                    MappingMode="Absolute">
                                                                 <GradientStop Color="#FFF94543" Offset="0" />
                                                                 <GradientStop Color="#00F94543" Offset="1" />
                                                             </LinearGradientBrush>
                                                         </Path.Fill>
                                                     </Path>
-                                                    <Path Data="M20.616 10.835a14.147 14.147 0 01-4.45-3.001 14.111 14.111 0 01-3.678-6.452.503.503 0 00-.975 0 14.134 14.134 0 01-3.679 6.452 14.155 14.155 0 01-4.45 3.001c-.65.28-1.318.505-2.002.678a.502.502 0 000 .975c.684.172 1.35.397 2.002.677a14.147 14.147 0 014.45 3.001 14.112 14.112 0 013.679 6.453.502.502 0 00.975 0c.172-.685.397-1.351.677-2.003a14.145 14.145 0 013.001-4.45 14.113 14.113 0 016.453-3.678.503.503 0 000-.975 13.245 13.245 0 01-2.003-.678z">
+                                                    <Path
+                                                        Data="M20.616 10.835a14.147 14.147 0 01-4.45-3.001 14.111 14.111 0 01-3.678-6.452.503.503 0 00-.975 0 14.134 14.134 0 01-3.679 6.452 14.155 14.155 0 01-4.45 3.001c-.65.28-1.318.505-2.002.678a.502.502 0 000 .975c.684.172 1.35.397 2.002.677a14.147 14.147 0 014.45 3.001 14.112 14.112 0 013.679 6.453.502.502 0 00.975 0c.172-.685.397-1.351.677-2.003a14.145 14.145 0 013.001-4.45 14.113 14.113 0 016.453-3.678.503.503 0 000-.975 13.245 13.245 0 01-2.003-.678z">
                                                         <Path.Fill>
                                                             <LinearGradientBrush StartPoint="3.5,13.5"
-                                                                                 EndPoint="17.5,12"
-                                                                                 MappingMode="Absolute">
+                                                                    EndPoint="17.5,12"
+                                                                    MappingMode="Absolute">
                                                                 <GradientStop Color="#FFFABC12" Offset="0" />
                                                                 <GradientStop Color="#00FABC12" Offset="0.46" />
                                                             </LinearGradientBrush>
@@ -394,7 +398,7 @@
                                        VerticalAlignment="Center" />
 
                             <TextBlock Grid.Column="1"
-                                       Text="{x:Bind ViewModel.LatencyText, Mode=OneWay}"                                   
+                                       Text="{x:Bind ViewModel.LatencyText, Mode=OneWay}"
                                        FontSize="20"
                                        FontWeight="SemiBold"
                                        VerticalAlignment="Center"

--- a/Views/ServerListControl.xaml
+++ b/Views/ServerListControl.xaml
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <UserControl x:Class="XrayUI.Views.ServerListControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -212,14 +213,36 @@
                     BorderBrush="Transparent"
                     Padding="8">
                 <Grid>
-                    <FontIcon Glyph="&#xEC4A;"
-                              FontSize="16"
-                              Visibility="{x:Bind ViewModel.IsTestingLatencies, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                    <Grid Visibility="{x:Bind ViewModel.IsTestingLatencies, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
+                        <FontIcon Glyph="&#xEC4A;"
+                                  FontSize="16"
+                                  Visibility="{x:Bind views:ServerListControl.ConnectModeIconVisibility(ViewModel.LatencyTestMode), Mode=OneWay}" />
+                        <Viewbox Width="16"
+                                 Height="16"
+                                 Visibility="{x:Bind views:ServerListControl.RealModeIconVisibility(ViewModel.LatencyTestMode), Mode=OneWay}">
+                            <PathIcon Data="M6.54322 5.48256C7.84003 4.39564 9.46603 3.6886 11.25 3.53263V5.25C11.25 5.66421 11.5858 6 12 6C12.4142 6 12.75 5.66421 12.75 5.25V3.53263C16.929 3.89798 20.2412 7.28742 20.4855 11.5H18.75C18.3358 11.5 18 11.8358 18 12.25C18 12.6642 18.3358 13 18.75 13H20.4444C20.1837 15.3116 19.0211 17.2483 17.2765 18.6683C16.9553 18.9298 16.9068 19.4022 17.1683 19.7235C17.4298 20.0447 17.9022 20.0932 18.2235 19.8317C20.45 18.0194 21.8936 15.4382 21.9944 12.3473C21.9985 12.3154 22.0006 12.283 22.0006 12.25C22.0006 12.2301 21.9998 12.2103 21.9983 12.1907C21.9994 12.1274 22 12.0638 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 15.2522 3.52303 17.9538 5.76986 19.8262C6.08807 20.0913 6.56099 20.0483 6.82617 19.7301C7.09134 19.4119 7.04835 18.939 6.73014 18.6738C5.01891 17.2478 3.82673 15.3069 3.55764 13H5.24963C5.66385 13 5.99963 12.6642 5.99963 12.25C5.99963 11.8358 5.66385 11.5 5.24963 11.5H3.51446C3.62363 9.61804 4.34508 7.90037 5.48256 6.54322L6.71967 7.78033C7.01256 8.07322 7.48744 8.07322 7.78033 7.78033C8.07322 7.48744 8.07322 7.01256 7.78033 6.71967L6.54322 5.48256ZM16.7589 6.63409C16.5207 6.44971 16.1824 6.45611 15.9516 6.64937L15.7344 6.83167C15.596 6.9479 15.3979 7.1145 15.1588 7.31609C14.6808 7.71919 14.0386 8.26249 13.3826 8.82286C12.727 9.38283 12.0555 9.96154 11.5197 10.4349C11.2521 10.6713 11.0157 10.8838 10.831 11.0556C10.6593 11.2154 10.4986 11.3707 10.4112 11.4787C9.75823 12.2863 9.89798 13.4588 10.7234 14.0977C11.5488 14.7365 12.7472 14.5998 13.4002 13.7923C13.4876 13.6842 13.6051 13.4955 13.7245 13.2953C13.8529 13.0799 14.0099 12.8059 14.1835 12.4967C14.5311 11.8777 14.9523 11.1053 15.3585 10.3522C15.7649 9.59869 16.1576 8.86226 16.4486 8.31438C16.5941 8.04039 16.7142 7.81345 16.798 7.65496L16.9294 7.40617C17.0685 7.14203 16.9971 6.81847 16.7589 6.63409Z" />
+                        </Viewbox>
+                    </Grid>
                     <ProgressRing Width="16"
                                   Height="16"
                                   IsActive="{x:Bind ViewModel.IsTestingLatencies, Mode=OneWay}"
                                   Visibility="{x:Bind ViewModel.IsTestingLatencies, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                 </Grid>
+                <Button.ContextFlyout>
+                    <MenuFlyout>
+                        <RadioMenuFlyoutItem x:Name="TestModeConnectItem"
+                                             x:Uid="ServerList_TestModeConnect"
+                                             Text="测试延迟"
+                                             GroupName="LatencyTestMode"
+                                             IsChecked="True"
+                                             Click="TestModeConnectItem_Click" />
+                        <RadioMenuFlyoutItem x:Name="TestModeRealItem"
+                                             x:Uid="ServerList_TestModeReal"
+                                             Text="真连接测试"
+                                             GroupName="LatencyTestMode"
+                                             Click="TestModeRealItem_Click" />
+                    </MenuFlyout>
+                </Button.ContextFlyout>
             </Button>
         </Grid>
 

--- a/Views/ServerListControl.xaml.cs
+++ b/Views/ServerListControl.xaml.cs
@@ -180,6 +180,21 @@ namespace XrayUI.Views
             };
         }
 
+        // Right-click latency-test mode menu pushes the chosen mode into the VM; the toolbar icon
+        // follows automatically via x:Bind on LatencyTestMode (see *IconVisibility below).
+        private void TestModeConnectItem_Click(object sender, RoutedEventArgs e)
+            => ViewModel.LatencyTestMode = "connect";
+
+        private void TestModeRealItem_Click(object sender, RoutedEventArgs e)
+            => ViewModel.LatencyTestMode = "real";
+
+        // Toolbar icon visibility derived from the latency-test mode (bound from XAML).
+        public static Visibility ConnectModeIconVisibility(string mode)
+            => mode == "real" ? Visibility.Collapsed : Visibility.Visible;
+
+        public static Visibility RealModeIconVisibility(string mode)
+            => mode == "real" ? Visibility.Visible : Visibility.Collapsed;
+
         // Foreground for the per-row latency number, keyed off the measured value:
         // failed probe (negative, e.g. -1) → critical, ≥200 ms → caution, else success.
         public static Brush LatencyForeground(int? milliseconds)

--- a/Views/TunConfirmationDialog.xaml
+++ b/Views/TunConfirmationDialog.xaml
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <UserControl
     x:Class="XrayUI.Views.TunConfirmationDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -26,11 +27,12 @@
                 <!-- MTU 设置 -->
                 <StackPanel Spacing="6">
                     <StackPanel Orientation="Horizontal" Spacing="6">
-                        <FontIcon Glyph="&#xE946;" FontSize="16" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        <FontIcon Glyph="&#xE946;" FontSize="16"
+                                  Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                         <TextBlock x:Uid="Tun_MtuLabel"
                                    Text="最大传输单元"
                                    FontSize="15"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                     </StackPanel>
                     <NumberBox x:Name="MtuNumberBox"
                                Value="1500"
@@ -43,11 +45,12 @@
                 <!-- 出口网卡设置 -->
                 <StackPanel Spacing="6">
                     <StackPanel Orientation="Horizontal" Spacing="6">
-                        <FontIcon Glyph="&#xE839;" FontSize="16" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        <FontIcon Glyph="&#xE839;" FontSize="16"
+                                  Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                         <TextBlock x:Uid="Tun_InterfaceLabel"
                                    Text="出口网卡"
                                    FontSize="15"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                     </StackPanel>
 
                     <ComboBox x:Name="InterfaceComboBox"


### PR DESCRIPTION
## Summary
- Add a real-delay latency test mode that routes HTTP probes through a throwaway xray core.
- Build a dedicated per-server speed-test config with local SOCKS inbounds and proxy outbounds.
- Share kill-on-close Job Object handling between the live core and helper test cores.
- Add the server-list mode selector and localized labels for connect vs real-delay tests.

## Validation
- dotnet build XrayUI-dev.csproj -c Debug