### PR TITLE
feat(import): import nodes from Clash YAML config

### DIFF
--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -133,6 +133,10 @@ public static class L
     public static string Personalize_PresetMissingMsg      => Loc.GetString("Personalize_PresetMissingMsg");
     public static string Personalize_ExportTooltip         => Loc.GetString("Personalize_ExportTooltip");
     public static string Personalize_ImportTooltip         => Loc.GetString("Personalize_ImportTooltip");
+    public static string Personalize_ClashImportSuccess        => Loc.GetString("Personalize_ClashImportSuccess");
+    public static string Personalize_ClashImportNoNodesTitle   => Loc.GetString("Personalize_ClashImportNoNodesTitle");
+    public static string Personalize_ClashImportNoNodesMsg     => Loc.GetString("Personalize_ClashImportNoNodesMsg");
+    public static string Personalize_ClashImportFailed         => Loc.GetString("Personalize_ClashImportFailed");
     public static string Error_ExportFailed                => Loc.GetString("Error_ExportFailed");
 
     // ── CustomRules / AddRule ──────────────────────────────────────────────

--- a/Services/ClashConfigParser.cs
+++ b/Services/ClashConfigParser.cs
@@ -75,16 +75,22 @@ namespace XrayUI.Services
             return entry;
         }
 
