### PR TITLE
Add  region setting

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -9,6 +9,9 @@ namespace XrayUI.Models
         public int LocalMixedPort { get; set; } = 16890;
         /// <summary>"smart" | "global"</summary>
         public string RoutingMode { get; set; } = "smart";
+        /// <summary>Domestic region treated as direct in smart routing: "cn" | "ru" | "ir".
+        /// Maps to geosite/geoip tokens in <see cref="XrayUI.Services.XrayConfigBuilder"/>.</summary>
+        public string RoutingRegion { get; set; } = "cn";
         /// <summary>Whether TUN mode is enabled.</summary>
         public bool IsTunMode { get; set; } = false;
         public string? LastTunServerHost { get; set; }

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -711,8 +711,8 @@ namespace XrayUI.Services
         }
 
         /// <summary>
-        /// The default smart-mode routing object — proxy Google, direct geosite:cn / geoip:cn,
-        /// fallback everything else to proxy. Returned as a fresh JsonObject so callers can
+        /// The default smart-mode routing object — proxy Google, direct domestic geosite/geoip
+        /// (per settings.RoutingRegion), fallback everything else to proxy. Returned as a fresh JsonObject so callers can
         /// either inject it into the live xray config or persist it as the seed of
         /// settings.AdvancedRouting (the "advanced editor" template).
         /// </summary>
@@ -726,17 +726,18 @@ namespace XrayUI.Services
                 ["outboundTag"] = ProxyOutboundTag,
                 ["domain"] = CreateStringArray("geosite:google")
             });
+            var (geositeDomestic, geoipDomestic) = RegionGeoTokens(settings.RoutingRegion);
             AddNode(rules, new JsonObject
             {
                 ["type"] = "field",
                 ["outboundTag"] = DirectOutboundTag,
-                ["domain"] = CreateStringArray("geosite:cn", "geosite:private")
+                ["domain"] = CreateStringArray(geositeDomestic, "geosite:private")
             });
             AddNode(rules, new JsonObject
             {
                 ["type"] = "field",
                 ["outboundTag"] = DirectOutboundTag,
-                ["ip"] = CreateStringArray("geoip:cn", "geoip:private")
+                ["ip"] = CreateStringArray(geoipDomestic, "geoip:private")
             });
             if (includeFallback)
             {
@@ -760,6 +761,30 @@ namespace XrayUI.Services
             });
         }
 
