### PR TITLE
feat: add WireGuard node support

### DIFF
--- a/Models/ServerEntry.cs
+++ b/Models/ServerEntry.cs
@@ -35,6 +35,11 @@ namespace XrayUI.Models
             Finalmask = string.Empty;
             ChainEntryServerId = string.Empty;
             ChainExitServerId = string.Empty;
+            WgPrivateKey = string.Empty;
+            WgPublicKey = string.Empty;
+            WgPreSharedKey = string.Empty;
+            WgLocalAddress = string.Empty;
+            WgReserved = string.Empty;
         }
 
         /// <summary>ID of the subscription this node was imported from; empty = manually added.</summary>
@@ -50,7 +55,7 @@ namespace XrayUI.Models
         [ObservableProperty]
         public partial int Port { get; set; }
 
-        /// <summary>ss | vmess | vless | hysteria2 | trojan | socks | chain</summary>
+        /// <summary>ss | vmess | vless | hysteria2 | trojan | socks | wireguard | chain</summary>
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(DisplayProtocol))]
         [NotifyPropertyChangedFor(nameof(IsChain))]
@@ -151,6 +156,31 @@ namespace XrayUI.Models
         [ObservableProperty]
         public partial string ChainExitServerId { get; set; }
 
+        // WireGuard
+        /// <summary>WireGuard client secret (private) key, base64. Maps to xray settings.secretKey.</summary>
+        [ObservableProperty]
+        public partial string WgPrivateKey { get; set; }
+
+        /// <summary>WireGuard peer public key, base64. Maps to xray peers[0].publicKey.</summary>
+        [ObservableProperty]
+        public partial string WgPublicKey { get; set; }
+
+        /// <summary>Optional WireGuard pre-shared key, base64. Maps to xray peers[0].preSharedKey.</summary>
+        [ObservableProperty]
+        public partial string WgPreSharedKey { get; set; }
+
+        /// <summary>Comma-separated local tunnel CIDRs (e.g. "172.16.0.2/32,fd00::2/128"). Maps to xray settings.address.</summary>
+        [ObservableProperty]
+        public partial string WgLocalAddress { get; set; }
+
+        /// <summary>Optional WireGuard reserved bytes as "a,b,c". Maps to xray settings.reserved when it yields 3 ints.</summary>
+        [ObservableProperty]
+        public partial string WgReserved { get; set; }
+
+        /// <summary>WireGuard tunnel MTU. 0 = let the config builder use its default.</summary>
+        [ObservableProperty]
+        public partial int WgMtu { get; set; }
+
         public string Id
         {
             get => _id;
@@ -166,6 +196,7 @@ namespace XrayUI.Models
             "hysteria2" => "Hysteria 2",
             "trojan" => "Trojan",
             "socks" => "SOCKS",
+            "wireguard" => "WireGuard",
             "chain" => "ProxyChain",
             _ => Protocol ?? string.Empty
         };

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A native Windows GUI client for the Xray core, built with <a style="text-decorat
 
 ## Features
 
-- Support Shadowsocks, VMess, VLESS, Trojan, Hysteria2 and Chain Proxy
+- Support Shadowsocks, VMess, VLESS, Trojan, Hysteria2, WireGuard and Chain Proxy
 - TUN mode
 - Subscription import and update
 - AI Unlock Status Detection

--- a/Services/ClashConfigParser.cs
+++ b/Services/ClashConfigParser.cs
@@ -14,7 +14,7 @@ namespace XrayUI.Services
     ///
     /// Routing rules and proxy-groups are ignored by design — this is node-only import.
     /// Only protocols the Xray core supports are mapped (ss / vmess / vless / trojan /
-    /// hysteria2); everything else (tuic, anytls, wireguard, hysteria v1, ssr, snell, …)
+    /// hysteria2 / wireguard); everything else (tuic, anytls, hysteria v1, ssr, snell, …)
     /// is counted as skipped.
     ///
     /// AOT-safe: uses YamlDotNet's reflection-free <see cref="YamlStream"/> DOM, never the
@@ -66,6 +66,7 @@ namespace XrayUI.Services
                 "vless"     => MapVless(p),
                 "trojan"    => MapTrojan(p),
                 "hysteria2" => MapHysteria2(p),
+                "wireguard" => MapWireguard(p),
                 _           => null,
             };
 