-        private static ServerEntry MapSs(YamlMappingNode p) => new()
+        private static ServerEntry? MapSs(YamlMappingNode p)
         {
-            Name       = Str(p, "name"),
-            Protocol   = "ss",
-            Host       = Str(p, "server"),
-            Port       = Int(p, "port"),
-            Encryption = Str(p, "cipher"),
-            Password   = Str(p, "password"),
-            Network    = "tcp",
-        };
+            if (Child(p, "plugin") is not null || Child(p, "plugin-opts") is not null)
+                return null;
+
+            return new ServerEntry
+            {
+                Name       = Str(p, "name"),
+                Protocol   = "ss",
+                Host       = Str(p, "server"),
+                Port       = Int(p, "port"),
+                Encryption = Str(p, "cipher"),
+                Password   = Str(p, "password"),
+                Network    = "tcp",
+            };
+        }
 
         private static ServerEntry? MapVmess(YamlMappingNode p)
         {
@@ -129,6 +135,7 @@ namespace XrayUI.Services
                 AllowInsecure = Bool(p, "skip-cert-verify"),
                 PublicKey     = reality is null ? string.Empty : Str(reality, "public-key"),
                 ShortId       = reality is null ? string.Empty : Str(reality, "short-id"),
+                SpiderX       = reality is null ? string.Empty : Str(reality, "spider-x"),
                 Path          = t.path,
                 WsHost        = t.wsHost,
                 Flow          = Str(p, "flow"),

--- a/Services/ClashConfigParser.cs
+++ b/Services/ClashConfigParser.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using XrayUI.Models;
+using YamlDotNet.RepresentationModel;
+
+namespace XrayUI.Services
+{
+    /// <summary>
+    /// Parses the <c>proxies:</c> section of a Clash / Clash.Meta YAML config into
+    /// <see cref="ServerEntry"/> instances. Field conventions mirror <see cref="NodeLinkParser"/>
+    /// so an imported node is indistinguishable from a link-imported one downstream
+    /// (<see cref="XrayConfigBuilder"/> etc.).
+    ///
+    /// Routing rules and proxy-groups are ignored by design — this is node-only import.
+    /// Only protocols the Xray core supports are mapped (ss / vmess / vless / trojan /
+    /// hysteria2); everything else (tuic, anytls, wireguard, hysteria v1, ssr, snell, …)
+    /// is counted as skipped.
+    ///
+    /// AOT-safe: uses YamlDotNet's reflection-free <see cref="YamlStream"/> DOM, never the
+    /// reflection-based <c>Deserializer</c>.
+    /// </summary>
+    public static class ClashConfigParser
+    {
+        /// <summary>
+        /// Parses <paramref name="yamlText"/>. Throws on invalid YAML (the caller surfaces it
+        /// as an import error). A valid document with no <c>proxies:</c> sequence yields an
+        /// empty result rather than throwing.
+        /// </summary>
+        public static ClashParseResult Parse(string yamlText)
+        {
+            var nodes = new List<ServerEntry>();
+            int skipped = 0;
+
+            var stream = new YamlStream();
+            stream.Load(new StringReader(yamlText));
+
+            if (stream.Documents.Count == 0 ||
+                stream.Documents[0].RootNode is not YamlMappingNode root ||
+                Child(root, "proxies") is not YamlSequenceNode proxies)
+                return new ClashParseResult(nodes, 0);
+
+            foreach (var item in proxies.Children)
+            {
+                if (item is not YamlMappingNode p)
+                    continue;
+
+                var entry = MapProxy(p);
+                if (entry is null)
+                    skipped++;
+                else
+                    nodes.Add(entry);
+            }
+
+            return new ClashParseResult(nodes, skipped);
+        }
+
+        // Returns null for unsupported protocols and for entries missing a usable host/port
+        // (so malformed rows don't pollute the list). Both count as "skipped".
+        private static ServerEntry? MapProxy(YamlMappingNode p)
+        {
+            ServerEntry? entry = Str(p, "type").ToLowerInvariant() switch
+            {
+                "ss"        => MapSs(p),
+                "vmess"     => MapVmess(p),
+                "vless"     => MapVless(p),
+                "trojan"    => MapTrojan(p),
+                "hysteria2" => MapHysteria2(p),
+                _           => null,
+            };
+
+            if (entry is null || string.IsNullOrWhiteSpace(entry.Host) || entry.Port <= 0)
+                return null;
+
+            return entry;
+        }
+
+        private static ServerEntry MapSs(YamlMappingNode p) => new()
+        {
+            Name       = Str(p, "name"),
+            Protocol   = "ss",
+            Host       = Str(p, "server"),
+            Port       = Int(p, "port"),
+            Encryption = Str(p, "cipher"),
+            Password   = Str(p, "password"),
+            Network    = "tcp",
+        };
+
+        private static ServerEntry? MapVmess(YamlMappingNode p)
+        {
+            if (Transport(p) is not { } t) return null;
+            bool tls = Bool(p, "tls");
+            return new ServerEntry
+            {
+                Name          = Str(p, "name"),
+                Protocol      = "vmess",
+                Host          = Str(p, "server"),
+                Port          = Int(p, "port"),
+                Uuid          = Str(p, "uuid"),
+                AlterId       = Int(p, "alterId"),
+                Network       = t.network,
+                Path          = t.path,
+                WsHost        = t.wsHost,
+                Security      = tls ? "tls" : "none",
+                Sni           = Str(p, "servername", Str(p, "sni")),
+                Fingerprint   = Str(p, "client-fingerprint"),
+                AllowInsecure = Bool(p, "skip-cert-verify"),
+                Encryption    = tls ? "TLS" : "None",
+            };
+        }
+
+        private static ServerEntry? MapVless(YamlMappingNode p)
+        {
+            if (Transport(p) is not { } t) return null;
+            var reality = Map(p, "reality-opts");
+            bool tls = Bool(p, "tls");
+            string security = reality is not null ? "reality" : tls ? "tls" : "none";
+            return new ServerEntry
+            {
+                Name          = Str(p, "name"),
+                Protocol      = "vless",
+                Host          = Str(p, "server"),
+                Port          = Int(p, "port"),
+                Uuid          = Str(p, "uuid"),
+                Network       = t.network,
+                Security      = security,
+                Sni           = Str(p, "servername", Str(p, "sni")),
+                Fingerprint   = Str(p, "client-fingerprint"),
+                AllowInsecure = Bool(p, "skip-cert-verify"),
+                PublicKey     = reality is null ? string.Empty : Str(reality, "public-key"),
+                ShortId       = reality is null ? string.Empty : Str(reality, "short-id"),
+                Path          = t.path,
+                WsHost        = t.wsHost,
+                Flow          = Str(p, "flow"),
+                Encryption    = security == "reality" ? "Reality"
+                              : security == "tls"     ? "TLS"
+                                                      : "None",
+            };
+        }
+
+        private static ServerEntry? MapTrojan(YamlMappingNode p)
+        {
+            if (Transport(p) is not { } t) return null;
+            return new ServerEntry
+            {
+                Name          = Str(p, "name"),
+                Protocol      = "trojan",
+                Host          = Str(p, "server"),
+                Port          = Int(p, "port"),
+                Password      = Str(p, "password"),
+                Network       = t.network,
+                Security      = "tls",
+                Sni           = Str(p, "sni", Str(p, "servername")),
+                Fingerprint   = Str(p, "client-fingerprint"),
+                AllowInsecure = Bool(p, "skip-cert-verify"),
+                Path          = t.path,
+                WsHost        = t.wsHost,
+                Encryption    = "TLS",
+            };
+        }
+
+        private static ServerEntry MapHysteria2(YamlMappingNode p) => new()
+        {
+            Name          = Str(p, "name"),
+            Protocol      = "hysteria2",
+            Host          = Str(p, "server"),
+            Port          = Int(p, "port"),
+            Password      = Str(p, "password"),
+            Network       = "udp",
+            Security      = "tls",
+            Sni           = Str(p, "sni", Str(p, "servername")),
+            AllowInsecure = Bool(p, "skip-cert-verify"),
+            Finalmask     = BuildHysteria2Finalmask(p),
+            Encryption    = "TLS",
+        };
+
+        private static string BuildHysteria2Finalmask(YamlMappingNode p)
+        {
+            var finalmask = FinalmaskJson.NormalizeForStorage(Str(p, "fm", Str(p, "finalmask")));
+
+            if (!string.Equals(Str(p, "obfs"), "salamander", StringComparison.OrdinalIgnoreCase))
+                return finalmask;
+
+            var obfsPassword = Str(p, "obfs-password", Str(p, "obfs_password", Str(p, "obfsPassword")));
+            if (string.IsNullOrWhiteSpace(obfsPassword))
+                return finalmask;
+
+            return FinalmaskJson.AddHysteria2SalamanderMask(finalmask, obfsPassword);
+        }
+
+        // Resolves the transport into the (network, path, wsHost) triple XrayConfigBuilder
+        // consumes. Returns null for network types XrayConfigBuilder can't build streamSettings
+        // for (h2/http/kcp/quic/…) so the caller skips the node rather than importing an
+        // unconnectable one. Note grpc's service name lives in grpc-opts (not ws-opts) and, like
+        // ws's path, is carried on ServerEntry.Path (see XrayConfigBuilder.BuildStreamSettings).
+        private static (string network, string path, string wsHost)? Transport(YamlMappingNode p)
+        {
+            switch (Str(p, "network", "tcp").ToLowerInvariant())
+            {
+                case "tcp":
+                    return ("tcp", string.Empty, string.Empty);
+                case "ws":
+                {
+                    var (wsPath, wsHost) = WsOpts(p);
+                    return ("ws", wsPath, wsHost);
+                }
+                case "grpc":
+                {
+                    var grpc = Map(p, "grpc-opts");
+                    var serviceName = grpc is null ? string.Empty : Str(grpc, "grpc-service-name");
+                    return ("grpc", serviceName, string.Empty);
+                }
+                default:
+                    return null;
+            }
+        }
+
+        // ws-opts: { path, headers: { Host } }
+        private static (string path, string wsHost) WsOpts(YamlMappingNode p)
+        {
+            var ws = Map(p, "ws-opts");
+            if (ws is null)
+                return (string.Empty, string.Empty);
+
+            var headers = Map(ws, "headers");
+            var host = headers is null ? string.Empty : Str(headers, "Host");
+            return (Str(ws, "path"), host);
+        }
+
+        // ── YAML DOM accessors (case-insensitive keys, no reflection) ──────────
+
+        private static YamlNode? Child(YamlMappingNode map, string key)
+        {
+            foreach (var kv in map.Children)
+                if (kv.Key is YamlScalarNode s &&
+                    string.Equals(s.Value, key, StringComparison.OrdinalIgnoreCase))
+                    return kv.Value;
+            return null;
+        }
+
+        private static string Str(YamlMappingNode map, string key, string def = "")
+            => Child(map, key) is YamlScalarNode { Value: { } v } ? v : def;
+
+        private static int Int(YamlMappingNode map, string key, int def = 0)
+            => Child(map, key) is YamlScalarNode s && int.TryParse(s.Value, out var n) ? n : def;
+
+        private static bool Bool(YamlMappingNode map, string key, bool def = false)
+            => Child(map, key) is YamlScalarNode { Value: { } v }
+                ? v.Equals("true", StringComparison.OrdinalIgnoreCase)
+                : def;
+
+        private static YamlMappingNode? Map(YamlMappingNode map, string key)
+            => Child(map, key) as YamlMappingNode;
+    }
+
+    public sealed record ClashParseResult(List<ServerEntry> Nodes, int Skipped);
+}

--- a/Services/FinalmaskJson.cs
+++ b/Services/FinalmaskJson.cs
@@ -60,5 +60,43 @@ namespace XrayUI.Services
                 return null;
             }
         }
