### PR TITLE
fix(ui): kill CustomRulesWindow theme-switch flash (regressed in #51 slim-down)

### DIFF
--- a/Views/CustomRulesWindow.xaml
+++ b/Views/CustomRulesWindow.xaml
@@ -9,10 +9,6 @@
         mc:Ignorable="d"
         Title="自定义路由规则">
 
-    <Window.SystemBackdrop>
-        <MicaBackdrop />
-    </Window.SystemBackdrop>
-
     <Grid x:Name="WindowRoot">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/Views/CustomRulesWindow.xaml.cs
+++ b/Views/CustomRulesWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml.Media;
 using WinUIEx;
 using XrayUI.Helpers;
 using XrayUI.Models;
@@ -32,6 +33,10 @@ namespace XrayUI.Views
             this.SetWindowSize(620, 460);
             AppWindow.Title = L.CustomRules_Title;
             ThemeHelper.FollowAppTheme(this, WindowRoot);
+            // Set the backdrop in code, AFTER FollowAppTheme has applied the correct theme.
+            // Declaring it in XAML paints Mica in the default theme first, then visibly retints
+            // when the theme switches — the unwanted transition flash. Mirrors LogWindow.
+            SystemBackdrop = new MicaBackdrop();
 
             ToolTipService.SetToolTip(OpenAdvancedEditorButton, L.CustomRules_AdvancedEditorTooltip);
             ToolTipService.SetToolTip(UpdateGeoButton,          L.CustomRules_UpdateGeoTooltip);


### PR DESCRIPTION
## What

Drop the XAML `<Window.SystemBackdrop><MicaBackdrop/></Window.SystemBackdrop>` from `CustomRulesWindow.xaml` and instead set `SystemBackdrop = new MicaBackdrop()` in code, right after `ThemeHelper.FollowAppTheme(...)` — mirroring how `LogWindow` already does it.

## Why

This is a regression from #51. #51 fixed the theme-switch flash on the secondary windows by moving the Mica backdrop out of XAML into code: setting it *after* `FollowAppTheme` means the window opens already in the correct theme, instead of painting Mica in the default theme and then visibly retinting when the theme is switched.

When #51 was slimmed down to avoid overlapping #50 (custom-rule matching), `CustomRulesWindow.xaml(.cs)` was reverted to `main` — which also dropped that backdrop fix for this one window. Result after both PRs merged: `LogWindow` switches themes cleanly, but `CustomRulesWindow` shows the unwanted Mica transition flash again (system-light/app-dark, system-dark/app-light, etc.).

This re-applies the fix to `CustomRulesWindow` only. #50's `Match` binding on the rules list is left untouched.

## Notes

- Verified with a Debug build (`BuildAndRun.ps1 -SkipRun`): BUILD SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)