@@ -193,6 +194,65 @@ namespace XrayUI.Services
                 return finalmask;
 
             return FinalmaskJson.AddHysteria2SalamanderMask(finalmask, obfsPassword);
+        }
+
+        // WireGuard: single-peer form (top-level public-key / server / port). Returns null when a
+        // required field is missing so the newer multi-peer `peers:` form and malformed rows skip.
+        private static ServerEntry? MapWireguard(YamlMappingNode p)
+        {
+            var privateKey = Str(p, "private-key");
+            var publicKey  = Str(p, "public-key");
+            var server     = Str(p, "server");
+            if (string.IsNullOrWhiteSpace(privateKey)
+                || string.IsNullOrWhiteSpace(publicKey)
+                || string.IsNullOrWhiteSpace(server))
+                return null;
+
+            return new ServerEntry
+            {
+                Name           = Str(p, "name"),
+                Protocol       = "wireguard",
+                Host           = server,
+                Port           = Int(p, "port"),
+                WgPrivateKey   = privateKey,
+                WgPublicKey    = publicKey,
+                WgPreSharedKey = Str(p, "pre-shared-key", Str(p, "preshared-key")),
+                WgLocalAddress = WireguardLocalAddress(p),
+                WgReserved     = Reserved(p),
+                WgMtu          = Int(p, "mtu"),
+                Encryption     = "WireGuard",
+            };
+        }
+
+        // Clash gives local tunnel IPs as bare `ip` / `ipv6`; xray's settings.address wants CIDRs.
+        private static string WireguardLocalAddress(YamlMappingNode p)
+        {
+            var parts = new List<string>(2);
+            AddCidr(parts, Str(p, "ip"), "/32");
+            AddCidr(parts, Str(p, "ipv6"), "/128");
+            return string.Join(",", parts);
+        }
+
+        private static void AddCidr(List<string> into, string address, string suffix)
+        {
+            if (string.IsNullOrWhiteSpace(address))
+                return;
+            into.Add(address.Contains('/') ? address : address + suffix);
+        }
+
+        // reserved is usually a 3-int sequence ([a,b,c]); some configs use a scalar (base64 / "a,b,c").
+        private static string Reserved(YamlMappingNode p) => Child(p, "reserved") switch
+        {
+            YamlSequenceNode seq => string.Join(",", ScalarValues(seq)),
+            YamlScalarNode { Value: { } v } => v,
+            _ => string.Empty,
+        };
+
+        private static IEnumerable<string> ScalarValues(YamlSequenceNode seq)
+        {
+            foreach (var item in seq.Children)
+                if (item is YamlScalarNode { Value: { } v })
+                    yield return v;
         }
 
         // Resolves the transport into the (network, path, wsHost) triple XrayConfigBuilder

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -119,7 +119,7 @@ namespace XrayUI.Services
                 SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline
             };
             var cmbProtocol = new ComboBox { Header = L.EditServer_Protocol, MinWidth = 200 };
-            foreach (var p in new[] { "ss", "vmess", "vless", "hysteria2", "trojan", "socks" })
+            foreach (var p in new[] { "ss", "vmess", "vless", "hysteria2", "trojan", "socks", "wireguard" })
                 cmbProtocol.Items.Add(p);
             cmbProtocol.SelectedItem = existing?.Protocol?.ToLower() ?? "ss";
 
@@ -193,6 +193,27 @@ namespace XrayUI.Services
                 Text = (existing?.Finalmask ?? string.Empty).Replace("\r\n", "\r").Replace("\n", "\r"),
             };
 
+            // WireGuard. Literal English headers, matching the other technical fields above
+            // (SNI / UUID / PublicKey (Reality) / Flow (VLESS)).
+            var txtWgPrivateKey = new TextBox { Header = "Private Key", Text = existing?.WgPrivateKey ?? string.Empty };
+            var txtWgPublicKey = new TextBox { Header = "Peer Public Key", Text = existing?.WgPublicKey ?? string.Empty };
+            var txtWgPreSharedKey = new TextBox { Header = "Pre-shared Key", Text = existing?.WgPreSharedKey ?? string.Empty };
+            var txtWgLocalAddress = new TextBox
+            {
+                Header = "Local Address",
+                PlaceholderText = "172.16.0.2/32, fd00::2/128",
+                Text = existing?.WgLocalAddress ?? string.Empty
+            };
+            var numWgMtu = new NumberBox
+            {
+                Header = "MTU",
+                Value = existing is { WgMtu: > 0 } ? existing.WgMtu : 1420,
+                Minimum = 0,
+                Maximum = 65535,
+                SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline
+            };
+            var txtWgReserved = new TextBox { Header = "Reserved", PlaceholderText = "0,0,0", Text = existing?.WgReserved ?? string.Empty };
+
             // Row containers for conditional visibility
             var rowEncryption = Wrap(cmbEncryption);
             var rowUsername = Wrap(txtUsername);