+
+        public static string AddHysteria2SalamanderMask(string finalmask, string password)
+        {
+            var parsed = Parse(finalmask);
+            if (parsed is not null and not JsonObject)
+                return finalmask;
+
+            if (parsed is null && !string.IsNullOrWhiteSpace(finalmask))
+                return finalmask;
+
+            var root = parsed as JsonObject ?? [];
+            var udp = root["udp"] as JsonArray;
+            if (udp is null)
+            {
+                udp = [];
+                root["udp"] = udp;
+            }
+
+            foreach (var item in udp)
+            {
+                if (item is JsonObject itemObject
+                    && string.Equals(itemObject["type"]?.GetValue<string>(), "salamander", StringComparison.OrdinalIgnoreCase))
+                {
+                    return root.ToJsonString(AppJsonSerializerContext.WriteReadable);
+                }
+            }
+
+            udp.Insert(0, new JsonObject
+            {
+                ["type"] = "salamander",
+                ["settings"] = new JsonObject
+                {
+                    ["password"] = password
+                }
+            });
+
+            return root.ToJsonString(AppJsonSerializerContext.WriteReadable);
+        }
     }
 }

--- a/Services/NodeLinkParser.cs
+++ b/Services/NodeLinkParser.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using XrayUI.Models;
 
 namespace XrayUI.Services
