### PR TITLE
feat(theme): make Log/CustomRules windows follow app theme live

### DIFF
--- a/Helpers/ThemeHelper.cs
+++ b/Helpers/ThemeHelper.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Media;
 
 namespace XrayUI.Helpers
@@ -17,6 +19,7 @@ namespace XrayUI.Helpers
         // allocate a fresh DComp controller each time.
         private static MicaBackdrop? _micaBackdrop;
         private static DesktopAcrylicBackdrop? _acrylicBackdrop;
+        private static readonly List<(Window Window, FrameworkElement RootElement)> _themeAwareWindows = new();
 
         /// <summary>Actual resolved theme (Light or Dark) based on current setting.</summary>
         public static ElementTheme ActualTheme
@@ -27,6 +30,37 @@ namespace XrayUI.Helpers
             _currentTheme = theme;
             if (RootElement != null)
                 RootElement.RequestedTheme = theme;
+
+            foreach (var registration in _themeAwareWindows.ToArray())
+            {
+                registration.RootElement.RequestedTheme = theme;
+                ApplyTitleBarTheme(registration.Window, registration.RootElement);
+            }
+        }
+
+        public static void RegisterThemeAwareWindow(Window window)
+        {
+            var rootElement = (FrameworkElement)window.Content;
+            var registration = (window, rootElement);
+            _themeAwareWindows.Add(registration);
+
+            rootElement.RequestedTheme = _currentTheme;
+            ApplyTitleBarTheme(window, rootElement);
+
+            rootElement.ActualThemeChanged += OnActualThemeChanged;
+            window.Closed += OnClosed;
+
+            void OnActualThemeChanged(FrameworkElement sender, object args)
+            {
+                ApplyTitleBarTheme(window, rootElement);
+            }
+
+            void OnClosed(object sender, WindowEventArgs args)
+            {
+                rootElement.ActualThemeChanged -= OnActualThemeChanged;
+                window.Closed -= OnClosed;
+                _themeAwareWindows.Remove(registration);
+            }
         }
 
         public static void ApplyBackdrop(string backdrop)
@@ -40,6 +74,16 @@ namespace XrayUI.Helpers
                 _         => _micaBackdrop ??= new MicaBackdrop(),
             };
             _currentBackdrop = backdrop;
+        }
+
+        private static void ApplyTitleBarTheme(Window window, FrameworkElement rootElement)
+        {
+            window.AppWindow.TitleBar.PreferredTheme = rootElement.ActualTheme switch
+            {
+                ElementTheme.Light => TitleBarTheme.Light,
+                ElementTheme.Dark  => TitleBarTheme.Dark,
+                _                  => TitleBarTheme.UseDefaultAppMode
+            };
         }
     }
 }

--- a/Views/CustomRulesWindow.xaml.cs
+++ b/Views/CustomRulesWindow.xaml.cs
@@ -27,11 +27,12 @@ namespace XrayUI.Views
         {
             ViewModel = viewModel;
             this.InitializeComponent();
+            ThemeHelper.RegisterThemeAwareWindow(this);
+
             _owner = owner;
 
             this.SetWindowSize(620, 460);
             AppWindow.Title = L.CustomRules_Title;
-			AppWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
 
             ToolTipService.SetToolTip(OpenAdvancedEditorButton, L.CustomRules_AdvancedEditorTooltip);
             ToolTipService.SetToolTip(UpdateGeoButton,          L.CustomRules_UpdateGeoTooltip);

--- a/Views/LogWindow.xaml.cs
+++ b/Views/LogWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.UI.Dispatching;
-using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Media;
 using System;
 using System.Threading;
@@ -39,6 +38,8 @@ namespace XrayUI.Views
             Func<Task> reapplyConfigAsync)
         {
             this.InitializeComponent();
+            ThemeHelper.RegisterThemeAwareWindow(this);
+
             _xray               = xray;
             _settings           = settings;
             _reapplyConfigAsync = reapplyConfigAsync;
@@ -46,8 +47,6 @@ namespace XrayUI.Views
 
             this.SetWindowSize(900, 600);
             AppWindow.Title = L.Log_Title;
-			AppWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
-
 			ToolTipService.SetToolTip(LogPrivacyButton, L.Log_PrivacyTooltip);
             MaskAddressSubMenu.Text = L.Log_IpMask;
             MaskOffMenuItem.Text    = L.Log_MaskOff;


### PR DESCRIPTION
## What

Secondary windows (`LogWindow`, `CustomRulesWindow`) now follow the global app theme instead of hardcoding `TitleBarTheme.UseDefaultAppMode`. A small registry in `ThemeHelper` keeps each registered window's `RequestedTheme` and system title bar in sync with the app theme, and reacts to OS light/dark switches while the app is in follow-system mode (`ElementTheme.Default`).

## Why

Previously these windows never tracked the app theme — their title bars could mismatch the rest of the UI after a theme change. They each hardcoded the title-bar theme and had no link to `ThemeHelper`.

## How

- `ThemeHelper.RegisterThemeAwareWindow(window)` adds the window to a `List<(Window, FrameworkElement)>` registry, applies the current theme + title bar immediately, and wires `ActualThemeChanged` (for live OS theme switches) and `Window.Closed` (deterministic unsubscribe + removal).
- `ApplyTheme` pushes the new theme to every registered window's `RequestedTheme` and refreshes its title bar.
- Each window registers with a single line in its constructor (`ThemeHelper.RegisterThemeAwareWindow(this)`); the API derives the root element from `window.Content` itself.

## Reviewer notes

- The `ActualThemeChanged` subscription is intentional and load-bearing: in follow-system mode `ApplyTheme` is never re-invoked on an OS light/dark toggle, so this is the only signal that refreshes the title bar. It mirrors how `MainWindow` already reacts to `ActualThemeChanged`.
- `MainWindow` is deliberately **not** routed through this registry — it extends into the title bar and drives per-caption-button colors rather than `PreferredTheme`, a genuinely different mechanism.