@@ -212,6 +233,12 @@ namespace XrayUI.Services
             var rowFlow = Wrap(txtFlow);
             var rowVlessEncryption = Wrap(txtVlessEncryption);
             var rowFinalmask = Wrap(txtFinalmask);
+            var rowWgPrivateKey = Wrap(txtWgPrivateKey);
+            var rowWgPublicKey = Wrap(txtWgPublicKey);
+            var rowWgPreSharedKey = Wrap(txtWgPreSharedKey);
+            var rowWgLocalAddress = Wrap(txtWgLocalAddress);
+            var rowWgMtu = Wrap(numWgMtu);
+            var rowWgReserved = Wrap(txtWgReserved);
 
             void UpdateVisibility()
             {
@@ -225,7 +252,8 @@ namespace XrayUI.Services
                 bool isHysteria2 = proto == "hysteria2";
                 bool isTrojan = proto == "trojan";
                 bool isSocks = proto == "socks";
-                bool isStandardTransport = !isHysteria2 && !isSocks;
+                bool isWireguard = proto == "wireguard";
+                bool isStandardTransport = !isHysteria2 && !isSocks && !isWireguard;
                 bool hasWs = isStandardTransport && net == "ws";
                 bool hasXhttp = isStandardTransport && net == "xhttp";
                 bool hasGrpc = isStandardTransport && net == "grpc";
@@ -255,6 +283,14 @@ namespace XrayUI.Services
                 rowSpx.Visibility = hasReality ? Visibility.Visible : Visibility.Collapsed;
                 rowFlow.Visibility = isVless ? Visibility.Visible : Visibility.Collapsed;
                 rowVlessEncryption.Visibility = isVless ? Visibility.Visible : Visibility.Collapsed;
+
+                var wg = isWireguard ? Visibility.Visible : Visibility.Collapsed;
+                rowWgPrivateKey.Visibility = wg;
+                rowWgPublicKey.Visibility = wg;
+                rowWgPreSharedKey.Visibility = wg;
+                rowWgLocalAddress.Visibility = wg;
+                rowWgMtu.Visibility = wg;
+                rowWgReserved.Visibility = wg;
             }
 
             cmbProtocol.SelectionChanged += (_, _) =>
@@ -282,6 +318,7 @@ namespace XrayUI.Services
                     cmbNetwork, rowPath, rowWsHost,
                     cmbSecurity, rowSni, rowFp, rowAllowInsecure, rowEchConfigList, rowEchForceQuery,
                     rowPk, rowSid, rowSpx, rowFlow, rowVlessEncryption,
+                    rowWgPrivateKey, rowWgPublicKey, rowWgPreSharedKey, rowWgLocalAddress, rowWgMtu, rowWgReserved,
                     rowFinalmask
                 }
             };
@@ -290,7 +327,13 @@ namespace XrayUI.Services
             {
                 Content = form,
                 MaxHeight = 520,
-                VerticalScrollBarVisibility = ScrollBarVisibility.Auto
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                // Padding gives the scrollbar its own gutter so it doesn't crowd the
+                // form; the matching negative margin lets that gutter overlap the
+                // dialog's existing right padding, so the form content stays centered
+                // (left/right whitespace symmetric) and aligned with the title.
+                Padding = new Thickness(0, 0, 14, 0),
+                Margin = new Thickness(0, 0, -14, 0)
             };
 
             var dialog = CreateDialog();
@@ -328,10 +371,39 @@ namespace XrayUI.Services
             entry.Flow = txtFlow.Text.Trim();
             entry.VlessEncryption = txtVlessEncryption.Text.Trim();
             entry.Finalmask = FinalmaskJson.NormalizeForStorage(txtFinalmask.Text);
