### PR TITLE
Replace fixed 800ms xray startup waits with a core readiness signal; UI polish

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -14,8 +14,14 @@
 
             <x:String x:Key="GitHubIconPath">M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z</x:String>
 
+            <SolidColorBrush x:Key="RunningStatusActiveBrush" Color="{ThemeResource SystemFillColorSuccess}" />
+            <SolidColorBrush x:Key="RunningStatusInactiveBrush" Color="{ThemeResource SystemFillColorNeutral}" />
+
             <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             <converters:InverseBooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter" />
+            <converters:BooleanToBrushConverter x:Key="RunningStatusBrushConverter"
+                                                TrueBrush="{StaticResource RunningStatusActiveBrush}"
+                                                FalseBrush="{StaticResource RunningStatusInactiveBrush}" />
             <converters:ColorToBrushConverter x:Key="ColorToBrushConverter" />
             <converters:ColorToHexStringConverter x:Key="ColorToHexStringConverter" />
             <converters:ProtocolToBrushConverter x:Key="ProtocolToBrushConverter" />

--- a/Converters/BooleanToBrushConverter.cs
+++ b/Converters/BooleanToBrushConverter.cs
@@ -1,0 +1,19 @@
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+using System;
+
+namespace XrayUI.Converters
+{
+    public partial class BooleanToBrushConverter : IValueConverter
+    {
+        public Brush TrueBrush { get; set; } = new SolidColorBrush();
+
+        public Brush FalseBrush { get; set; } = new SolidColorBrush();
+
+        public object Convert(object value, Type targetType, object parameter, string language)
+            => value is true ? TrueBrush : FalseBrush;
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+            => throw new NotImplementedException();
+    }
+}

--- a/Properties/PublishProfiles/win-x64.pubxml
+++ b/Properties/PublishProfiles/win-x64.pubxml
@@ -6,6 +6,7 @@
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishAot>true</PublishAot>
+    <OptimizationPreference>Speed</OptimizationPreference>
     <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
     <PublishTrimmed>true</PublishTrimmed>
     <PublishSingleFile>false</PublishSingleFile>

--- a/Services/RealLatencyProbeService.cs
+++ b/Services/RealLatencyProbeService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -44,8 +44,10 @@ namespace XrayUI.Services
         // stable even under brief contention. Halves the wave count vs 16 for dozens of nodes.
         private const int MaxConcurrency = 32;
 
-        // Give the throwaway core a moment to bind every socks inbound before we probe.
-        private const int CoreReadyDelayMs = 800;
+        // Upper bound on waiting for the throwaway core's readiness line (printed after every
+        // socks inbound is bound — see XrayReadySignal). Normally arrives in tens of ms; the
+        // cap reproduces the old fixed-delay behavior if the core stays silent.
+        private static readonly TimeSpan CoreReadyCap = TimeSpan.FromSeconds(2);
 
         // Dedicated config path, separate from XrayService's xray_config.json so a test never
         // clobbers the live session's config file.
@@ -119,6 +121,7 @@ namespace XrayUI.Services
                 psi.EnvironmentVariables["XRAY_LOCATION_ASSET"] = XrayService.RulesDir;
 
                 process = new Process { StartInfo = psi };