+        /// <summary>
+        /// Maps a routing region code to its domestic geosite/geoip tokens. "cn" (default) uses
+        /// geosite:cn / geoip:cn; "ru"/"ir" use geosite:category-ru|ir + geoip:ru|ir — the shipped
+        /// geosite.dat (Loyalsoldier) has no bare geosite:ru / geosite:ir, only the category-* lists.
+        /// </summary>
+        private static (string geosite, string geoip) RegionGeoTokens(string? region) => region switch
+        {
+            "ru" => ("geosite:category-ru", "geoip:ru"),
+            "ir" => ("geosite:category-ir", "geoip:ir"),
+            _    => ("geosite:cn", "geoip:cn"),
+        };
+
+        /// <summary>
+        /// Default "direct" DNS resolver for the selected region, used only when the user hasn't set
+        /// <see cref="AppSettings.DirectDnsServer"/>. CN keeps the existing fast domestic resolvers;
+        /// RU/IR use well-known in-country public resolvers (Yandex / Shecan).
+        /// </summary>
+        private static string DefaultDirectDns(string? region, bool tunMode) => region switch
+        {
+            "ru" => "77.88.8.8",
+            "ir" => "178.22.122.100",
+            _    => tunMode ? "223.5.5.5" : "114.114.114.114",
+        };
+
         private static JsonObject CustomRuleToJsonObject(CustomRoutingRule rule)
         {
             var node = new JsonObject
@@ -778,14 +803,15 @@ namespace XrayUI.Services
 
         private static JsonObject BuildDns(AppSettings settings)
         {
+            var (geositeDomestic, _) = RegionGeoTokens(settings.RoutingRegion);
             var directDns = settings.DirectDnsServer
-                ?? (settings.IsTunMode ? "223.5.5.5" : "114.114.114.114");
+                ?? DefaultDirectDns(settings.RoutingRegion, settings.IsTunMode);
             var proxyDns = settings.ProxyDnsServer ?? "8.8.8.8";
 
             var directEntry = new JsonObject
             {
                 ["address"]      = directDns,
-                ["domains"]      = CreateStringArray("geosite:cn", "geosite:private"),
+                ["domains"]      = CreateStringArray(geositeDomestic, "geosite:private"),
                 ["skipFallback"] = true,
             };
 

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -716,7 +716,7 @@
     <value>Routing:</value>
   </data>
   <data name="Personalize_LanguageLbl.Text" xml:space="preserve">
-    <value>Language</value>
+    <value>Language &amp; Region</value>
   </data>
   <data name="ServerList_HeaderText.Text" xml:space="preserve">
     <value>Server List</value>
@@ -845,7 +845,7 @@
     <value>Add</value>
   </data>
   <data name="CustomRules_NotEffectiveText.Text" xml:space="preserve">
-    <value>Global routing is active — custom rules are not in effect. They will apply when switching back to Smart Routing.</value>
+    <value>Global routing is active. Custom rules apply only in Smart Routing.</value>
   </data>
   <data name="CustomRules_SaveBtn.Content" xml:space="preserve">
     <value>Save</value>
@@ -938,7 +938,7 @@
     <value>Choose interface language</value>
   </data>
   <data name="Personalize_LangRestartBar.Title" xml:space="preserve">
-    <value>Restart XrayUI to apply  language changes</value>
+    <value>Restart XrayUI to apply changes</value>
   </data>
   <data name="Personalize_LangRestartBtn.Content" xml:space="preserve">
     <value>Restart</value>
@@ -1187,5 +1187,20 @@ Path: {0}</value>
   </data>
   <data name="ServerList_TestModeReal.Text" xml:space="preserve">
     <value>Test real delay</value>
+  </data>
+  <data name="Personalize_RoutingRegionTitle.Text" xml:space="preserve">
+    <value>Region</value>
+  </data>
+  <data name="Personalize_Region_CN.Content" xml:space="preserve">
+    <value>China</value>
+  </data>
+  <data name="Personalize_Region_RU.Content" xml:space="preserve">
+    <value>Russia</value>
+  </data>
+  <data name="Personalize_Region_IR.Content" xml:space="preserve">
+    <value>Iran</value>
+  </data>
+  <data name="Personalize_RoutingRegionDesc.Text" xml:space="preserve">
+    <value>Region routed setting</value>
   </data>
 </root>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -716,7 +716,7 @@
     <value>路由:</value>
   </data>
   <data name="Personalize_LanguageLbl.Text" xml:space="preserve">
-    <value>语言</value>
+    <value>语言和区域</value>
   </data>
   <data name="ServerList_HeaderText.Text" xml:space="preserve">
     <value>服务器列表</value>
@@ -938,7 +938,7 @@
     <value>选择应用界面的显示语言</value>
   </data>
   <data name="Personalize_LangRestartBar.Title" xml:space="preserve">
-    <value>重启应用以应用语言更改</value>
+    <value>重启应用以应用更改</value>
   </data>
   <data name="Personalize_LangRestartBtn.Content" xml:space="preserve">
     <value>重启</value>
@@ -1187,5 +1187,20 @@
   </data>
   <data name="ServerList_TestModeReal.Text" xml:space="preserve">
     <value>真连接测试</value>
+  </data>
+  <data name="Personalize_RoutingRegionTitle.Text" xml:space="preserve">
+    <value>区域设置</value>
+  </data>
+  <data name="Personalize_Region_CN.Content" xml:space="preserve">
+    <value>中国</value>
+  </data>
+  <data name="Personalize_Region_RU.Content" xml:space="preserve">
+    <value>俄罗斯</value>
+  </data>
+  <data name="Personalize_Region_IR.Content" xml:space="preserve">
+    <value>伊朗</value>
+  </data>
+  <data name="Personalize_RoutingRegionDesc.Text" xml:space="preserve">
+    <value>选择智能路由的国家或地区</value>
   </data>
 </root>

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -113,6 +113,7 @@ namespace XrayUI.ViewModels
             ControlPanel.InitializePersonalize(s);
             Personalize.LoadDisplayOptions(s);
             Personalize.LoadLanguage(s);
+            Personalize.LoadRegion(s);
             ServerDetail.ShowLatencyInDetails = s.ShowLatencyInDetails;
             ServerDetail.ShowAiUnlockInDetails = s.ShowAiUnlockInDetails;
 

--- a/ViewModels/PersonalizeViewModel.cs
+++ b/ViewModels/PersonalizeViewModel.cs
@@ -14,6 +14,8 @@ namespace XrayUI.ViewModels
 
         private int _initialLanguageIndex = -1;
         private bool _suppressLanguageRestartHint;
+        private int _initialRegionIndex = -1;
+        private bool _suppressRegionRestartHint;
 
         public event EventHandler? CloseRequested;
         public event EventHandler? PresetImported;
@@ -110,22 +112,51 @@ namespace XrayUI.ViewModels
 
         partial void OnSelectedLanguageIndexChanged(int value)
         {
-            // Hint visibility tracks divergence from the loaded value, not whether the
-                // user touched the dropdown" — flipping back to the initial choice means
-            // no restart is needed, so the hint should disappear too.
-            if (!_suppressLanguageRestartHint && _initialLanguageIndex >= 0)
-                ShowLanguageRestartHint = value != _initialLanguageIndex;
+            // Hint visibility tracks divergence from the loaded value, not whether the user
+            // touched the dropdown — flipping back to the initial choice clears the hint too.
+            if (!_suppressLanguageRestartHint)
+                UpdateRestartHint();
         }
 
-        [ObservableProperty]
-        public partial bool ShowLanguageRestartHint { get; set; }
+        // ── Region (domestic region for smart routing) ─────────────────────────
+        // Lives under the Application-language expander. Like language, it only takes effect
+        // on the next process start, so it shares the restart hint below.
 
-        /// <summary>Persist the currently-selected language. Call right before <see cref="App.Restart"/>.</summary>
-        public async Task ApplyLanguageAsync()
+        /// <summary>Region codes, in the same order as the region ComboBox items in PersonalizeControl.xaml.</summary>
+        private static readonly string[] RegionCodes = { "cn", "ru", "ir" };
+
+        [ObservableProperty]
+        public partial int SelectedRegionIndex { get; set; }
+
+        partial void OnSelectedRegionIndexChanged(int value)
         {
-            var tag = LanguageHelper.TagAt(SelectedLanguageIndex);
+            if (!_suppressRegionRestartHint)
+                UpdateRestartHint();
+        }
+
+        /// <summary>Selected region code, clamped to a valid entry; persisted to <see cref="AppSettings.RoutingRegion"/>.</summary>
+        private string SelectedRegionCode =>
+            (uint)SelectedRegionIndex < (uint)RegionCodes.Length ? RegionCodes[SelectedRegionIndex] : RegionCodes[0];
+
+        /// <summary>True when language or region diverges from the loaded baseline — both apply
+        /// only after a process restart, so the InfoBar offers one.</summary>
+        [ObservableProperty]
+        public partial bool ShowRestartHint { get; set; }
+
+        private void UpdateRestartHint()
+        {
+            var langDiverged   = _initialLanguageIndex >= 0 && SelectedLanguageIndex != _initialLanguageIndex;
+            var regionDiverged = _initialRegionIndex   >= 0 && SelectedRegionIndex   != _initialRegionIndex;
+            ShowRestartHint = langDiverged || regionDiverged;
+        }
+
+        /// <summary>Persist the currently-selected language and routing region. Call right before
+        /// <see cref="App.Restart"/> — both only take effect on the next process start.</summary>
+        public async Task ApplyPendingChangesAsync()
+        {
             var s = await _settings.LoadSettingsAsync();
-            s.Language = tag;
+            s.Language = LanguageHelper.TagAt(SelectedLanguageIndex);
+            s.RoutingRegion = SelectedRegionCode;
             await _settings.SaveSettingsAsync(s);
         }
 
@@ -204,10 +235,11 @@ namespace XrayUI.ViewModels
             s.BackdropSetting = ThemeHelper.CurrentBackdrop;
             s.ShowLatencyInDetails = ShowLatencyInDetails;
             s.ShowAiUnlockInDetails = ShowAiUnlockInDetails;
-            // Language doesn't take effect until the next process start, but Done still
-            // persists it — otherwise the user would have to click the restart hint to
-            // save at all, which is surprising compared to how Theme / Backdrop behave.
+            // Language and region don't take effect until the next process start, but Done
+            // still persists them — otherwise the user would have to click the restart hint
+            // to save at all, which is surprising compared to how Theme / Backdrop behave.
             s.Language = LanguageHelper.TagAt(SelectedLanguageIndex);
+            s.RoutingRegion = SelectedRegionCode;
             await _settings.SaveSettingsAsync(s);
             CloseRequested?.Invoke(this, EventArgs.Empty);
         }
@@ -247,6 +279,18 @@ namespace XrayUI.ViewModels
             SelectedLanguageIndex = index;
             _suppressLanguageRestartHint = false;
             _initialLanguageIndex = index;
+        }
+
+        public void LoadRegion(AppSettings settings)
+        {
+            // Mirror LoadLanguage: assign suppressed, then record the baseline so the restart
+            // hint tracks divergence-from-baseline rather than "user touched the dropdown".
+            var index = Array.IndexOf(RegionCodes, settings.RoutingRegion);
+            if (index < 0) index = 0;
+            _suppressRegionRestartHint = true;
+            SelectedRegionIndex = index;
+            _suppressRegionRestartHint = false;
+            _initialRegionIndex = index;
         }
     }
 }