@@ -327,45 +326,7 @@ namespace XrayUI.Services
             if (obfsPassword is null)
                 return finalmask;
 
-            return AddHysteria2SalamanderMask(finalmask, obfsPassword);
-        }
-
-        private static string AddHysteria2SalamanderMask(string finalmask, string password)
-        {
-            var parsed = FinalmaskJson.Parse(finalmask);
-            if (parsed is not null and not JsonObject)
-                return finalmask;
-
-            if (parsed is null && !string.IsNullOrWhiteSpace(finalmask))
-                return finalmask;
-
-            var root = parsed as JsonObject ?? [];
-            var udp = root["udp"] as JsonArray;
-            if (udp is null)
-            {
-                udp = [];
-                root["udp"] = udp;
-            }
-
-            foreach (var item in udp)
-            {
-                if (item is JsonObject itemObject
-                    && string.Equals(itemObject["type"]?.GetValue<string>(), "salamander", StringComparison.OrdinalIgnoreCase))
-                {
-                    return root.ToJsonString(AppJsonSerializerContext.WriteReadable);
-                }
-            }
-
-            udp.Insert(0, new JsonObject
-            {
-                ["type"] = "salamander",
-                ["settings"] = new JsonObject
-                {
-                    ["password"] = password
-                }
-            });
-
-            return root.ToJsonString(AppJsonSerializerContext.WriteReadable);
+            return FinalmaskJson.AddHysteria2SalamanderMask(finalmask, obfsPassword);
         }
 
         // Trojan

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -979,6 +979,27 @@
   <data name="Personalize_ImportBtn.Content" xml:space="preserve">
     <value>Import</value>
   </data>
