### PR TITLE
feat(tray): reflect connection status in tray icon tooltip

### DIFF
--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -190,6 +190,8 @@ public static class L
     public static string MainWindow_Close      => Loc.GetString("MainWindow_Close");
     public static string Tray_Open             => Loc.GetString("Tray_Open");
     public static string Tray_Exit             => Loc.GetString("Tray_Exit");
+    // Tray_TooltipRunning is parameterized ("XrayUI - {0}") — use Loc.Format at the call site.
+    public static string Tray_TooltipIdle      => Loc.GetString("Tray_TooltipIdle");
 
     // ── ServerList ─────────────────────────────────────────────────────────
     public static string ServerList_AllServers       => Loc.GetString("ServerList_AllServers");

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -20,8 +20,10 @@ namespace XrayUI
         private readonly FrameworkElement _rootElement;
         private readonly Border _miniDragRegion;
         private readonly Button _miniExpandButton;
-        private readonly WindowManager _windowManager;
         private readonly WindowMessageMonitor _windowMessageMonitor;
+        // We own the tray icon directly (rather than WindowManager.IsVisibleInTray) so the
+        // tooltip can track connection state; see ConfigureTray.
+        private TrayIcon? _trayIcon;
         private bool _isSessionEnding;
         private bool _allowClose;
         private bool _initialized;
@@ -41,6 +43,12 @@ namespace XrayUI
         private const int FullWindowHeight = 600;
         private const int MiniWindowWidth = 330;
         private const int MiniWindowHeight = 136;
+        // Unique id for our own tray icon, independent of WinUIEx's WindowManager tray.
+        // Must be a positive 16-bit value: the Shell_NotifyIcon v4 callback reports the icon id
+        // in HIWORD(lParam) (a signed short), so a wider id is truncated on the way back and
+        // every click would fail the id match in TrayIcon.ProcessTrayIconEvents (icon still
+        // shows, but left/right clicks do nothing).
+        private const uint TrayIconId = 0x5852;
 
         public MainViewModel ViewModel { get; }
 
@@ -67,7 +75,10 @@ namespace XrayUI
             ToolTipService.SetToolTip(MinicloseButton,   L.MainWindow_Close);
 
             // Initial size is established by ApplyWindowMode(isMini: false) below.
-            _windowManager = WindowManager.Get(this);
+            // Get attaches WinUIEx window management to this window for its side effects
+            // (min-size clamping, placement); we don't keep the reference — the tray icon is
+            // owned directly via _trayIcon so we can drive its tooltip from connection state.
+            WindowManager.Get(this);
             _windowMessageMonitor = new WindowMessageMonitor(this);
             _windowMessageMonitor.WindowMessageReceived += OnWindowMessageReceived;
 
@@ -89,7 +100,11 @@ namespace XrayUI
             _miniExpandButton.Click += MiniExpandButton_Click;
 
             var miniCloseButton = (Button)_rootElement.FindName("MinicloseButton");
-            miniCloseButton.Click += (_, _) => HideToTray();
+            miniCloseButton.Click += (_, _) =>
+            {
+                if (!HideToTray())
+                    ExitApplication();
+            };
 
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(AppTitleBar);
@@ -119,7 +134,10 @@ namespace XrayUI
 
             await ViewModel.InitializeAsync(isBootLaunch: _startMinimized);
 
-            if (_startMinimized) HideToTray();
+            if (_startMinimized && !HideToTray())
+            {
+                RestoreFromTray();
+            }
         }
 
         private void AppTitleBar_BackRequested(object sender, RoutedEventArgs e)
@@ -141,26 +159,9 @@ namespace XrayUI
             if (File.Exists(iconPath))
             {
                 AppWindow.SetIcon(iconPath);
+                _trayIcon = TryCreateTrayIcon(iconPath);
             }
 