--- a/Views/LogWindow.xaml.cs
+++ b/Views/LogWindow.xaml.cs
@@ -1,8 +1,9 @@
+﻿using Microsoft.UI.Dispatching;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml.Media;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.UI.Dispatching;
-using Microsoft.UI.Xaml.Media;
 using Windows.ApplicationModel.DataTransfer;
 using WinUIEx;
 using XrayUI.Helpers;
@@ -45,8 +46,9 @@ namespace XrayUI.Views
 
             this.SetWindowSize(900, 600);
             AppWindow.Title = L.Log_Title;
+			AppWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
 
-            ToolTipService.SetToolTip(LogPrivacyButton, L.Log_PrivacyTooltip);
+			ToolTipService.SetToolTip(LogPrivacyButton, L.Log_PrivacyTooltip);
             MaskAddressSubMenu.Text = L.Log_IpMask;
             MaskOffMenuItem.Text    = L.Log_MaskOff;
             AutoScrollToggle.Content = L.Log_AutoScroll;

--- a/Views/PersonalizeControl.xaml
+++ b/Views/PersonalizeControl.xaml
@@ -78,61 +78,97 @@
                     <ComboBoxItem x:Uid="Personalize_Acrylic" Content="亚克力" />
                 </ComboBox>
             </StackPanel>