+  <data name="Personalize_ImportMenuRestore.Text" xml:space="preserve">
+    <value>Restore from Backup</value>
+  </data>
+  <data name="Personalize_ImportMenuClash.Text" xml:space="preserve">
+    <value>Import Clash Config</value>
+  </data>
+  <data name="Personalize_ClashImportSuccess" xml:space="preserve">
+    <value>Clash config imported</value>
+  </data>
+  <data name="Personalize_ClashImportSuccessMsg" xml:space="preserve">
+    <value>Imported {0} node(s), skipped {1} unsupported.</value>
+  </data>
+  <data name="Personalize_ClashImportNoNodesTitle" xml:space="preserve">
+    <value>No nodes imported</value>
+  </data>
+  <data name="Personalize_ClashImportNoNodesMsg" xml:space="preserve">
+    <value>No importable nodes found in this file (all unsupported protocols, or not a valid Clash config).</value>
+  </data>
+  <data name="Personalize_ClashImportFailed" xml:space="preserve">
+    <value>Clash import failed</value>
+  </data>
   <data name="Personalize_ExportTooltip" xml:space="preserve">
     <value>Export preset configuration</value>
   </data>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -979,6 +979,27 @@
   <data name="Personalize_ImportBtn.Content" xml:space="preserve">
     <value>导入</value>
   </data>
+  <data name="Personalize_ImportMenuRestore.Text" xml:space="preserve">
+    <value>恢复配置备份</value>
+  </data>
+  <data name="Personalize_ImportMenuClash.Text" xml:space="preserve">
+    <value>导入 Clash 配置</value>
+  </data>
+  <data name="Personalize_ClashImportSuccess" xml:space="preserve">
+    <value>Clash 配置导入成功</value>
+  </data>
+  <data name="Personalize_ClashImportSuccessMsg" xml:space="preserve">
+    <value>已导入 {0} 个节点，跳过 {1} 个不支持的节点。</value>
+  </data>
+  <data name="Personalize_ClashImportNoNodesTitle" xml:space="preserve">
+    <value>未导入任何节点</value>
+  </data>
+  <data name="Personalize_ClashImportNoNodesMsg" xml:space="preserve">
+    <value>该文件中没有可导入的节点（可能都是不支持的协议，或不是有效的 Clash 配置）。</value>
+  </data>
+  <data name="Personalize_ClashImportFailed" xml:space="preserve">
+    <value>Clash 配置导入失败</value>
+  </data>
   <data name="Personalize_ExportTooltip" xml:space="preserve">
     <value>导出预置配置</value>
   </data>

--- a/ViewModels/PersonalizeViewModel.cs
+++ b/ViewModels/PersonalizeViewModel.cs
@@ -152,6 +152,28 @@ namespace XrayUI.ViewModels
 
         public static bool PresetExists() => PresetImportService.PresetExists();
 
