### PR TITLE
feat: improve custom rule matching

### DIFF
--- a/Models/CustomRoutingRule.cs
+++ b/Models/CustomRoutingRule.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
+using XrayUI.Services;
 
 namespace XrayUI.Models
 {
@@ -7,27 +11,76 @@ namespace XrayUI.Models
         /// <summary>"domain" | "ip" | "process"</summary>
         public string Type { get; set; } = "domain";
 
+        [JsonPropertyName("domain")]
+        public List<string>? Domain { get; set; }
+
+        [JsonPropertyName("ip")]
+        public List<string>? Ip { get; set; }
+
+        [JsonPropertyName("process")]
+        public List<string>? Process { get; set; }
+
+        /// <summary>Legacy settings.json compatibility. New saves use domain/ip/process arrays.</summary>
+        [JsonPropertyName("Match")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? LegacyMatch
+        {
+            get => null;
+            set
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                    Match = value;
+            }
+        }
+
         /// <summary>youtube.com / 192.168.0.0/16 / geosite:cn / geoip:cn / chrome.exe / C:\Games\xxx.exe</summary>
-        public string Match { get; set; } = "";
+        [JsonIgnore]
+        public string Match
+        {
+            get => string.Join(Environment.NewLine, MatchValues);
+            set => SetMatchValues(CustomRuleValueParser.Parse(value));
+        }
+
+        [JsonIgnore]
+        public IReadOnlyList<string> MatchValues => Type switch
+        {
+            "ip"      => Ip ?? [],
+            "process" => Process ?? [],
+            _         => Domain ?? [],
+        };
 
         /// <summary>"proxy" | "direct" | "block"</summary>
         public string OutboundTag { get; set; } = "proxy";
 
         public bool IsEnabled { get; set; } = true;
 
-        /// <summary>True when this rule matches on process name (xray <c>process</c> field).</summary>
-        [JsonIgnore] public bool IsProcess => Type == "process";
-
         // Helpers for x:Bind (OneTime) inside DataTemplate.
         // Visibility is computed directly to avoid converter lookups in a Window root.
         [JsonIgnore] public Visibility DomainVisibility  => Type == "domain"  ? Visibility.Visible : Visibility.Collapsed;
         [JsonIgnore] public Visibility IpVisibility      => Type == "ip"      ? Visibility.Visible : Visibility.Collapsed;
-        [JsonIgnore] public Visibility ProcessVisibility => IsProcess         ? Visibility.Visible : Visibility.Collapsed;
+        [JsonIgnore] public Visibility ProcessVisibility => Type == "process" ? Visibility.Visible : Visibility.Collapsed;
+
+        private void SetMatchValues(IReadOnlyList<string> values)
+        {
+            Domain = null;
+            Ip = null;
+            Process = null;
+
+            var list = values.ToList();
+            switch (Type)
+            {
+                case "ip":      Ip = list; break;
+                case "process": Process = list; break;
+                default:        Domain = list; break;
+            }
+        }
 
         public CustomRoutingRule Clone() => new()
         {
             Type        = Type,
-            Match       = Match,
+            Domain      = Domain?.ToList(),
+            Ip          = Ip?.ToList(),
+            Process     = Process?.ToList(),
             OutboundTag = OutboundTag,
             IsEnabled   = IsEnabled,
         };

--- a/Models/CustomRoutingRule.cs
+++ b/Models/CustomRoutingRule.cs
@@ -49,6 +49,19 @@ namespace XrayUI.Models
             _         => Domain ?? [],
         };
 
+        /// <summary>One-line list summary for the rules list (values joined by " · ").</summary>
+        [JsonIgnore]
+        public string MatchSummary => MatchValues.Count switch
+        {
+            0 => "",
+            1 => MatchValues[0],
+            _ => string.Join(" · ", MatchValues),
+        };
+
+        /// <summary>Full value list, one per line — used as the list row tooltip.</summary>
+        [JsonIgnore]
+        public string MatchDetails => string.Join(Environment.NewLine, MatchValues);
+
         /// <summary>"proxy" | "direct" | "block"</summary>
         public string OutboundTag { get; set; } = "proxy";
 