-            <!-- ── Language ────────────────────────────────────────────────── -->
+            <!-- ── Language & Region ───────────────────────────────────────── -->
             <StackPanel Spacing="10">
                 <TextBlock x:Uid="Personalize_LanguageLbl"
-                           Text="语言"
+                           Text="语言和区域"
                            FontSize="15"
                            FontWeight="SemiBold" />
 
-                <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
-                        BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
-                        BorderThickness="1"
-                        CornerRadius="{ThemeResource OverlayCornerRadius}">
-                    <Grid Padding="16,13"
-                          ColumnSpacing="12">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
+                <Expander HorizontalAlignment="Stretch"
+                          HorizontalContentAlignment="Stretch"
+                          CornerRadius="{ThemeResource OverlayCornerRadius}"
+                          Background="{ThemeResource LayerFillColorDefaultBrush}"
+                          BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}">
+                    <Expander.Header>
+                        <!-- Application language -->
+                        <Grid Padding="0,12"
+                              ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
 
-                        <FontIcon Grid.Column="0"
-                                  Glyph="&#xF2B7;"
-                                  FontSize="16"
-                                  VerticalAlignment="Center"
-                                  Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            <FontIcon Grid.Column="0"
+                                      Glyph="&#xF2B7;"
+                                      FontSize="16"
+                                      VerticalAlignment="Center"
+                                      Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
 