+        /// <summary>
+        /// Parses a Clash YAML config and appends its supported nodes to the saved server list
+        /// (pure append, no dedupe — same semantics as "import from link"). Reuses the
+        /// <see cref="PresetImported"/> reload path so the live list refreshes from disk.
+        /// Returns (imported, skipped). Throws on invalid YAML — the caller surfaces it.
+        /// </summary>
+        public async Task<(int Imported, int Skipped)> ImportClashConfigAsync(string yamlText)
+        {
+            var parsed = ClashConfigParser.Parse(yamlText);
+
+            if (parsed.Nodes.Count > 0)
+            {
+                // Imported nodes are manual entries (ServerEntry defaults SubscriptionId to "").
+                var servers = await _settings.LoadServersAsync();
+                servers.AddRange(parsed.Nodes);
+                await _settings.SaveServersAsync(servers);
+                PresetImported?.Invoke(this, EventArgs.Empty);
+            }
+
+            return (parsed.Nodes.Count, parsed.Skipped);
+        }
+
         public async Task<PresetImportResult?> ConfirmAndImportPresetAsync()
         {
             var confirmed = await _dialogs.ShowConfirmationAsync(

--- a/Views/PersonalizeControl.xaml
+++ b/Views/PersonalizeControl.xaml
@@ -585,11 +585,23 @@
                                     Padding="12,6"
                                     Content="导出"
                                     Click="ExportPresetButton_Click" />
-                            <Button x:Name="ImportPresetButton"
-                                    x:Uid="Personalize_ImportBtn"
-                                    Padding="12,6"
-                                    Content="导入"
-                                    Click="ImportPresetButton_Click" />
+                            <DropDownButton x:Name="ImportDropDownButton"
+                                            x:Uid="Personalize_ImportBtn"
+                                            Padding="12,6"
+                                            Content="导入">
+                                <DropDownButton.Flyout>
+                                    <MenuFlyout Placement="BottomEdgeAlignedLeft">
+                                        <MenuFlyoutItem x:Name="ImportPresetMenuItem"
+                                                        x:Uid="Personalize_ImportMenuRestore"
+                                                        Text="恢复配置备份"
+                                                        Click="ImportPresetButton_Click" />
+                                        <MenuFlyoutItem x:Name="ImportClashMenuItem"
+                                                        x:Uid="Personalize_ImportMenuClash"
+                                                        Text="导入 Clash 配置"
+                                                        Click="ImportClashConfig_Click" />
+                                    </MenuFlyout>
+                                </DropDownButton.Flyout>
+                            </DropDownButton>
                         </StackPanel>
                     </Grid>
                 </Border>

--- a/Views/PersonalizeControl.xaml.cs
+++ b/Views/PersonalizeControl.xaml.cs
@@ -1,5 +1,7 @@
 using System;
 using Microsoft.UI.Xaml.Automation;
+using Windows.Storage;
+using Windows.Storage.Pickers;
 using XrayUI.Helpers;
 using XrayUI.Services;
 
@@ -14,7 +16,7 @@ namespace XrayUI.Views
             this.InitializeComponent();
 
             AutomationProperties.SetName(ExportPresetButton, L.Personalize_ExportTooltip);
-            AutomationProperties.SetName(ImportPresetButton, L.Personalize_ImportTooltip);
+            AutomationProperties.SetName(ImportDropDownButton, L.Personalize_ImportTooltip);
         }
 
         private async void ExportPresetButton_Click(object sender, RoutedEventArgs e)
@@ -59,6 +61,45 @@ namespace XrayUI.Views
             catch (Exception ex)
             {
                 ShowInfo(InfoBarSeverity.Error, L.Personalize_ImportFailed, ex.Message);
+            }
+        }
+
+        private async void ImportClashConfig_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var picker = new FileOpenPicker
+                {
+                    SuggestedStartLocation = PickerLocationId.ComputerFolder,
+                };
+                picker.FileTypeFilter.Add(".yaml");
+                picker.FileTypeFilter.Add(".yml");
+
+                // Unpackaged app: the picker must be associated with the host window's HWND.
+                var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(ThemeHelper.MainWindow);
+                WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
+
+                var file = await picker.PickSingleFileAsync();
+                if (file is null) return;
+
+                var text = await FileIO.ReadTextAsync(file);
+                var (imported, skipped) = await ViewModel.ImportClashConfigAsync(text);
+
+                if (imported == 0)
+                {
+                    ShowInfo(InfoBarSeverity.Warning,
+                        L.Personalize_ClashImportNoNodesTitle,
+                        L.Personalize_ClashImportNoNodesMsg);
+                    return;
+                }
+
+                ShowInfo(InfoBarSeverity.Success,
+                    L.Personalize_ClashImportSuccess,
+                    Loc.Format("Personalize_ClashImportSuccessMsg", imported, skipped));
+            }
+            catch (Exception ex)
+            {
+                ShowInfo(InfoBarSeverity.Error, L.Personalize_ClashImportFailed, ex.Message);
             }
         }
 