+            entry.WgPrivateKey = txtWgPrivateKey.Text.Trim();
+            entry.WgPublicKey = txtWgPublicKey.Text.Trim();
+            entry.WgPreSharedKey = txtWgPreSharedKey.Text.Trim();
+            entry.WgLocalAddress = txtWgLocalAddress.Text.Trim();
+            entry.WgReserved = txtWgReserved.Text.Trim();
+            entry.WgMtu = double.IsNaN(numWgMtu.Value) ? 0 : (int)numWgMtu.Value;
 
             if (entry.Protocol == "hysteria2")
             {
                 entry.Security = "tls";
+            }
+            else if (entry.Protocol == "wireguard")
+            {
+                entry.Network = string.Empty;
+                entry.Security = string.Empty;
+                entry.Encryption = "WireGuard";
+                entry.Username = string.Empty;
+                entry.Password = string.Empty;
+                entry.Uuid = string.Empty;
+                entry.AlterId = 0;
+                entry.Path = string.Empty;
+                entry.WsHost = string.Empty;
+                entry.Sni = string.Empty;
+                entry.Fingerprint = string.Empty;
+                entry.AllowInsecure = false;
+                entry.EchConfigList = string.Empty;
+                entry.EchForceQuery = string.Empty;
+                entry.PublicKey = string.Empty;
+                entry.ShortId = string.Empty;
+                entry.SpiderX = string.Empty;
+                entry.Flow = string.Empty;
+                entry.VlessEncryption = string.Empty;
+                entry.Finalmask = string.Empty;
             }
             else if (entry.Protocol == "socks")
             {
@@ -359,6 +431,17 @@ namespace XrayUI.Services
                 entry.Username = string.Empty;
             }
 
+            // Switching away from WireGuard must not leave stale tunnel keys/addresses behind.
+            if (entry.Protocol != "wireguard")
+            {
+                entry.WgPrivateKey = string.Empty;
+                entry.WgPublicKey = string.Empty;
+                entry.WgPreSharedKey = string.Empty;
+                entry.WgLocalAddress = string.Empty;
+                entry.WgReserved = string.Empty;
+                entry.WgMtu = 0;
+            }
+
             if (!string.Equals(entry.Protocol, "vless", StringComparison.OrdinalIgnoreCase)
                 || !string.Equals(entry.Security, "tls", StringComparison.OrdinalIgnoreCase)
                 || string.IsNullOrWhiteSpace(entry.EchConfigList))
@@ -367,7 +450,7 @@ namespace XrayUI.Services
                 entry.EchForceQuery = string.Empty;
             }
 
-            if (entry.Protocol != "ss" && entry.Protocol != "socks")
+            if (entry.Protocol != "ss" && entry.Protocol != "socks" && entry.Protocol != "wireguard")
             {
                 entry.Encryption = entry.Security == "reality" ? "Reality"
                     : entry.Security == "tls" ? "TLS"

--- a/Services/LatencyProbeService.cs
+++ b/Services/LatencyProbeService.cs
@@ -45,7 +45,13 @@ namespace XrayUI.Services
                 });
             }
 
-            return string.Equals(server.Protocol, "hysteria2", StringComparison.OrdinalIgnoreCase)
+            // hysteria2 and wireguard expose a UDP endpoint that won't answer a TCP connect, so
+            // fall back to an ICMP ping of the host for their single-node latency readout.
+            var isUdpEndpoint =
+                string.Equals(server.Protocol, "hysteria2", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(server.Protocol, "wireguard", StringComparison.OrdinalIgnoreCase);
+
+            return isUdpEndpoint
                 ? _pingProbe.ProbeAsync(server.Host, timeout, cancellationToken)
                 : _tcpConnectProbe.ProbeAsync(server.Host, server.Port, timeout, cancellationToken);
         }

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -548,21 +548,47 @@ namespace XrayUI.Services
             return $"{formatted}:{port}";
         }
 