-                        <StackPanel Grid.Column="1"
-                                    VerticalAlignment="Center"
-                                    Spacing="2">
-                            <TextBlock x:Uid="Personalize_AppLanguageTitle"
-                                       Text="应用语言"
-                                       FontSize="14" />
-                            <TextBlock x:Uid="Personalize_AppLanguageDesc"
-                                       Text="选择应用界面的显示语言"
-                                       FontSize="12"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        </StackPanel>
+                            <StackPanel Grid.Column="1"
+                                        VerticalAlignment="Center"
+                                        Spacing="2">
+                                <TextBlock x:Uid="Personalize_AppLanguageTitle"
+                                           Text="应用语言"
+                                           FontSize="14" />
+                                <TextBlock x:Uid="Personalize_AppLanguageDesc"
+                                           Text="选择应用界面的显示语言"
+                                           FontSize="12"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
 
-                        <ComboBox Grid.Column="2"
-                                  MinWidth="160"
-                                  VerticalAlignment="Center"
-                                  ItemsSource="{x:Bind ViewModel.SupportedLanguages, Mode=OneTime}"
-                                  SelectedIndex="{x:Bind ViewModel.SelectedLanguageIndex, Mode=TwoWay}">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate x:DataType="helpers:LanguageInfo">
-                                    <TextBlock Text="{x:Bind DisplayName}" />
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
-                    </Grid>
-                </Border>
+                            <ComboBox Grid.Column="2"
+                                      MinWidth="130"
+                                      Margin="0,0,-18,0"
+                                      VerticalAlignment="Center"
+                                      ItemsSource="{x:Bind ViewModel.SupportedLanguages, Mode=OneTime}"
+                                      SelectedIndex="{x:Bind ViewModel.SelectedLanguageIndex, Mode=TwoWay}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate x:DataType="helpers:LanguageInfo">
+                                        <TextBlock Text="{x:Bind DisplayName}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </Grid>
+                    </Expander.Header>
+
+                    <!-- Region (domestic region for smart routing) -->
+                    <StackPanel Margin="-16,-12,-16,-12">
+                        <Grid Padding="42,12,16,12"
+                              ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Column="0"
+                                        VerticalAlignment="Center"
+                                        Spacing="2">
+                                <TextBlock x:Uid="Personalize_RoutingRegionTitle"
+                                           Text="区域设置"
+                                           FontSize="14" />
+                                <TextBlock x:Uid="Personalize_RoutingRegionDesc"
+                                           Text="选择直连的国家或地区"
+                                           FontSize="12"
+                                           TextWrapping="Wrap"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                            <ComboBox Grid.Column="1"
+                                      MinWidth="130"
+                                      VerticalAlignment="Center"
+                                      SelectedIndex="{x:Bind ViewModel.SelectedRegionIndex, Mode=TwoWay}">
+                                <ComboBoxItem x:Uid="Personalize_Region_CN" Content="中国" />
+                                <ComboBoxItem x:Uid="Personalize_Region_RU" Content="俄罗斯" />
+                                <ComboBoxItem x:Uid="Personalize_Region_IR" Content="伊朗" />
+                            </ComboBox>
+                        </Grid>
+                    </StackPanel>
+                </Expander>
 
                 <InfoBar x:Uid="Personalize_LangRestartBar"
-                         IsOpen="{x:Bind ViewModel.ShowLanguageRestartHint, Mode=TwoWay}"
+                         IsOpen="{x:Bind ViewModel.ShowRestartHint, Mode=TwoWay}"
                          Severity="Informational"
-                         Title="重启应用以应用语言更改"
+                         Title="重启应用以应用更改"
                          IsClosable="False">
                     <InfoBar.ActionButton>
                         <Button x:Uid="Personalize_LangRestartBtn"

--- a/Views/PersonalizeControl.xaml.cs
+++ b/Views/PersonalizeControl.xaml.cs
@@ -113,7 +113,7 @@ namespace XrayUI.Views
 
         private async void LanguageRestartButton_Click(object sender, RoutedEventArgs e)
         {
-            await ViewModel.ApplyLanguageAsync();
+            await ViewModel.ApplyPendingChangesAsync();
             App.Restart();
         }
     }


### PR DESCRIPTION
﻿## Summary

- Add a persisted routing region setting for smart routing
- Use region-specific geosite/geoip tokens and default direct DNS
- Add Personalize UI and localized strings for selecting the domestic routing region

## Impact

Users can choose CN, RU, or IR as the direct domestic region used by smart routing. The setting is saved with the rest of personalization and takes effect after restart alongside language changes.

## Validation

- dotnet build XrayUI-dev.slnx --no-restore