--- a/XrayUI-dev.csproj
+++ b/XrayUI-dev.csproj
@@ -102,6 +102,9 @@
       <IncludeAssets>compile</IncludeAssets>
     </PackageReference>
     <PackageReference Include="WinUIEx" Version="2.9.1" />
+    <!-- Clash YAML import: parsed via YamlDotNet's reflection-free RepresentationModel
+         (YamlStream) only — never the typed Deserializer — to stay AOT/trim-safe. -->
+    <PackageReference Include="YamlDotNet" Version="18.0.0" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
## What

Adds **Import Clash Config** to the Personalize → data-management import dropdown: a file picker (`.yaml`/`.yml`) that parses a Clash / Clash.Meta config and **appends its supported nodes** to the server list.

## Why

Users on Clash-format airports had no way to bring their nodes into XrayUI without manually re-entering them. This imports the `proxies:` directly.

## How

- **`ClashConfigParser`** (new) parses the `proxies:` section via YamlDotNet's reflection-free `YamlStream` DOM — **never** the typed `Deserializer` — so it stays **AOT/trim-safe**. Field conventions mirror `NodeLinkParser`, so an imported node is indistinguishable from a link-imported one downstream (`XrayConfigBuilder`, etc.).
- Maps **ss / vmess / vless / trojan / hysteria2**. Protocols the Xray core can't run (`tuic`, `anytls`, `wireguard`, …) and transports `XrayConfigBuilder` can't build (`h2`/`http`/`kcp`/…) are **skipped and reported** ("imported N, skipped M").
- **grpc** service name is read from `grpc-opts.grpc-service-name` (not `ws-opts`) onto `ServerEntry.Path`, matching `XrayConfigBuilder.BuildStreamSettings`.
- **Pure append** (no dedupe, no overwrite) — same semantics as "import from link". Reuses the existing servers-reload path.
- Extracts `AddHysteria2SalamanderMask` from `NodeLinkParser` into `FinalmaskJson` so the URI parser and the Clash parser share the obfs logic.

## Scope note

**Routing rules and proxy-groups are intentionally not imported** (node-only). Clash routing (proxy-groups + remote rule-providers, incl. binary `.srs`/`.mrs`) doesn't map cleanly onto Xray's model, so importing it would be lossy and misleading. XrayUI's smart-mode default already covers the common case.

## Verification

- Debug build ✓
- Standalone parser tests ✓ — incl. grpc/h2 transports, and tricky real-world names (quoted names with colons, emoji/CJK, flow maps, nested `reality-opts`/`ws-opts`)
- Full **Native AOT publish** ✓ — YamlDotNet trims/AOT-compiles cleanly (compiled into the native exe)
- Manual E2E ✓ — imported real airport configs, nodes appear and connect

## Reviewer notes

- New dependency: **YamlDotNet 18.0.0** (DOM API only).
- No tests in this repo (per `CLAUDE.md`); verification was build + standalone harness + manual.