### PR TITLE
feat(ui): animate main↔mini window-mode transition

### DIFF
--- a/Helpers/WindowModeTransition.cs
+++ b/Helpers/WindowModeTransition.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Hosting;
+
+namespace XrayUI.Helpers
+{
+    /// <summary>
+    /// Composition-driven cross-fade for the main↔mini window-mode switch.
+    ///
+    /// The outgoing panel just snaps away (so the click stays
+    /// as responsive as a plain switch); the incoming panel scales + fades in as a
+    /// short, non-blocking entrance flourish.
+    ///
+    /// The animation runs on the Composition (render) thread, so it stays smooth
+    /// even while the UI thread is busy resizing.
+    /// </summary>
+    internal static class WindowModeTransition
+    {
+
+        private const float ShrunkScale = 0.90f;
+
+
+        private static readonly TimeSpan InDuration = TimeSpan.FromMilliseconds(160);
+
+        /// <summary>
+        /// Stage a panel in its hidden (invisible + shrunk) state synchronously, so it
+        /// doesn't flash at full opacity when its bound Visibility flips to Visible.
+        /// </summary>
+        public static void PrepareHidden(FrameworkElement element)
+        {
+            var visual = ElementCompositionPreview.GetElementVisual(element);
+            visual.Opacity = 0f;
+            visual.Scale = new Vector3(ShrunkScale, ShrunkScale, 1f);
+        }
+
+        /// <summary>
+        /// Fade + scale the newly visible panel up to its resting state. Fire-and-forget:
+        /// the animation lives on the render thread, and nothing awaits its completion, so
+        /// there's no Task/ScopedBatch plumbing to signal one.
+        /// </summary>
+        public static void FadeIn(FrameworkElement element)
+        {
+            // The window just resized; force a layout pass so CenterPoint uses the
+            // panel's new size rather than the stale pre-resize one.
+            element.UpdateLayout();
+
+            var visual = ElementCompositionPreview.GetElementVisual(element);
+            var compositor = visual.Compositor;
+
+            // Pivot the scale around the panel's center, not its top-left corner.
+            visual.CenterPoint = new Vector3(
+                (float)(element.ActualWidth  / 2),
+                (float)(element.ActualHeight / 2),
+                0f);
+
+            // Ease-out (Fluent "Decelerate"): arrive fast, settle softly.
+            var ease = compositor.CreateCubicBezierEasingFunction(new Vector2(0.1f, 0.9f), new Vector2(0.2f, 1.0f));
+
+            var fade = compositor.CreateScalarKeyFrameAnimation();
+            fade.InsertKeyFrame(1f, 1f, ease);
+            fade.Duration = InDuration;
+
+            var scale = compositor.CreateVector3KeyFrameAnimation();
+            scale.InsertKeyFrame(1f, Vector3.One, ease);
+            scale.Duration = InDuration;
+
+            visual.StartAnimation("Opacity", fade);
+            visual.StartAnimation("Scale", scale);
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -60,7 +60,8 @@
         </Grid>
 
         <!-- Mini mode compact panel -->
-        <Grid Grid.Row="1"
+        <Grid x:Name="MiniModePanel"
+              Grid.Row="1"
               Visibility="{x:Bind ViewModel.MiniModeVisibility, Mode=OneWay}"
               Margin="16,0,16,0">
             <!-- Mini content: tighten vertical rhythm to match the mockup -->
@@ -157,7 +158,8 @@
             </Grid>
         </Grid>
 
-        <Grid Grid.Row="1"
+        <Grid x:Name="FullModePanel"
+              Grid.Row="1"
               Visibility="{x:Bind ViewModel.FullModeVisibility, Mode=OneWay}"
               Margin="16,0,16,16"
               ColumnSpacing="16">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -272,8 +272,19 @@ namespace XrayUI
 
         private void SetMiniMode(bool isMini)
         {
+            if (ViewModel.IsMiniMode == isMini) return;
+
+            var incoming = isMini ? MiniModePanel : FullModePanel;
+
+            // Snap to the new mode immediately so the click feels as instant as it
+            // did before — no blocking fade-out. The only animation is a quick
+            // entrance on the new content: stage it hidden so it doesn't flash when
+            // its bound Visibility flips, switch modes + resize the HWND, then let
+            // the new panel scale/fade in as a non-blocking flourish.
+            WindowModeTransition.PrepareHidden(incoming);
             ViewModel.IsMiniMode = isMini;
             ApplyWindowMode(isMini);
+            WindowModeTransition.FadeIn(incoming);
         }
 
         private void ApplyWindowMode(bool isMini)


### PR DESCRIPTION
## What

Adds a lightweight entrance animation to the main ↔ mini window-mode switch. Previously the toggle was an instant HWND resize with no motion.

The click still **snaps to the new mode immediately** — the window resize stays instant. Only the *incoming* content panel scales + fades in as a short, non-blocking flourish, so the eye reads the hidden resize snap as a smooth grow.

## Why

WinUI 3 can't smoothly animate the real HWND size (especially under a Mica backdrop — per-frame resize tears/flickers). So instead of animating the window, we animate only the content around the instant resize. An earlier sequential cross-fade (fade-out → resize → fade-in) felt sluggish because it *blocked* on the old content leaving; this version is entrance-only, so responsiveness matches the pre-animation behavior.

## How

- **`Helpers/WindowModeTransition.cs`** (new) — Composition helper:
  - `PrepareHidden()` stages the incoming panel invisible + slightly shrunk so it doesn't flash at full opacity when its bound `Visibility` flips to `Visible`.
  - `FadeIn()` runs an opacity + scale entrance on the Composition (render) thread — fire-and-forget, Fluent "Decelerate" easing `cubic-bezier(0.1, 0.9, 0.2, 1.0)`, 160 ms.
- **`MainWindow.SetMiniMode`** — sequence: stage incoming hidden → flip `IsMiniMode` + `ApplyWindowMode` (instant resize) → fade the new panel in. Early-returns on a no-op toggle.
- **`MainWindow.xaml`** — `x:Name` on the two Row-1 panels (`MiniModePanel` / `FullModePanel`) so code-behind can reach their visuals.

## Reviewer notes

- Fire-and-forget by design: nothing awaits the entrance, so there's no `Task`/`ScopedBatch` plumbing.
- The entrance staging hooks the single `SetMiniMode` call site (today the only writer of `IsMiniMode`). If a future second writer sets `IsMiniMode` directly (hotkey, settings-restore), route it through `SetMiniMode` or it'll bypass the staging.
- Tuning knobs live at the top of `WindowModeTransition.cs`: `ShrunkScale` (0.90) and `InDuration` (160 ms).
- Verified: Debug build via `BuildAndRun.ps1` succeeds; toggled mini ↔ full in both directions.