--- a/Services/CustomRuleValueParser.cs
+++ b/Services/CustomRuleValueParser.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace XrayUI.Services
+{
+    public static class CustomRuleValueParser
+    {
+        public static List<string> Parse(string? text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return [];
+            }
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var values = new List<string>();
+            foreach (var part in text.Split([',', ';', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (part.Length == 0 || !seen.Add(part))
+                {
+                    continue;
+                }
+
+                values.Add(part);
+            }
+
+            return values;
+        }
+    }
+}

--- a/Services/CustomRuleValueParser.cs
+++ b/Services/CustomRuleValueParser.cs
@@ -14,7 +14,9 @@ namespace XrayUI.Services
 
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var values = new List<string>();
-            foreach (var part in text.Split([',', ';', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            // Commas and semicolons are valid inside match values (for example,
+            // regexp quantifiers and Windows paths), so only line breaks delimit values.
+            foreach (var part in text.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             {
                 if (part.Length == 0 || !seen.Add(part))
                 {

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -115,6 +115,8 @@ namespace XrayUI.Services
             {
                 ["enabled"] = true,
                 ["destOverride"] = destOverride,
+                ["excludedOutboundTags"] = CreateStringArray(DirectOutboundTag),
+                ["routeOnly"] = true,
             };
             if (settings.FakeDnsEnabled)
             {
@@ -176,17 +178,16 @@ namespace XrayUI.Services
 
             AddNode(list, direct);
 
-            // block outbound is needed by:
-            //   1. TUN mode's UDP:443 quench rule
-            //   2. Any enabled custom rule targeting "block" (smart mode only)
+            // block outbound is needed by any enabled custom rule targeting "block"
+            // (smart mode only).
             bool customRulesUseBlock =
                 settings.RoutingMode == "smart"
                 && settings.CustomRules is { } rules
                 && rules.Any(r => r.IsEnabled
-                                  && !string.IsNullOrWhiteSpace(r.Match)
+                                  && r.MatchValues.Count > 0
                                   && r.OutboundTag == BlockOutboundTag);
 
-            if (settings.IsTunMode || customRulesUseBlock)
+            if (customRulesUseBlock)
             {
                 AddNode(list, new JsonObject
                 {
@@ -611,31 +612,67 @@ namespace XrayUI.Services
                 ? (JsonObject)settings.AdvancedRouting!.DeepClone()
                 : BuildDefaultRoutingTemplate(settings, includeFallback: false);
 
-            // baseRouting is exclusively owned (fresh clone or fresh build). Build a fresh
-            // rules array so TUN process bypass rules can sit before the UDP/443 quench rule,
-            // while ordinary domain/IP rules still remain behind it.
-            var baseRules = baseRouting["rules"] as JsonArray ?? new JsonArray();
-            var rules = BuildSmartRules(settings, baseRules);
-            baseRouting["rules"] = rules;
+            // baseRouting is exclusively owned (fresh clone or fresh build), so mutate
+            // its rules array in place. TUN mode keeps process bypass rules before
+            // other custom rules while preserving custom rules before the base rules.
+            if (baseRouting["rules"] is not JsonArray rules)
+            {
+                rules = new JsonArray();
+                baseRouting["rules"] = rules;
+            }
+
+            var insertIdx = PrependTunLeadingRules(rules, settings);
+
+            if (settings.CustomRules is { } customRules)
+            {
+                if (settings.IsTunMode)
+                {
+                    foreach (var rule in customRules.Where(IsEnabledProcessRule))
+                    {
+                        rules.Insert(insertIdx++, CustomRuleToJsonObject(rule));
+                    }
+
+                    foreach (var rule in customRules.Where(r => !IsEnabledProcessRule(r) && IsEnabledRule(r)))
+                    {
+                        rules.Insert(insertIdx++, CustomRuleToJsonObject(rule));
+                    }
+                }
+                else
+                {
+                    foreach (var rule in customRules.Where(IsEnabledRule))
+                    {
+                        rules.Insert(insertIdx++, CustomRuleToJsonObject(rule));
+                    }
+                }
+            }
 
             if (!hasAdvancedRouting)
             {
                 AddDefaultProxyFallbackRule(rules);
             }
 
-            if (baseRouting["domainStrategy"] is null)
+            if (settings.IsTunMode)
             {
-                baseRouting["domainStrategy"] = "AsIs";
+                baseRouting["domainStrategy"] = RoutingDomainStrategy(settings);
+            }
+            else if (baseRouting["domainStrategy"] is null)
+            {
+                baseRouting["domainStrategy"] = RoutingDomainStrategy(settings);
             }
 
             return baseRouting;
         }
 
+        private static bool IsEnabledRule(CustomRoutingRule rule) =>
+            rule.IsEnabled && rule.MatchValues.Count > 0;
+
+        private static bool IsEnabledProcessRule(CustomRoutingRule rule) =>
+            rule.Type == "process" && IsEnabledRule(rule);
+
         private static JsonObject BuildGlobalRouting(AppSettings settings)
         {
             var rules = new JsonArray();
-            AppendTunLeadRules(rules, settings);
-            AppendTunUdp443BlockRule(rules, settings);
+            var insertIdx = PrependTunLeadingRules(rules, settings);
 
             AddNode(rules, new JsonObject
             {
@@ -646,52 +683,28 @@ namespace XrayUI.Services
 
             return new JsonObject
             {
-                ["domainStrategy"] = "AsIs",
+                ["domainStrategy"] = RoutingDomainStrategy(settings),
                 ["rules"] = rules
             };
         }
 
         /// <summary>
-        /// Builds smart-mode rules. In TUN mode, process rules from both the UI and
-        /// AdvancedRouting are promoted before the UDP/443 quench rule so explicit
-        /// per-process bypasses for QUIC-based clients are not shadowed.
+        /// Inserts the fixed TUN leading rules at the head of <paramref name="rules"/> and
+        /// returns the number inserted, so callers know where the user-rule region starts.
+        /// These keep DNS and self/xray traffic out of the tunnel; never user-editable and
+        /// must precede any user/advanced rules.
         /// </summary>
-        private static JsonArray BuildSmartRules(AppSettings settings, JsonArray baseRules)
+        private static int PrependTunLeadingRules(JsonArray rules, AppSettings settings)
         {
-            var rules = new JsonArray();
+            if (!settings.IsTunMode) return 0;
 
-            if (settings.IsTunMode)
-            {
-                AppendTunLeadRules(rules, settings);
-                AddCustomRules(rules, settings.CustomRules, IsProcessCustomRule);
-                AddClonedRules(rules, baseRules, IsProcessRoutingRule);
-                AppendTunUdp443BlockRule(rules, settings);
-                AddCustomRules(rules, settings.CustomRules, rule => !IsProcessCustomRule(rule));
-                AddClonedRules(rules, baseRules, rule => !IsProcessRoutingRule(rule));
-            }
-            else
-            {
-                AddCustomRules(rules, settings.CustomRules, _ => true);
-                AddClonedRules(rules, baseRules, _ => true);
-            }
-
-            return rules;
-        }
-
-        /// <summary>
-        /// Adds the fixed TUN lead rules that must stay before user/advanced rules:
-        /// FakeDNS DNS capture first, then xray/self direct.
-        /// </summary>
-        private static void AppendTunLeadRules(JsonArray rules, AppSettings settings)
-        {
-            if (!settings.IsTunMode) return;
-
+            var i = 0;
             if (settings.FakeDnsEnabled)
             {
                 // Must precede the self/xray direct rule so DNS queries from tun-in get
                 // intercepted by xray's internal DNS handler (and the fakedns pool) rather
                 // than being forwarded upstream.
-                AddNode(rules, new JsonObject
+                rules.Insert(i++, new JsonObject
                 {
                     ["type"] = "field",
                     ["inboundTag"] = CreateStringArray(XrayConfigConstants.TunInboundTag),
@@ -700,61 +713,15 @@ namespace XrayUI.Services
                 });
             }
 
-            AddNode(rules, new JsonObject
+            rules.Insert(i++, new JsonObject
             {
                 ["type"] = "field",
                 ["outboundTag"] = DirectOutboundTag,
                 ["process"] = CreateStringArray("self/", "xray/")
             });
+
+            return i;
         }
-
-        private static void AppendTunUdp443BlockRule(JsonArray rules, AppSettings settings)
-        {
-            if (!settings.IsTunMode) return;
-
-            AddNode(rules, new JsonObject
-            {
-                ["type"] = "field",
-                ["outboundTag"] = BlockOutboundTag,
-                ["network"] = "udp",
-                ["port"] = "443"
-            });
-        }
-
-        private static void AddCustomRules(
-            JsonArray rules,
-            IEnumerable<CustomRoutingRule>? customRules,
-            Func<CustomRoutingRule, bool> predicate)
-        {
-            if (customRules is null) return;
-
-            foreach (var rule in customRules)
-            {
-                if (!rule.IsEnabled || string.IsNullOrWhiteSpace(rule.Match) || !predicate(rule))
-                    continue;
-
-                AddNode(rules, CustomRuleToJsonObject(rule));
-            }
-        }
-
-        private static void AddClonedRules(
-            JsonArray rules,
-            JsonArray sourceRules,
-            Func<JsonNode?, bool> predicate)
-        {
-            foreach (var rule in sourceRules)
-            {
-                if (rule is null || !predicate(rule))
-                    continue;
-
-                AddNode(rules, rule.DeepClone());
-            }
-        }
-
-        private static bool IsProcessCustomRule(CustomRoutingRule rule) => rule.IsProcess;
-
-        private static bool IsProcessRoutingRule(JsonNode? rule) =>
-            rule is JsonObject ruleObject && ruleObject["process"] is not null;
 
         /// <summary>
         /// The default smart-mode routing object — proxy Google, direct domestic geosite/geoip
@@ -792,10 +759,13 @@ namespace XrayUI.Services
 
             return new JsonObject
             {
-                ["domainStrategy"] = "AsIs",
+                ["domainStrategy"] = RoutingDomainStrategy(settings),
                 ["rules"] = rules
             };
         }
+
+        private static string RoutingDomainStrategy(AppSettings settings) =>
+            settings.IsTunMode ? "IPIfNonMatch" : "AsIs";
 
         private static void AddDefaultProxyFallbackRule(JsonArray rules)
         {
@@ -840,9 +810,9 @@ namespace XrayUI.Services
             };
             switch (rule.Type)
             {
-                case "ip":      node["ip"]      = CreateStringArray(rule.Match); break;
-                case "process": node["process"] = CreateStringArray(rule.Match); break;
-                default:        node["domain"]  = CreateStringArray(rule.Match); break;
+                case "ip":      node["ip"]      = CreateStringArray(rule.MatchValues); break;
+                case "process": node["process"] = CreateStringArray(rule.MatchValues); break;
+                default:        node["domain"]  = CreateStringArray(rule.MatchValues); break;
             }
             return node;
         }
@@ -887,6 +857,17 @@ namespace XrayUI.Services
         }
 
         private static JsonArray CreateStringArray(params string[] values)
+        {
+            var array = new JsonArray();
+            foreach (var value in values)
+            {
+                AddValue(array, value);
+            }
+
+            return array;
+        }
+
+        private static JsonArray CreateStringArray(IEnumerable<string> values)
         {
             var array = new JsonArray();
             foreach (var value in values)

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -115,8 +115,6 @@ namespace XrayUI.Services
             {
                 ["enabled"] = true,
                 ["destOverride"] = destOverride,
-                ["excludedOutboundTags"] = CreateStringArray(DirectOutboundTag),
-                ["routeOnly"] = true,
             };
             if (settings.FakeDnsEnabled)
             {
@@ -178,8 +176,9 @@ namespace XrayUI.Services
 
             AddNode(list, direct);
 
-            // block outbound is needed by any enabled custom rule targeting "block"
-            // (smart mode only).
+            // block outbound is needed by:
+            //   1. TUN mode's UDP:443 quench rule
+            //   2. Any enabled custom rule targeting "block" (smart mode only)
             bool customRulesUseBlock =
                 settings.RoutingMode == "smart"
                 && settings.CustomRules is { } rules
@@ -187,7 +186,7 @@ namespace XrayUI.Services
                                   && r.MatchValues.Count > 0
                                   && r.OutboundTag == BlockOutboundTag);
 
-            if (customRulesUseBlock)
+            if (settings.IsTunMode || customRulesUseBlock)
             {
                 AddNode(list, new JsonObject
                 {
@@ -612,67 +611,31 @@ namespace XrayUI.Services
                 ? (JsonObject)settings.AdvancedRouting!.DeepClone()
                 : BuildDefaultRoutingTemplate(settings, includeFallback: false);
 
-            // baseRouting is exclusively owned (fresh clone or fresh build), so mutate
-            // its rules array in place. TUN mode keeps process bypass rules before
-            // other custom rules while preserving custom rules before the base rules.
-            if (baseRouting["rules"] is not JsonArray rules)
-            {
-                rules = new JsonArray();
-                baseRouting["rules"] = rules;
-            }
-
-            var insertIdx = PrependTunLeadingRules(rules, settings);
-
-            if (settings.CustomRules is { } customRules)
-            {
-                if (settings.IsTunMode)
-                {
-                    foreach (var rule in customRules.Where(IsEnabledProcessRule))
-                    {
-                        rules.Insert(insertIdx++, CustomRuleToJsonObject(rule));
-                    }
-
-                    foreach (var rule in customRules.Where(r => !IsEnabledProcessRule(r) && IsEnabledRule(r)))
-                    {
-                        rules.Insert(insertIdx++, CustomRuleToJsonObject(rule));
-                    }
-                }
-                else
-                {
-                    foreach (var rule in customRules.Where(IsEnabledRule))
-                    {
-                        rules.Insert(insertIdx++, CustomRuleToJsonObject(rule));
-                    }
-                }
-            }
+            // baseRouting is exclusively owned (fresh clone or fresh build). Build a fresh
+            // rules array so TUN process bypass rules can sit before the UDP/443 quench rule,
+            // while ordinary domain/IP rules still remain behind it.
+            var baseRules = baseRouting["rules"] as JsonArray ?? new JsonArray();
+            var rules = BuildSmartRules(settings, baseRules);
+            baseRouting["rules"] = rules;
 
             if (!hasAdvancedRouting)
             {
                 AddDefaultProxyFallbackRule(rules);
             }
 
-            if (settings.IsTunMode)
+            if (baseRouting["domainStrategy"] is null)
             {
-                baseRouting["domainStrategy"] = RoutingDomainStrategy(settings);
-            }
-            else if (baseRouting["domainStrategy"] is null)
-            {
-                baseRouting["domainStrategy"] = RoutingDomainStrategy(settings);
+                baseRouting["domainStrategy"] = "AsIs";
             }
 
             return baseRouting;
         }
 
-        private static bool IsEnabledRule(CustomRoutingRule rule) =>
-            rule.IsEnabled && rule.MatchValues.Count > 0;
-
-        private static bool IsEnabledProcessRule(CustomRoutingRule rule) =>
-            rule.Type == "process" && IsEnabledRule(rule);
-
         private static JsonObject BuildGlobalRouting(AppSettings settings)
         {
             var rules = new JsonArray();
-            var insertIdx = PrependTunLeadingRules(rules, settings);
+            AppendTunLeadRules(rules, settings);
+            AppendTunUdp443BlockRule(rules, settings);
 
             AddNode(rules, new JsonObject
             {
@@ -683,28 +646,52 @@ namespace XrayUI.Services
 
             return new JsonObject
             {
-                ["domainStrategy"] = RoutingDomainStrategy(settings),
+                ["domainStrategy"] = "AsIs",
                 ["rules"] = rules
             };
         }
 
         /// <summary>
-        /// Inserts the fixed TUN leading rules at the head of <paramref name="rules"/> and
-        /// returns the number inserted, so callers know where the user-rule region starts.
-        /// These keep DNS and self/xray traffic out of the tunnel; never user-editable and
-        /// must precede any user/advanced rules.
+        /// Builds smart-mode rules. In TUN mode, process rules from both the UI and
+        /// AdvancedRouting are promoted before the UDP/443 quench rule so explicit
+        /// per-process bypasses for QUIC-based clients are not shadowed.
         /// </summary>
-        private static int PrependTunLeadingRules(JsonArray rules, AppSettings settings)
+        private static JsonArray BuildSmartRules(AppSettings settings, JsonArray baseRules)
         {
-            if (!settings.IsTunMode) return 0;
+            var rules = new JsonArray();
 
-            var i = 0;
+            if (settings.IsTunMode)
+            {
+                AppendTunLeadRules(rules, settings);
+                AddCustomRules(rules, settings.CustomRules, IsProcessCustomRule);
+                AddClonedRules(rules, baseRules, IsProcessRoutingRule);
+                AppendTunUdp443BlockRule(rules, settings);
+                AddCustomRules(rules, settings.CustomRules, rule => !IsProcessCustomRule(rule));
+                AddClonedRules(rules, baseRules, rule => !IsProcessRoutingRule(rule));
+            }
+            else
+            {
+                AddCustomRules(rules, settings.CustomRules, _ => true);
+                AddClonedRules(rules, baseRules, _ => true);
+            }
+
+            return rules;
+        }
+
+        /// <summary>
+        /// Adds the fixed TUN lead rules that must stay before user/advanced rules:
+        /// FakeDNS DNS capture first, then xray/self direct.
+        /// </summary>
+        private static void AppendTunLeadRules(JsonArray rules, AppSettings settings)
+        {
+            if (!settings.IsTunMode) return;
+
             if (settings.FakeDnsEnabled)
             {
                 // Must precede the self/xray direct rule so DNS queries from tun-in get
                 // intercepted by xray's internal DNS handler (and the fakedns pool) rather
                 // than being forwarded upstream.
-                rules.Insert(i++, new JsonObject
+                AddNode(rules, new JsonObject
                 {
                     ["type"] = "field",
                     ["inboundTag"] = CreateStringArray(XrayConfigConstants.TunInboundTag),
@@ -713,15 +700,61 @@ namespace XrayUI.Services
                 });
             }
 
-            rules.Insert(i++, new JsonObject
+            AddNode(rules, new JsonObject
             {
                 ["type"] = "field",
                 ["outboundTag"] = DirectOutboundTag,
                 ["process"] = CreateStringArray("self/", "xray/")
             });
-
-            return i;
         }
+
+        private static void AppendTunUdp443BlockRule(JsonArray rules, AppSettings settings)
+        {
+            if (!settings.IsTunMode) return;
+
+            AddNode(rules, new JsonObject
+            {
+                ["type"] = "field",
+                ["outboundTag"] = BlockOutboundTag,
+                ["network"] = "udp",
+                ["port"] = "443"
+            });
+        }
+
+        private static void AddCustomRules(
+            JsonArray rules,
+            IEnumerable<CustomRoutingRule>? customRules,
+            Func<CustomRoutingRule, bool> predicate)
+        {
+            if (customRules is null) return;
+
+            foreach (var rule in customRules)
+            {
+                if (!rule.IsEnabled || rule.MatchValues.Count == 0 || !predicate(rule))
+                    continue;
+
+                AddNode(rules, CustomRuleToJsonObject(rule));
+            }
+        }
+
+        private static void AddClonedRules(
+            JsonArray rules,
+            JsonArray sourceRules,
+            Func<JsonNode?, bool> predicate)
+        {
+            foreach (var rule in sourceRules)
+            {
+                if (rule is null || !predicate(rule))
+                    continue;
+
+                AddNode(rules, rule.DeepClone());
+            }
+        }
+
+        private static bool IsProcessCustomRule(CustomRoutingRule rule) => rule.Type == "process";
+
+        private static bool IsProcessRoutingRule(JsonNode? rule) =>
+            rule is JsonObject ruleObject && ruleObject["process"] is not null;
 
         /// <summary>
         /// The default smart-mode routing object — proxy Google, direct domestic geosite/geoip
@@ -759,13 +792,10 @@ namespace XrayUI.Services
 
             return new JsonObject
             {
-                ["domainStrategy"] = RoutingDomainStrategy(settings),
+                ["domainStrategy"] = "AsIs",
                 ["rules"] = rules
             };
         }
-
-        private static string RoutingDomainStrategy(AppSettings settings) =>
-            settings.IsTunMode ? "IPIfNonMatch" : "AsIs";
 
         private static void AddDefaultProxyFallbackRule(JsonArray rules)
         {

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -914,22 +914,22 @@
     <value>Browse folder...</value>
   </data>
   <data name="AddRule_PlaceholderDomain" xml:space="preserve">
-    <value>youtube.com or geosite:cn</value>
+    <value>youtube.com, geosite:cn, or one per line</value>
   </data>
   <data name="AddRule_PlaceholderIp" xml:space="preserve">
-    <value>192.168.0.0/16 or geoip:cn</value>
+    <value>192.168.0.0/16, geoip:cn, or one per line</value>
   </data>
   <data name="AddRule_PlaceholderProcess" xml:space="preserve">
-    <value>Type a process name / path / folder, or click Browse</value>
+    <value>Process names, paths, or folders; comma or newline separated</value>
   </data>
   <data name="AddRule_HintDomain" xml:space="preserve">
-    <value>Supports exact match, regexp:, geosite: prefixes</value>
+    <value>Supports exact match, regexp:, geosite: prefixes. Separate multiple values with comma, semicolon, or newline.</value>
   </data>
   <data name="AddRule_HintIp" xml:space="preserve">
-    <value>Supports CIDR and geoip: prefixes</value>
+    <value>Supports CIDR and geoip: prefixes. Separate multiple values with comma, semicolon, or newline.</value>
   </data>
   <data name="AddRule_HintProcess" xml:space="preserve">
-    <value>By name: matches any exe with this name. By full path: matches only this exe. By folder: matches all exes under the folder.</value>
+    <value>By name, full path, or folder. Separate multiple values with comma, semicolon, or newline; Browse appends to the list.</value>
   </data>
   <data name="Personalize_AppLanguageTitle.Text" xml:space="preserve">
     <value>Application language</value>

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -908,7 +908,7 @@
     <value>Please enter match content</value>
   </data>
   <data name="AddRule_BrowseExe" xml:space="preserve">
-    <value>Browse exe...</value>
+    <value>Browse exe files...</value>
   </data>
   <data name="AddRule_BrowseFolder" xml:space="preserve">
     <value>Browse folder...</value>
@@ -920,7 +920,7 @@
     <value>192.168.0.0/16, geoip:cn, or one per line</value>
   </data>
   <data name="AddRule_PlaceholderProcess" xml:space="preserve">
-    <value>Process names, paths, or folders; comma or newline separated</value>
+    <value>One process name, full path, or folder per line</value>
   </data>
   <data name="AddRule_HintDomain" xml:space="preserve">
     <value>Supports exact match, regexp:, geosite: prefixes. Separate multiple values with comma, semicolon, or newline.</value>
@@ -929,7 +929,7 @@
     <value>Supports CIDR and geoip: prefixes. Separate multiple values with comma, semicolon, or newline.</value>
   </data>
   <data name="AddRule_HintProcess" xml:space="preserve">
-    <value>By name, full path, or folder. Separate multiple values with comma, semicolon, or newline; Browse appends to the list.</value>
+    <value>One per line; multi-select available and removes duplicates.</value>
   </data>
   <data name="Personalize_AppLanguageTitle.Text" xml:space="preserve">
     <value>Application language</value>

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -914,22 +914,22 @@
     <value>Browse folder...</value>
   </data>
   <data name="AddRule_PlaceholderDomain" xml:space="preserve">
-    <value>youtube.com, geosite:cn, or one per line</value>
+    <value>One domain or rule per line (e.g. youtube.com or geosite:cn)</value>
   </data>
   <data name="AddRule_PlaceholderIp" xml:space="preserve">
-    <value>192.168.0.0/16, geoip:cn, or one per line</value>
+    <value>One IP rule per line (e.g. 192.168.0.0/16 or geoip:cn)</value>
   </data>
   <data name="AddRule_PlaceholderProcess" xml:space="preserve">
     <value>One process name, full path, or folder per line</value>
   </data>
   <data name="AddRule_HintDomain" xml:space="preserve">
-    <value>Supports exact match, regexp:, geosite: prefixes. Separate multiple values with comma, semicolon, or newline.</value>
+    <value>Supports exact match and regexp:/geosite: prefixes. Add one value per line.</value>
   </data>
   <data name="AddRule_HintIp" xml:space="preserve">
-    <value>Supports CIDR and geoip: prefixes. Separate multiple values with comma, semicolon, or newline.</value>
+    <value>Supports CIDR and geoip: prefixes. Add one value per line.</value>
   </data>
   <data name="AddRule_HintProcess" xml:space="preserve">
-    <value>One per line; multi-select available and removes duplicates.</value>
+    <value>One value per line; Browse supports multi-select and removes duplicates.</value>
   </data>
   <data name="Personalize_AppLanguageTitle.Text" xml:space="preserve">
     <value>Application language</value>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -914,22 +914,22 @@
     <value>浏览文件夹...</value>
   </data>
   <data name="AddRule_PlaceholderDomain" xml:space="preserve">
-    <value>youtube.com 或 geosite:cn</value>
+    <value>youtube.com、geosite:cn，或每行一个</value>
   </data>
   <data name="AddRule_PlaceholderIp" xml:space="preserve">
-    <value>192.168.0.0/16 或 geoip:cn</value>
+    <value>192.168.0.0/16、geoip:cn，或每行一个</value>
   </data>
   <data name="AddRule_PlaceholderProcess" xml:space="preserve">
-    <value>可手填进程名 / 路径 / 文件夹，或点浏览选取</value>
+    <value>进程名、路径或文件夹；可用逗号或换行分隔</value>
   </data>
   <data name="AddRule_HintDomain" xml:space="preserve">
-    <value>支持精确匹配、regexp:、geosite: 前缀</value>
+    <value>支持精确匹配、regexp:、geosite: 前缀。多个值可用逗号、分号或换行分隔。</value>
   </data>
   <data name="AddRule_HintIp" xml:space="preserve">
-    <value>支持 CIDR 与 geoip: 前缀</value>
+    <value>支持 CIDR 与 geoip: 前缀。多个值可用逗号、分号或换行分隔。</value>
   </data>
   <data name="AddRule_HintProcess" xml:space="preserve">
-    <value>同名进程：匹配任意路径下的同名 exe；完整路径：只匹配此 exe；整个目录：匹配该目录下所有 exe</value>
+    <value>支持同名进程、完整路径或文件夹。多个值可用逗号、分号或换行分隔；浏览会追加到列表。</value>
   </data>
   <data name="Personalize_AppLanguageTitle.Text" xml:space="preserve">
     <value>应用语言</value>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -914,22 +914,22 @@
     <value>浏览文件夹...</value>
   </data>
   <data name="AddRule_PlaceholderDomain" xml:space="preserve">
-    <value>youtube.com、geosite:cn，或每行一个</value>
+    <value>每行一个域名或规则，例如 youtube.com 或 geosite:cn</value>
   </data>
   <data name="AddRule_PlaceholderIp" xml:space="preserve">
-    <value>192.168.0.0/16、geoip:cn，或每行一个</value>
+    <value>每行一个 IP 规则，例如 192.168.0.0/16 或 geoip:cn</value>
   </data>
   <data name="AddRule_PlaceholderProcess" xml:space="preserve">
     <value>每行输入一个进程名、完整路径或文件夹</value>
   </data>
   <data name="AddRule_HintDomain" xml:space="preserve">
-    <value>支持精确匹配、regexp:、geosite: 前缀。多个值可用逗号、分号或换行分隔。</value>
+    <value>支持精确匹配及 regexp:、geosite: 前缀；每行填写一个值。</value>
   </data>
   <data name="AddRule_HintIp" xml:space="preserve">
-    <value>支持 CIDR 与 geoip: 前缀。多个值可用逗号、分号或换行分隔。</value>
+    <value>支持 CIDR 与 geoip: 前缀；每行填写一个值。</value>
   </data>
   <data name="AddRule_HintProcess" xml:space="preserve">
-    <value>每行一个；支持多选并自动去重。</value>
+    <value>每行填写一个值；浏览支持多选，并会自动去重。</value>
   </data>
   <data name="Personalize_AppLanguageTitle.Text" xml:space="preserve">
     <value>应用语言</value>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -908,7 +908,7 @@
     <value>请填写匹配内容</value>
   </data>
   <data name="AddRule_BrowseExe" xml:space="preserve">
-    <value>浏览 exe...</value>
+    <value>选择 exe（可多选）...</value>
   </data>
   <data name="AddRule_BrowseFolder" xml:space="preserve">
     <value>浏览文件夹...</value>
@@ -920,7 +920,7 @@
     <value>192.168.0.0/16、geoip:cn，或每行一个</value>
   </data>
   <data name="AddRule_PlaceholderProcess" xml:space="preserve">
-    <value>进程名、路径或文件夹；可用逗号或换行分隔</value>
+    <value>每行输入一个进程名、完整路径或文件夹</value>
   </data>
   <data name="AddRule_HintDomain" xml:space="preserve">
     <value>支持精确匹配、regexp:、geosite: 前缀。多个值可用逗号、分号或换行分隔。</value>
@@ -929,7 +929,7 @@
     <value>支持 CIDR 与 geoip: 前缀。多个值可用逗号、分号或换行分隔。</value>
   </data>
   <data name="AddRule_HintProcess" xml:space="preserve">
-    <value>支持同名进程、完整路径或文件夹。多个值可用逗号、分号或换行分隔；浏览会追加到列表。</value>
+    <value>每行一个；支持多选并自动去重。</value>
   </data>
   <data name="Personalize_AppLanguageTitle.Text" xml:space="preserve">
     <value>应用语言</value>

--- a/Views/AddRuleDialog.xaml
+++ b/Views/AddRuleDialog.xaml
@@ -12,7 +12,9 @@
     CloseButtonText="取消"
     DefaultButton="Primary">
 
-    <StackPanel Spacing="16" MinWidth="320" MaxWidth="380">
+    <ScrollViewer MaxHeight="640"
+                  VerticalScrollBarVisibility="Auto">
+    <StackPanel Spacing="16" MinWidth="520" MaxWidth="560">
 
         <StackPanel Spacing="6">
             <TextBlock x:Uid="AddRule_TypeLabelText"
@@ -34,7 +36,10 @@
                        FontSize="12"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
             <TextBox x:Name="MatchTextBox"
-                     PlaceholderText="youtube.com 或 geosite:cn" />
+                     PlaceholderText="youtube.com 或 geosite:cn"
+                     AcceptsReturn="True"
+                     TextWrapping="Wrap"
+                     MinHeight="140" />
 
             <!-- Browse helpers (visible only when Type = process) -->
             <StackPanel x:Name="BrowsePanel"
@@ -49,7 +54,7 @@
                 </Button>
                 <ComboBox x:Name="BrowseFormatComboBox"
                           SelectedIndex="0"
-                          MinWidth="130">
+                          MinWidth="170">
                     <ComboBoxItem x:Uid="AddRule_BrowseNameItem" Content="匹配同名进程" Tag="name" />
                     <ComboBoxItem x:Uid="AddRule_BrowsePathItem" Content="匹配完整路径" Tag="path" />
                     <ComboBoxItem x:Uid="AddRule_BrowseFolderItem" Content="匹配整个目录" Tag="folder" />
@@ -85,4 +90,5 @@
                    Visibility="Collapsed" />
 
     </StackPanel>
+    </ScrollViewer>
 </ContentDialog>

--- a/Views/AddRuleDialog.xaml
+++ b/Views/AddRuleDialog.xaml
@@ -12,9 +12,18 @@
     CloseButtonText="取消"
     DefaultButton="Primary">
 
-    <ScrollViewer MaxHeight="640"
-                  VerticalScrollBarVisibility="Auto">
-    <StackPanel Spacing="16" MinWidth="520" MaxWidth="560">
+    <!-- A ContentDialog does not auto-scroll over-tall content, so wrap it.
+         MaxHeight must stay below the CustomRulesWindow host height (620x460,
+         see CustomRulesWindow.xaml.cs) minus the dialog chrome, or it clips again.
+         Right padding gives the scrollbar its own gutter. -->
+    <ScrollViewer MaxHeight="300"
+                  VerticalScrollBarVisibility="Auto"
+                  HorizontalScrollBarVisibility="Disabled"
+                  VerticalScrollMode="Auto"
+                  Padding="0,0,14,0">
+    <!-- Fixed width so the dialog stays the same size across types; otherwise the
+         process Browse row makes it wider than domain/IP. -->
+    <StackPanel Spacing="16" Width="360">
 
         <StackPanel Spacing="6">
             <TextBlock x:Uid="AddRule_TypeLabelText"
@@ -39,7 +48,9 @@
                      PlaceholderText="youtube.com 或 geosite:cn"
                      AcceptsReturn="True"
                      TextWrapping="Wrap"
-                     MinHeight="140" />
+                     MinHeight="84"
+                     MaxHeight="144"
+                     ScrollViewer.VerticalScrollBarVisibility="Auto" />
 
             <!-- Browse helpers (visible only when Type = process) -->
             <StackPanel x:Name="BrowsePanel"
@@ -54,7 +65,7 @@
                 </Button>
                 <ComboBox x:Name="BrowseFormatComboBox"
                           SelectedIndex="0"
-                          MinWidth="170">
+                          MinWidth="130">
                     <ComboBoxItem x:Uid="AddRule_BrowseNameItem" Content="匹配同名进程" Tag="name" />
                     <ComboBoxItem x:Uid="AddRule_BrowsePathItem" Content="匹配完整路径" Tag="path" />
                     <ComboBoxItem x:Uid="AddRule_BrowseFolderItem" Content="匹配整个目录" Tag="folder" />
@@ -65,6 +76,7 @@
                        Text="支持精确匹配、regexp:、geosite: 前缀"
                        FontSize="11"
                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                       MaxLines="2"
                        TextWrapping="Wrap" />
         </StackPanel>
 

--- a/Views/AddRuleDialog.xaml
+++ b/Views/AddRuleDialog.xaml
@@ -45,7 +45,7 @@
                        FontSize="12"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
             <TextBox x:Name="MatchTextBox"
-                     PlaceholderText="youtube.com 或 geosite:cn"
+                     PlaceholderText="每行一个域名或规则，例如 youtube.com 或 geosite:cn"
                      AcceptsReturn="True"
                      TextWrapping="Wrap"
                      MinHeight="84"
@@ -73,7 +73,7 @@
             </StackPanel>
 
             <TextBlock x:Name="HintTextBlock"
-                       Text="支持精确匹配、regexp:、geosite: 前缀"
+                       Text="支持精确匹配及 regexp:、geosite: 前缀；每行填写一个值。"
                        FontSize="11"
                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                        MaxLines="2"

--- a/Views/AddRuleDialog.xaml.cs
+++ b/Views/AddRuleDialog.xaml.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Storage.Pickers;
 using XrayUI.Helpers;
 using XrayUI.Models;
+using XrayUI.Services;
 
 namespace XrayUI.Views
 {
@@ -151,7 +153,7 @@ namespace XrayUI.Views
 
                 // Trailing backslash makes xray treat this as a folder match for
                 // all executables under the directory.
-                MatchTextBox.Text = folder.Path.TrimEnd('\\') + "\\";
+                AppendMatchValue(folder.Path.TrimEnd('\\') + "\\");
                 return;
             }
 
@@ -165,13 +167,13 @@ namespace XrayUI.Views
             var file = await picker.PickSingleFileAsync();
             if (file is null) return;
 
-            MatchTextBox.Text = format == "path" ? file.Path : file.Name;
+            AppendMatchValue(format == "path" ? file.Path : file.Name);
         }
 
         private void OnPrimaryClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
         {
             var match = MatchTextBox.Text?.Trim() ?? "";
-            if (match.Length == 0)
+            if (CustomRuleValueParser.Parse(match).Count == 0)
             {
                 ErrorText.Visibility = Visibility.Visible;
                 args.Cancel = true;
@@ -188,6 +190,17 @@ namespace XrayUI.Views
                 OutboundTag = outboundTag,
                 IsEnabled   = true,
             };
+        }
+
+        private void AppendMatchValue(string value)
+        {
+            var values = CustomRuleValueParser.Parse(MatchTextBox.Text);
+            if (!values.Contains(value, StringComparer.OrdinalIgnoreCase))
+            {
+                values.Add(value);
+            }
+
+            MatchTextBox.Text = string.Join(Environment.NewLine, values);
         }
     }
 }

--- a/Views/AddRuleDialog.xaml.cs
+++ b/Views/AddRuleDialog.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.UI.Xaml.Controls;
@@ -153,7 +154,7 @@ namespace XrayUI.Views
 
                 // Trailing backslash makes xray treat this as a folder match for
                 // all executables under the directory.
-                AppendMatchValue(folder.Path.TrimEnd('\\') + "\\");
+                AppendMatchValues([folder.Path.TrimEnd('\\') + "\\"]);
                 return;
             }
 
@@ -164,10 +165,10 @@ namespace XrayUI.Views
             picker.FileTypeFilter.Add(".exe");
             WinRT.Interop.InitializeWithWindow.Initialize(picker, _hostHwnd);
 
-            var file = await picker.PickSingleFileAsync();
-            if (file is null) return;
+            var files = await picker.PickMultipleFilesAsync();
+            if (files.Count == 0) return;
 
-            AppendMatchValue(format == "path" ? file.Path : file.Name);
+            AppendMatchValues(files.Select(file => format == "path" ? file.Path : file.Name));
         }
 
         private void OnPrimaryClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
@@ -192,12 +193,15 @@ namespace XrayUI.Views
             };
         }
 
-        private void AppendMatchValue(string value)
+        private void AppendMatchValues(IEnumerable<string> additions)
         {
             var values = CustomRuleValueParser.Parse(MatchTextBox.Text);
-            if (!values.Contains(value, StringComparer.OrdinalIgnoreCase))
+            foreach (var addition in additions)
             {
-                values.Add(value);
+                if (!values.Contains(addition, StringComparer.OrdinalIgnoreCase))
+                {
+                    values.Add(addition);
+                }
             }
 
             MatchTextBox.Text = string.Join(Environment.NewLine, values);

--- a/Views/CustomRulesWindow.xaml
+++ b/Views/CustomRulesWindow.xaml
@@ -135,9 +135,10 @@
                             </Border>
                         </Grid>
 
-                        <!-- Match text -->
+                        <!-- Match text (multi-value summary; hover for the full list) -->
                         <TextBlock Grid.Column="1"
-                                   Text="{x:Bind Match}"
+                                   Text="{x:Bind MatchSummary}"
+                                   ToolTipService.ToolTip="{x:Bind MatchDetails}"
                                    VerticalAlignment="Center"
                                    TextTrimming="CharacterEllipsis" />
 


### PR DESCRIPTION
# fix: improve TUN routing config and custom rule matching

## Summary

This PR improves TUN-mode Xray config generation and custom routing rule handling.

Major changes:

- Add TUN sniffing safeguards:
  - add `routeOnly: true`
  - add `excludedOutboundTags: ["direct"]`
- Force `domainStrategy: "IPIfNonMatch"` when TUN mode is enabled, including when advanced routing JSON is used.
- Remove the hardcoded UDP/443 block rule from generated TUN routing.
- Keep TUN leading rules focused on DNS hijack and self/xray direct routing.
- Support multiple values for custom domain, IP, and process routing rules.
- Persist custom routing matches as typed JSON arrays:
  - `domain: ["a.com", "b.com"]`
  - `ip: ["192.168.0.0/16", "geoip:cn"]`
  - `process: ["a.exe", "b.exe"]`
- Preserve compatibility with existing settings that still contain the legacy single `Match` value.
- Emit custom routing rules into Xray config as JSON arrays instead of single-item strings.
- Improve the add/edit custom rule dialog for multi-value input:
  - supports comma, semicolon, and newline separated values
  - appends browse selections instead of replacing existing input
  - enlarges the editor area for multi-value rules
  - updates English and Simplified Chinese helper text

## Why

The previous generated TUN routing config contained a fixed UDP/443 block rule. That rule could unexpectedly block QUIC traffic and made user-defined process/domain/IP rules harder to reason about.

TUN mode also benefits from `IPIfNonMatch` so domain rules can still fall back to IP resolution when needed. The sniffing `routeOnly` and `excludedOutboundTags` settings keep sniffing focused on routing decisions without affecting direct outbound handling.

Custom routing rules previously stored a single match string. This made common use cases such as multiple process names, multiple domains, or multiple CIDR ranges awkward. Storing typed arrays makes the persisted settings and generated Xray config match the actual multi-value model.

## Testing

- Applied the generated patch to a clean clone of `https://github.com/PhoenixNil/XrayUI-dev`.
- Verified the patch with:

```powershell
git apply --check task-tun-upstream.patch
git apply task-tun-upstream.patch
dotnet build -c Release -p:Platform=x64
```

- Build result:
  - 0 warnings
  - 0 errors