### PR TITLE
feat(ui): secondary windows follow app light/dark theme

### DIFF
--- a/Helpers/ThemeHelper.cs
+++ b/Helpers/ThemeHelper.cs
@@ -1,3 +1,5 @@
+using System;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Media;
 
 namespace XrayUI.Helpers
@@ -9,6 +11,8 @@ namespace XrayUI.Helpers
 
         private static ElementTheme _currentTheme = ElementTheme.Default;
         public static ElementTheme CurrentTheme => _currentTheme;
+
+        private static event Action<ElementTheme>? ThemeChanged;
 
         private static string _currentBackdrop = "Mica";
         public static string CurrentBackdrop => _currentBackdrop;
@@ -27,6 +31,39 @@ namespace XrayUI.Helpers
             _currentTheme = theme;
             if (RootElement != null)
                 RootElement.RequestedTheme = theme;
+
+            ThemeChanged?.Invoke(theme);
+        }
+
+        public static void ApplyTitleBarTheme(Window window, ElementTheme theme)
+        {
+            window.AppWindow.TitleBar.PreferredTheme = theme switch
+            {
+                ElementTheme.Light => TitleBarTheme.Light,
+                ElementTheme.Dark  => TitleBarTheme.Dark,
+                _                  => TitleBarTheme.UseDefaultAppMode,
+            };
+        }
+
+        /// <summary>
+        /// Makes a secondary window follow the app's light/dark theme: seeds the
+        /// initial theme on <paramref name="root"/> and the title bar, then keeps
+        /// both in sync until the window closes (self-unsubscribes on Closed).
+        /// Backdrop is intentionally left to each window (fixed Mica in XAML).
+        /// </summary>
+        public static void FollowAppTheme(Window window, FrameworkElement root)
+        {
+            root.RequestedTheme = _currentTheme;
+            ApplyTitleBarTheme(window, _currentTheme);
+
+            void OnChanged(ElementTheme theme)
+            {
+                root.RequestedTheme = theme;
+                ApplyTitleBarTheme(window, theme);
+            }
+
+            ThemeChanged += OnChanged;
+            window.Closed += (_, _) => ThemeChanged -= OnChanged;
         }
 
         public static void ApplyBackdrop(string backdrop)

--- a/Views/CustomRulesWindow.xaml
+++ b/Views/CustomRulesWindow.xaml
@@ -13,7 +13,7 @@
         <MicaBackdrop />
     </Window.SystemBackdrop>
 
-    <Grid>
+    <Grid x:Name="WindowRoot">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />

--- a/Views/CustomRulesWindow.xaml.cs
+++ b/Views/CustomRulesWindow.xaml.cs
@@ -31,7 +31,7 @@ namespace XrayUI.Views
 
             this.SetWindowSize(620, 460);
             AppWindow.Title = L.CustomRules_Title;
-			AppWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
+            ThemeHelper.FollowAppTheme(this, WindowRoot);
 
             ToolTipService.SetToolTip(OpenAdvancedEditorButton, L.CustomRules_AdvancedEditorTooltip);
             ToolTipService.SetToolTip(UpdateGeoButton,          L.CustomRules_UpdateGeoTooltip);

--- a/Views/LogWindow.xaml
+++ b/Views/LogWindow.xaml
@@ -12,7 +12,7 @@
         <MicaBackdrop />
     </Window.SystemBackdrop>
 
-    <Grid RowSpacing="0">
+    <Grid x:Name="WindowRoot" RowSpacing="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />

--- a/Views/LogWindow.xaml.cs
+++ b/Views/LogWindow.xaml.cs
@@ -46,7 +46,7 @@ namespace XrayUI.Views
 
             this.SetWindowSize(900, 600);
             AppWindow.Title = L.Log_Title;
-			AppWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
+            ThemeHelper.FollowAppTheme(this, WindowRoot);
 
 			ToolTipService.SetToolTip(LogPrivacyButton, L.Log_PrivacyTooltip);
             MaskAddressSubMenu.Text = L.Log_IpMask;
@@ -68,15 +68,17 @@ namespace XrayUI.Views
             _flushTimer.Tick += OnFlushTick;
             _flushTimer.Start();
 
-            this.Closed += (_, _) =>
-            {
-                _flushTimer.Stop();
-                _xray.LogReceived    -= OnLogReceived;
-                _xray.RunningChanged -= OnRunningChanged;
-            };
+            this.Closed += OnClosed;
         }
 
         // ── Event handlers ─────────────────────────────────────────────────────
+
+        private void OnClosed(object sender, WindowEventArgs args)
+        {
+            _flushTimer.Stop();
+            _xray.LogReceived    -= OnLogReceived;
+            _xray.RunningChanged -= OnRunningChanged;
+        }
 
         private void OnLogReceived(object? sender, string line)
         {


### PR DESCRIPTION
## What

The **Log** and **Custom Rules** windows now follow the app's light/dark theme at runtime — both the content (window root `RequestedTheme`) and the title bar. Their backdrop stays fixed to **Mica**, per the secondary-window convention (material is hardcoded in XAML; only light/dark is followed).

## How

All the per-window theme wiring is consolidated into one helper:

```csharp
ThemeHelper.FollowAppTheme(this, WindowRoot);
```

`FollowAppTheme(Window, FrameworkElement)`:
- seeds the initial theme on the root + title bar (before the window is shown, so no flash),
- subscribes to `ThemeHelper.ThemeChanged`,
- **self-unsubscribes on `Window.Closed`**.

So each window opts in with a single line instead of a duplicated `OnAppThemeChanged` handler plus manual `+=`/`-=` bookkeeping. `ThemeChanged` is now `private` — fully encapsulated behind `FollowAppTheme`.

## Reviewer notes

- The backdrop is intentionally left **declarative** in each window's XAML (`<Window.SystemBackdrop><MicaBackdrop/></Window.SystemBackdrop>`); it is not centralized into `ThemeHelper`. A `SystemBackdrop` instance can't be shared across windows, and `ThemeHelper`'s cached Mica is bound to `MainWindow`.
- No custom XAML root type is introduced — the window roots are plain `<Grid x:Name="WindowRoot">`. The initial theme is set in `FollowAppTheme` before the window is shown. (An earlier non-`partial` custom `Grid` subclass froze AOT/Release builds when opening these windows; this approach avoids any custom WinRT-projected type on that path.)
- Builds clean with `BuildAndRun.ps1 -SkipRun` (WinAppSDK analyzer enabled, no warnings).