-            _windowManager.IsVisibleInTray = true;
-            _windowManager.TrayIconSelected += (_, _) => RestoreFromTray();
-            _windowManager.TrayIconContextMenu += (_, e) =>
-            {
-                var flyout = new MenuFlyout();
-
-				var openItem = new MenuFlyoutItem { Text = L.Tray_Open };
-                openItem.Click += (_, _) => RestoreFromTray();
-                flyout.Items.Add(openItem);
-
-                flyout.Items.Add(new MenuFlyoutSeparator());
-
-                var exitItem = new MenuFlyoutItem { Text = L.Tray_Exit };
-                exitItem.Click += (_, _) => ExitApplication();
-                flyout.Items.Add(exitItem);
-
-                e.Flyout = flyout;
-            };
             AppWindow.Closing += (_, args) =>
             {
                 if (_allowClose || _isSessionEnding)
@@ -168,16 +169,65 @@ namespace XrayUI
                     return;
                 }
 
-                args.Cancel = true;
-                HideToTray();
+                if (HideToTray())
+                {
+                    args.Cancel = true;
+                }
             };
         }
 
-        private void HideToTray()
+        // Own the tray icon directly instead of WindowManager.IsVisibleInTray: WinUIEx ties that
+        // built-in tooltip to the static window Title and never exposes it, so we create our own
+        // TrayIcon and push the tooltip via Tooltip (NIM_MODIFY) — that updates szTip only,
+        // leaving the taskbar/window icon untouched. Returns null if creation fails so the window
+        // is never stranded in a tray that isn't there (HideToTray checks for it).
+        private TrayIcon? TryCreateTrayIcon(string iconPath)
+        {
+            TrayIcon? trayIcon = null;
+            try
+            {
+                trayIcon = new TrayIcon(TrayIconId, iconPath, ViewModel.TrayTooltip);
+                trayIcon.Selected += (_, _) => RestoreFromTray();
+                trayIcon.ContextMenu += (_, e) => e.Flyout = BuildTrayContextMenu();
+                trayIcon.IsVisible = true;
+                return trayIcon;
+            }
+            catch (Exception ex)
+            {
+                trayIcon?.Dispose();
+                Debug.WriteLine($"[Tray] Failed to create tray icon: {ex.Message}");
+                return null;
+            }
+        }
+
+        private MenuFlyout BuildTrayContextMenu()
+        {
+            var flyout = new MenuFlyout();
+
+            var openItem = new MenuFlyoutItem { Text = L.Tray_Open };
+            openItem.Click += (_, _) => RestoreFromTray();
+            flyout.Items.Add(openItem);
+
+            flyout.Items.Add(new MenuFlyoutSeparator());
+
+            var exitItem = new MenuFlyoutItem { Text = L.Tray_Exit };
+            exitItem.Click += (_, _) => ExitApplication();
+            flyout.Items.Add(exitItem);
+
+            return flyout;
+        }
+
+        private bool HideToTray()
         {
             if (_isHiddenToTray)
             {
-                return;
+                return true;
+            }
+
+            if (_trayIcon is null)
+            {
+                Debug.WriteLine("[Tray] Hide requested but tray icon is unavailable.");
+                return false;
             }
 
             _isHiddenToTray = true;
@@ -193,6 +243,7 @@ namespace XrayUI
             _rootElement.Visibility = Visibility.Collapsed;
 
             ReleaseUiResources();
+            return true;
         }
 
         internal void RestoreFromTray()