-        /// <summary>Parses "a,b,c" into a 3-int JsonArray for xray's WireGuard reserved field; null when it isn't exactly three integers.</summary>
+        /// <summary>
+        /// Parses xray's WireGuard reserved bytes into a 3-int JsonArray. Accepts both the integer
+        /// form ("209,98,59") and the base64 scalar form ("U4An", common for Cloudflare WARP nodes);
+        /// returns null when it resolves to neither exactly three integers nor exactly three bytes.
+        /// </summary>
         private static JsonArray? ParseWireguardReserved(string reserved)
         {
             if (string.IsNullOrWhiteSpace(reserved))
                 return null;
 
-            var parts = reserved.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            if (parts.Length != 3)
-                return null;
+            var trimmed = reserved.Trim();
 
-            var array = new JsonArray();
-            foreach (var part in parts)
+            // Integer form: exactly three comma-separated ints.
+            var parts = trimmed.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length == 3 && parts.All(p => int.TryParse(p, out _)))
             {
-                if (!int.TryParse(part, out var value))
-                    return null;
+                return ToReservedArray(parts.Select(int.Parse));
+            }
+
+            // Base64 form: WARP-style "U4An" decodes to the three reserved bytes. Dropping it would
+            // silently omit settings.reserved and break the handshake for those nodes.
+            try
+            {
+                var bytes = Convert.FromBase64String(trimmed);
+                if (bytes.Length == 3)
+                {
+                    return ToReservedArray(bytes.Select(b => (int)b));
+                }
+            }
+            catch (FormatException)
+            {
+            }
+
+            return null;
+        }
+
+        private static JsonArray ToReservedArray(IEnumerable<int> values)
+        {
+            var array = new JsonArray();
+            foreach (var value in values)
+            {
                 array.Add((JsonNode?)JsonValue.Create(value));
             }
             return array;

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -211,8 +211,12 @@ namespace XrayUI.Services
                 foreach (var outbound in list.OfType<JsonObject>())
                 {
                     var tag = outbound["tag"]?.GetValue<string>();
-                    if (tag is ProxyOutboundTag or DirectOutboundTag or ChainEntryOutboundTag)
+                    var protocol = outbound["protocol"]?.GetValue<string>();
+                    if (tag is ProxyOutboundTag or DirectOutboundTag or ChainEntryOutboundTag
+                        && !string.Equals(protocol, "wireguard", StringComparison.OrdinalIgnoreCase))
+                    {
                         ApplyOutboundInterface(outbound, outboundInterface);
+                    }
                 }
             }
 
@@ -298,6 +302,7 @@ namespace XrayUI.Services
                 "hysteria2" => BuildHysteria2Outbound(server, tag),
                 "trojan" => BuildTrojanOutbound(server, tag),
                 "socks" => BuildSocksOutbound(server, tag),
+                "wireguard" => BuildWireguardOutbound(server, tag),
                 _ => BuildSsOutbound(server, tag)
             };
         }
@@ -480,6 +485,87 @@ namespace XrayUI.Services
                     ["servers"] = servers
                 }
             };
+        }
+
+        private static JsonObject BuildWireguardOutbound(ServerEntry server, string tag)
+        {
+            var address = CreateStringArray(
+                server.WgLocalAddress.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+
+            var peer = new JsonObject
+            {
+                ["publicKey"] = server.WgPublicKey,
+                ["endpoint"] = FormatEndpoint(server.Host, server.Port),
+                ["allowedIPs"] = CreateStringArray("0.0.0.0/0", "::/0"),
+                ["keepAlive"] = 0
+            };
+            if (!string.IsNullOrWhiteSpace(server.WgPreSharedKey))
+            {
+                peer["preSharedKey"] = server.WgPreSharedKey;
+            }
+
+            var peers = new JsonArray();
+            AddNode(peers, peer);
+
+            var settings = new JsonObject
+            {
+                ["secretKey"] = server.WgPrivateKey,
+                ["peers"] = peers,
+                ["domainStrategy"] = "ForceIP"
+            };
+
+            // Omit address entirely when no CIDR was configured: an explicit "address": [] reads as
+            // "the user set zero local addresses", whereas omitting it lets xray fall back to its
+            // built-in default. Mirrors the omit-when-empty handling of mtu/reserved/preSharedKey.
+            if (address.Count > 0)
+            {
+                settings["address"] = address;
+            }
+
+            if (server.WgMtu > 0)
+            {
+                settings["mtu"] = server.WgMtu;
+            }
+
+            var reserved = ParseWireguardReserved(server.WgReserved);
+            if (reserved is not null)
+            {
+                settings["reserved"] = reserved;
+            }
+
+            return new JsonObject
+            {
+                ["tag"] = tag,
+                ["protocol"] = "wireguard",
+                ["settings"] = settings
+            };
+        }
+
+        /// <summary>Wraps a bare IPv6 literal in brackets so "host:port" stays unambiguous.</summary>
+        private static string FormatEndpoint(string host, int port)
+        {
+            var formatted = host.Contains(':') && !host.StartsWith('[') ? $"[{host}]" : host;
+            return $"{formatted}:{port}";
+        }
+
+        /// <summary>Parses "a,b,c" into a 3-int JsonArray for xray's WireGuard reserved field; null when it isn't exactly three integers.</summary>
+        private static JsonArray? ParseWireguardReserved(string reserved)
+        {
+            if (string.IsNullOrWhiteSpace(reserved))
+                return null;
+
+            var parts = reserved.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length != 3)
+                return null;
+
+            var array = new JsonArray();
+            foreach (var part in parts)
+            {
+                if (!int.TryParse(part, out var value))
+                    return null;
+                array.Add((JsonNode?)JsonValue.Create(value));
+            }
+            return array;
         }
 
         private static JsonObject BuildStreamSettings(ServerEntry server)