+                var readySignal = XrayReadySignal.Attach(process);
                 // xray logs to both stdout and stderr; capture both so a failed start has a reason.
                 void Capture(string? line)
                 {
@@ -133,8 +136,9 @@ namespace XrayUI.Services
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
 
-                // 4. Wait for the inbounds to come up.
-                await Task.Delay(CoreReadyDelayMs, ct).ConfigureAwait(false);
+                // 4. Wait until the core reports every inbound is up. An early exit falls
+                // through to the HasExited check below, which reads the captured log.
+                await readySignal.WaitAsync(CoreReadyCap, ct).ConfigureAwait(false);
 
                 if (process.HasExited)
                 {

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -14,6 +14,9 @@ namespace XrayUI.Services
     /// </summary>
     public static class XrayConfigBuilder
     {
+        // Must stay at debug/info/warning: XrayReadySignal detects core readiness via the
+        // Warning-level "core: Xray x.y.z started" log line, which "error"/"none" would
+        // suppress — degrading every connect/switch/reapply to the 3s timeout fallback.
         private const string DefaultLogLevel = "info";
         private const string ProxyOutboundTag = "proxy";
         private const string DirectOutboundTag = "direct";
@@ -886,6 +889,7 @@ namespace XrayUI.Services
 
             var config = new JsonObject
             {
+                // Keep ≥ warning visibility: XrayReadySignal needs the "started" line.
                 ["log"] = new JsonObject { ["loglevel"] = "warning" },
                 ["inbounds"] = inbounds,
                 ["outbounds"] = outbounds,

--- a/Services/XrayReadySignal.cs
+++ b/Services/XrayReadySignal.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace XrayUI.Services
+{
+    /// <summary>
+    /// Resolves as soon as a freshly launched xray core reports readiness, replacing the old
+    /// fixed startup delays. The primary signal is the "[Warning] core: Xray x.y.z started"
+    /// log line, which xray prints only after every inbound (mixed socks/http, TUN device,
+    /// the speed-test core's N test ports) has come up. The line goes through xray's logger
+    /// at Warning level, so the config loglevel must be debug/info/warning for it to appear —
+    /// XrayConfigBuilder guarantees that (see DefaultLogLevel). Verified against the bundled
+    /// Xray 26.6.1; if a future core rewords the line, WaitAsync's cap degrades gracefully
+    /// to the previous fixed-delay behavior instead of breaking.
+    /// </summary>
+    internal sealed class XrayReadySignal
+    {
+        public enum Outcome { Ready, Exited, TimedOut }
+
+        private readonly TaskCompletionSource<Outcome> _outcome =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private XrayReadySignal()
+        {
+        }
+
+        /// <summary>
+        /// Wires a signal onto <paramref name="process"/>: subscribes its own stdout/stderr/
+        /// Exited handlers (multicast, so the caller's logging handlers are unaffected) and
+        /// turns on <see cref="Process.EnableRaisingEvents"/>. Call before Start().
+        /// </summary>
+        public static XrayReadySignal Attach(Process process)
+        {
+            var signal = new XrayReadySignal();
+            process.EnableRaisingEvents = true;
+            process.OutputDataReceived += (_, e) => signal.OnOutputLine(e.Data);
+            process.ErrorDataReceived += (_, e) => signal.OnOutputLine(e.Data);
+            process.Exited += (_, _) => signal._outcome.TrySetResult(Outcome.Exited);
+            return signal;
+        }
+
+        private void OnOutputLine(string? line)
+        {
+            // Matches "2026/06/10 09:00:54 [Warning] core: Xray 26.6.1 started". Only the
+            // startup window awaits this signal, so user traffic in the access log can
+            // never race a false positive.
+            if (line is not null
+                && line.EndsWith(" started", StringComparison.Ordinal)
+                && line.Contains("core:", StringComparison.Ordinal))
+            {
+                _outcome.TrySetResult(Outcome.Ready);
+            }
+        }
+
+        /// <summary>
+        /// Waits for the first of: readiness line (Ready), process death (Exited), or
+        /// <paramref name="cap"/> elapsing (TimedOut). Cancellation propagates as
+        /// <see cref="OperationCanceledException"/>.
+        /// </summary>
+        public async Task<Outcome> WaitAsync(TimeSpan cap, CancellationToken ct = default)
+        {
+            try
+            {
+                return await _outcome.Task.WaitAsync(cap, ct).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                return Outcome.TimedOut;
+            }
+        }
+    }
+}

--- a/Services/XrayService.cs
+++ b/Services/XrayService.cs
@@ -26,6 +26,11 @@ namespace XrayUI.Services
 
         private const int LogBufferMax = 500;
 
+        // Upper bound on waiting for the readiness line of a freshly launched core (see
+        // XrayReadySignal). Normally Ready lands in tens of ms; this cap only bites when
+        // the core stays silent, where it reproduces the old fixed-delay behavior.
+        private static readonly TimeSpan StartupReadyCap = TimeSpan.FromSeconds(3);
+
         private Process? _process;
 
         // Kernel-level safety net: xray.exe is assigned to a kill-on-close Job Object, so if the
@@ -183,6 +188,7 @@ namespace XrayUI.Services
                 psi.EnvironmentVariables["XRAY_LOCATION_ASSET"] = RulesDir;
 
                 _process = new Process { StartInfo = psi, EnableRaisingEvents = true };
+                var readySignal = XrayReadySignal.Attach(_process);
 
                 _process.OutputDataReceived += (_, e) =>
                 {
@@ -209,9 +215,12 @@ namespace XrayUI.Services
                 AppendLog(Loc.Format("XrayLog_Started", ExePath));
                 AppendLog(Loc.Format("XrayLog_Config", ConfigPath));
 
-                await Task.Delay(800);
+                // Ready typically lands well under 100ms; Exited surfaces bad configs / port
+                // clashes / TUN elevation failures immediately instead of after a fixed wait.
+                // TimedOut with the process still alive counts as success, same as before.
+                var outcome = await readySignal.WaitAsync(StartupReadyCap);
 
-                if (_process.HasExited)
+                if (outcome == XrayReadySignal.Outcome.Exited || _process.HasExited)
                 {
                     var startupLog = StopStartupLogCaptureAndRead();
                     LastError = startupLog.Length > 0

--- a/Views/ControlPanelControl.xaml
+++ b/Views/ControlPanelControl.xaml
@@ -143,14 +143,8 @@
                 <StackPanel Orientation="Horizontal"
                             VerticalAlignment="Center"
                             Spacing="6">
-                    <Grid>
-                        <FontIcon Glyph="&#xECCC;"
-                                  Foreground="{ThemeResource SystemFillColorSuccessBrush}"
-                                  Visibility="{x:Bind ViewModel.IsRunning, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                        <FontIcon Glyph="&#xECCC;"
-                                  Foreground="{ThemeResource SystemFillColorNeutralBrush}"
-                                  Visibility="{x:Bind ViewModel.IsRunning, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
-                    </Grid>
+                    <FontIcon Glyph="&#xECCC;"
+                              Foreground="{x:Bind ViewModel.IsRunning, Mode=OneWay, Converter={StaticResource RunningStatusBrushConverter}}" />
                     <TextBlock FontSize="14"
                                Text="{x:Bind ViewModel.StatusText, Mode=OneWay}"
                                MaxWidth="125"

--- a/Views/ServerDetailControl.xaml
+++ b/Views/ServerDetailControl.xaml
@@ -157,7 +157,6 @@
                                 <!-- OpenAI -->
                                 <Border Grid.Column="0"
                                         Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
-                                        BorderThickness="0.8"
                                         CornerRadius="{ThemeResource OverlayCornerRadius}"
                                         Translation="0,0,16" Loaded="ShadowRect_Loaded"
                                         Width="110"
@@ -223,7 +222,6 @@
                                 <Border Grid.Column="1"
                                         Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
                                         CornerRadius="{ThemeResource OverlayCornerRadius}"
-                                        BorderThickness="0.8"
                                         Translation="0,0,16" Loaded="ShadowRect_Loaded"
                                         Width="110"
                                         Padding="14,12">
@@ -289,7 +287,6 @@
                                 <Border Grid.Column="2"
                                         Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
                                         CornerRadius="{ThemeResource OverlayCornerRadius}"
-                                        BorderThickness="0.8"
                                         Translation="0,0,16" Loaded="ShadowRect_Loaded"
                                         Width="110"
                                         Padding="14,12">

--- a/Views/ServerListControl.xaml
+++ b/Views/ServerListControl.xaml
@@ -283,8 +283,17 @@
                                         CornerRadius="3"
                                         Padding="6,2"
                                         Visibility="{x:Bind IsActive, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        Opacity="{x:Bind views:ServerListControl.ActiveBadgeOpacity(IsActive), Mode=OneWay}"
+                                        Scale="{x:Bind views:ServerListControl.ActiveBadgeScale(IsActive), Mode=OneWay}"
                                         Grid.Column="1"
-                                        Margin="8,0,0,0">
+                                        Margin="8,0,0,0"
+                                        SizeChanged="ActiveBadge_SizeChanged">
+                                    <Border.OpacityTransition>
+                                        <ScalarTransition Duration="0:0:0.18" />
+                                    </Border.OpacityTransition>
+                                    <Border.ScaleTransition>
+                                        <Vector3Transition Duration="0:0:0.18" />
+                                    </Border.ScaleTransition>
                                     <TextBlock x:Uid="ServerList_ActivatedBadge"
                                                Text="● Activated"
                                                FontSize="12"

--- a/Views/ServerListControl.xaml.cs
+++ b/Views/ServerListControl.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Numerics;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
@@ -84,6 +85,12 @@ namespace XrayUI.Views
         private void ServersListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             ViewModel.SetSelectedServers(ServersListView.SelectedItems.OfType<ServerEntry>().ToArray());
+        }
+
+        private void ActiveBadge_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (sender is UIElement element)
+                element.CenterPoint = new Vector3((float)e.NewSize.Width / 2f, (float)e.NewSize.Height / 2f, 0f);
         }
 
         private async void ServerItem_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
@@ -194,6 +201,12 @@ namespace XrayUI.Views
 
         public static Visibility RealModeIconVisibility(string mode)
             => mode == "real" ? Visibility.Visible : Visibility.Collapsed;
+
+        public static double ActiveBadgeOpacity(bool isActive)
+            => isActive ? 1.0 : 0.0;
+
+        public static Vector3 ActiveBadgeScale(bool isActive)
+            => isActive ? Vector3.One : new Vector3(0.92f, 0.92f, 1f);
 
         // Foreground for the per-row latency number, keyed off the measured value:
         // failed probe (negative, e.g. -1) → critical, ≥200 ms → caution, else success.

--- a/Views/TunConfirmationDialog.xaml
+++ b/Views/TunConfirmationDialog.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d">
 
     <StackPanel Spacing="12" Width="280">
-        <!-- 核心警告提示 -->
+        <!-- UAC warning message -->
         <TextBlock Text="TUN 模式需要管理员权限，程序将会重启，是否继续？"
                    x:Uid="Tun_EnableMsg"
                    TextWrapping="Wrap" />
@@ -24,7 +24,7 @@
         <Border x:Name="AdvancedSettingsPanel"
                 Visibility="Collapsed">
             <StackPanel Spacing="16">
-                <!-- MTU 设置 -->
+                <!-- MTU setting -->
                 <StackPanel Spacing="6">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <FontIcon Glyph="&#xE946;" FontSize="16"
@@ -42,7 +42,7 @@
                                HorizontalAlignment="Stretch" />
                 </StackPanel>
 
-                <!-- 出口网卡设置 -->
+                <!-- network interface setting -->
                 <StackPanel Spacing="6">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <FontIcon Glyph="&#xE839;" FontSize="16"
@@ -59,7 +59,7 @@
                               SelectedIndex="0" />
                 </StackPanel>
 
-                <!-- IPv6 设置 -->
+                <!-- IPv6 setting -->
                 <Grid ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />

--- a/XrayUI-dev.csproj
+++ b/XrayUI-dev.csproj
@@ -115,9 +115,8 @@
 
   <!-- Publish Properties -->
   <PropertyGroup>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-    <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
+    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishTrimmed>False</PublishTrimmed>
     <ApplicationIcon>Assets\Icons\output.ico</ApplicationIcon>
   </PropertyGroup>
 


### PR DESCRIPTION
## What

### Core: xray readiness signal (replaces flat 800ms sleeps)
- New `XrayReadySignal` (Services/XrayReadySignal.cs): races the core's `[Warning] core: Xray x.y.z started` log line against process exit and a timeout cap (3s live core / 2s speed-test core).
- `XrayService.StartAsync` and `RealLatencyProbeService.ProbeAllAsync` wait on the signal instead of `Task.Delay(800)`.
- Wiring is owned by `XrayReadySignal.Attach(Process)` - it subscribes its own multicast stdout/stderr/Exited handlers, so a call site cannot half-wire the convention.

### UI / build
- Control-panel status icon: one FontIcon + parameterized `BooleanToBrushConverter` replaces the stacked dual-FontIcon visibility toggle.
- Server-list "Activated" badge: 180ms fade+scale entrance via implicit transitions; CenterPoint kept centered through SizeChanged.
- `win-x64.pubxml`: `OptimizationPreference=Speed` for the AOT publish; csproj drops dead `PublishReadyToRun`/`PublishTrimmed` conditionals (every real publish path overrides them explicitly).
- Cleanup: TunConfirmationDialog comments translated, leftover blank attribute lines removed in ServerDetailControl.

## Why

Every connect, node switch, routing/DNS/proxy-mode reapply, and real-delay speed test paid a fixed 800ms wait, while the bundled core is actually ready ~16ms after reading its config. Measured against the bundled Xray 26.6.1:

| Path | Before | After |
|---|---|---|
| Successful start (ready line matched) | flat 800ms | ~69ms |
| Failed start (bad config, process exits) | discovered at 800ms | ~63ms |

This also fixes a latent correctness gap: the old code only checked "process alive after 800ms", so a slow start (AV scan, TUN device creation) could be reported as connected before it was actually ready. The signal waits for true readiness; the cap reproduces the old fixed-wait behavior as a graceful fallback.

## Reviewer notes

- Contract: config `loglevel` must stay at debug/info/warning, or the ready line disappears and every start degrades to the timeout cap (slower, never broken). Documented at both write sites in `XrayConfigBuilder`.
- Verified against the bundled core: the ready line prints at `loglevel: info` and `warning`, and is suppressed at `none`.
- TUN: the started line should print after TUN device/route setup (part of inbound start), but one manual TUN connect is worth doing to confirm; the timeout fallback covers the worst case.
- Badge exit animation intentionally does not play (Visibility collapses immediately) - entrance-only is by design.

Generated with [Claude Code](https://claude.com/claude-code)