@@ -231,11 +282,12 @@ namespace XrayUI
             _isHiddenToTray = false;
             try
             {
-                _windowManager.IsVisibleInTray = false;
+                _trayIcon?.Dispose();
+                _trayIcon = null;
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[Tray] Failed to hide tray icon during exit: {ex.Message}");
+                Debug.WriteLine($"[Tray] Failed to remove tray icon during exit: {ex.Message}");
             }
 
             _ = Task.Run(async () =>
@@ -359,6 +411,14 @@ namespace XrayUI
 
         private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
+            if (e.PropertyName == nameof(MainViewModel.TrayTooltip))
+            {
+                // Runs on the UI thread (VM raises PropertyChanged there); no dispatch needed.
+                if (_trayIcon is not null)
+                    _trayIcon.Tooltip = ViewModel.TrayTooltip;
+                return;
+            }
+
             if (_personalizeRealized) return;
             if (e.PropertyName != nameof(MainViewModel.PersonalizeVisibility)) return;
             if (ViewModel.PersonalizeVisibility != Visibility.Visible) return;

--- a/Properties/PublishProfiles/win-x64.pubxml
+++ b/Properties/PublishProfiles/win-x64.pubxml
@@ -7,6 +7,7 @@
     <SelfContained>true</SelfContained>
     <PublishAot>true</PublishAot>
     <OptimizationPreference>Speed</OptimizationPreference>
+    <IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
     <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
     <PublishTrimmed>true</PublishTrimmed>
     <PublishSingleFile>false</PublishSingleFile>

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -135,6 +135,13 @@
   <data name="Tray_Exit" xml:space="preserve">
     <value>Quit</value>
   </data>
+  <data name="Tray_TooltipRunning" xml:space="preserve">
+    <value>XrayUI - {0}</value>
+    <comment>{0} = active node name. Shown as the tray icon tooltip while running.</comment>
+  </data>
+  <data name="Tray_TooltipIdle" xml:space="preserve">
+    <value>XrayUI - Idle</value>
+  </data>
   <data name="ServerList_Edit" xml:space="preserve">
     <value>Edit</value>
   </data>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -135,6 +135,13 @@
   <data name="Tray_Exit" xml:space="preserve">
     <value>退出</value>
   </data>
+  <data name="Tray_TooltipRunning" xml:space="preserve">
+    <value>XrayUI - {0}</value>
+    <comment>{0} = active node name. Shown as the tray icon tooltip while running.</comment>
+  </data>
+  <data name="Tray_TooltipIdle" xml:space="preserve">
+    <value>XrayUI - 未运行</value>
+  </data>
   <data name="ServerList_Edit" xml:space="preserve">
     <value>编辑</value>
   </data>

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -38,6 +38,14 @@ namespace XrayUI.ViewModels
         public string ActiveServerName =>
             (ControlPanel.IsRunning ? _activeServer : ServerList.SelectedServer)?.Name ?? L.Main_NoSelection;
 
+        // Tray icon tooltip. Uses (IsRunning || IsReapplying) so it stays in the "running"
+        // form across a node switch — IsReapplying brackets the stop→start gap (the same
+        // masking StatusText relies on), so the tray text never flickers to "idle" mid-switch.
+        public string TrayTooltip =>
+            (ControlPanel.IsRunning || ControlPanel.IsReapplying)
+                ? Loc.Format("Tray_TooltipRunning", ActiveServerName)
+                : L.Tray_TooltipIdle;
+
         public string MiniRoutingMode => ControlPanel.RoutingModeText;
         public IAsyncRelayCommand MiniStartStopCommand => ControlPanel.StartStopCommand;
         public bool MiniIsRunning => ControlPanel.IsRunning;
@@ -248,6 +256,7 @@ namespace XrayUI.ViewModels
             {
                 ServerDetail.SelectedServer = ServerList.SelectedServer;
                 OnPropertyChanged(nameof(ActiveServerName));
+                OnPropertyChanged(nameof(TrayTooltip));
                 ControlPanel.NotifyStartStopStateChanged();
                 SwitchToSelectedServerCommand.NotifyCanExecuteChanged();
             }
@@ -275,6 +284,7 @@ namespace XrayUI.ViewModels
                 UpdateActiveServer(null);
                 ServerList.IsProxyRunning = ControlPanel.IsRunning;
                 OnPropertyChanged(nameof(ActiveServerName));
+                OnPropertyChanged(nameof(TrayTooltip));
             }
             catch (System.Exception ex)
             {
@@ -310,6 +320,7 @@ namespace XrayUI.ViewModels
             if (e.PropertyName == nameof(ControlPanelViewModel.IsReapplying))
             {
                 SwitchToSelectedServerCommand.NotifyCanExecuteChanged();
+                OnPropertyChanged(nameof(TrayTooltip));
                 return;
             }
 
@@ -325,6 +336,7 @@ namespace XrayUI.ViewModels
             UpdateActiveServer(isRunning ? ServerList.SelectedServer : null);
             ServerList.IsProxyRunning = isRunning;
             OnPropertyChanged(nameof(ActiveServerName));
+            OnPropertyChanged(nameof(TrayTooltip));
             OnPropertyChanged(nameof(MiniIsRunning));
             OnPropertyChanged(nameof(MiniStatusText));
             OnPropertyChanged(nameof(MiniDotVisibility));


### PR DESCRIPTION
## What

Show connection status in the system-tray icon **tooltip**: it reads `XrayUI - <node>` while connected and `XrayUI - Idle` when not running.

## Why

The tray icon previously had no status indication — you had to open the window to see whether the proxy was running and which node was active. A tooltip is the lightest-weight way to surface that (no icon assets, doesn't touch the taskbar/window icon).

## How

- **Own the tray icon directly.** Replaced `WindowManager.IsVisibleInTray` with a directly-owned `WinUIEx.TrayIcon`. WinUIEx slaves the `IsVisibleInTray` tooltip to the static window `Title` and never exposes it; owning the `TrayIcon` lets us push the tooltip via its `Tooltip` setter (`NIM_MODIFY` → `szTip` only), leaving the taskbar/window icon untouched.
- **New `MainViewModel.TrayTooltip`** derived property, pushed to `_trayIcon.Tooltip` from `OnViewModelPropertyChanged` (UI thread, no dispatch needed).
- **No flicker on node switch.** `TrayTooltip` keys off `(IsRunning || IsReapplying)`. During a node switch `IsReapplying` brackets the stop→start gap, so the tooltip stays in the connected form and never flickers to "idle" mid-switch — the same masking `ControlPanelViewModel.StatusText` already uses.
- **i18n.** Added `Tray_TooltipRunning` (`XrayUI - {0}`) and `Tray_TooltipIdle` to both `zh-CN` and `en-US` `.resw`, plus an `L.Tray_TooltipIdle` accessor (the parameterized one goes through `Loc.Format` per the existing convention).

## Reviewer notes

- **`TrayIconId` must be a positive 16-bit value (`0x5852`).** The `Shell_NotifyIcon` v4 callback reports the icon id in `HIWORD(lParam)` (a signed short), so a wider id is truncated on the way back and click events stop matching in WinUIEx's `TrayIcon.ProcessTrayIconEvents` (icon still shows, but left/right clicks silently do nothing). This bit the first attempt with a 32-bit id — see the inline comment.
- **`HideToTray()` now returns `bool`** (false when no tray icon exists). The three callers handle the no-tray case distinctly so the window is never stranded off-screen: mini-close falls back to exit, startup-minimized falls back to staying visible, `AppWindow.Closing` only cancels the close when the hide succeeded.
- `ConfigureTray` was factored into `TryCreateTrayIcon` + `BuildTrayContextMenu` to keep it flat.
- The second commit is an unrelated one-line build tweak (`IlcFoldIdenticalMethodBodies` in the win-x64 publish profile, AOT binary-size reduction) that was already staged in the working tree.

## Testing

- `BuildAndRun.ps1 -SkipRun` — builds clean (only pre-existing `WMC1510` warnings in `AppSettingsExpander.xaml`).
- Ran locally; verified tray right-click menu, left-click restore, and tooltip text. Please double-check the tooltip across connect / disconnect / **node switch** (the no-flicker path) on your setup.