--- a/ViewModels/ServerDetailViewModel.cs
+++ b/ViewModels/ServerDetailViewModel.cs
@@ -112,7 +112,8 @@ namespace XrayUI.ViewModels
                     return "-";
                 }
 
-                if (string.Equals(SelectedServer.Protocol, "hysteria2", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(SelectedServer.Protocol, "hysteria2", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(SelectedServer.Protocol, "wireguard", StringComparison.OrdinalIgnoreCase))
                 {
                     return "UDP";
                 }


### PR DESCRIPTION
## What

Adds **WireGuard** as a supported outbound protocol, alongside the existing `ss / vmess / vless / hysteria2 / trojan / socks`. Nodes can be added via the manual **Add/Edit** dialog or imported from **Clash YAML** (`type: wireguard`). There is intentionally **no share-link** support — WireGuard has no standard URI scheme.

## Why

Users asked to connect to WireGuard endpoints. xray-core ships a native `wireguard` outbound, so this is purely client-side plumbing: extend the flat `ServerEntry` field-bag, emit the outbound, wire up the dialog/import, and fix the per-protocol display/probe switches.

## Changes

- **`Models/ServerEntry.cs`** — 6 WireGuard fields (`WgPrivateKey`, `WgPublicKey`, `WgPreSharedKey`, `WgLocalAddress`, `WgReserved`, `WgMtu`), following the existing flat per-protocol layout; `DisplayProtocol` → `WireGuard`.
- **`Services/XrayConfigBuilder.cs`** — `BuildWireguardOutbound` emits a native xray `wireguard` outbound (`secretKey`, `address`, `peers[].endpoint/allowedIPs`, `domainStrategy: ForceIP`). `mtu` / `reserved` / `preSharedKey` / `address` are **omitted when empty** so xray's built-in defaults still apply (avoids emitting a misleading `"address": []`). WireGuard outbounds are also excluded from TUN `sockopt.interface` pinning since they have no `streamSettings`.
- **`Services/ClashConfigParser.cs`** — maps `type: wireguard` proxies on import (bare `ip`/`ipv6` → CIDR; rows missing required keys are skipped).
- **`Services/DialogService.cs`** — WireGuard fields + conditional visibility in the Add/Edit dialog, with stale-field cleanup when switching protocols.
- **`ViewModels/ServerDetailViewModel.cs`** — transport shown as `UDP` for WireGuard.
- **`Services/LatencyProbeService.cs`** — single-node latency uses ICMP ping (the UDP endpoint won't answer a TCP connect), matching hysteria2. The batch real-delay test already routes through `BuildProxyOutbound`, so it works for free.
- **`README.md`** — protocol list updated.

## Notes for reviewer

- Badge color reuses the neutral **Fallback** color (same as `trojan`/`socks`) — `ProtocolColorStore.GetColor` already falls through, so no personalization changes.
- No new `[JsonSerializable]` entry needed: adding properties to the already-registered `ServerEntry` is covered by the source generator.
- Field headers in the dialog use literal English (`Private Key`, `Peer Public Key`, …), matching the existing technical labels there (`SNI`, `UUID`, `PublicKey (Reality)`), so no new `.resw`/`L.*` entries.
- Includes a small incidental `ScrollViewer` gutter tweak in the (now-taller) Add/Edit dialog.
- Builds clean (`BuildAndRun.ps1 -SkipRun`); the only warnings are pre-existing `WMC1510` in `AppSettingsExpander.xaml`.

## Testing

- [x] Debug build succeeds.
- [x] Manual: add a WireGuard node, connect, verify the generated `wireguard` outbound and that traffic exits via the tunnel.
- [ ] Import a Clash YAML containing a `type: wireguard` proxy.
- [x] Node-detail latency returns a ping value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)