### PR TITLE
feat: add HTTP outbound protocol support

### DIFF
--- a/Models/ServerEntry.cs
+++ b/Models/ServerEntry.cs
@@ -196,6 +196,7 @@ namespace XrayUI.Models
             "hysteria2" => "Hysteria 2",
             "trojan" => "Trojan",
             "socks" => "SOCKS",
+            "http" => "HTTP",
             "wireguard" => "WireGuard",
             "chain" => "ProxyChain",
             _ => Protocol ?? string.Empty

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -119,7 +119,7 @@ namespace XrayUI.Services
                 SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline
             };
             var cmbProtocol = new ComboBox { Header = L.EditServer_Protocol, MinWidth = 200 };
-            foreach (var p in new[] { "ss", "vmess", "vless", "hysteria2", "trojan", "socks", "wireguard" })
+            foreach (var p in new[] { "ss", "vmess", "vless", "hysteria2", "trojan", "socks", "http", "wireguard" })
                 cmbProtocol.Items.Add(p);
             cmbProtocol.SelectedItem = existing?.Protocol?.ToLower() ?? "ss";
 
@@ -252,8 +252,9 @@ namespace XrayUI.Services
                 bool isHysteria2 = proto == "hysteria2";
                 bool isTrojan = proto == "trojan";
                 bool isSocks = proto == "socks";
+                bool isHttp = proto == "http";
                 bool isWireguard = proto == "wireguard";
-                bool isStandardTransport = !isHysteria2 && !isSocks && !isWireguard;
+                bool isStandardTransport = !isHysteria2 && !isSocks && !isHttp && !isWireguard;
                 bool hasWs = isStandardTransport && net == "ws";
                 bool hasXhttp = isStandardTransport && net == "xhttp";
                 bool hasGrpc = isStandardTransport && net == "grpc";
@@ -265,8 +266,8 @@ namespace XrayUI.Services
                 cmbSecurity.Visibility = isStandardTransport ? Visibility.Visible : Visibility.Collapsed;
 
                 rowEncryption.Visibility = isSs ? Visibility.Visible : Visibility.Collapsed;
-                rowUsername.Visibility = isSocks ? Visibility.Visible : Visibility.Collapsed;
-                rowPassword.Visibility = (isSs || isHysteria2 || isTrojan || isSocks)
+                rowUsername.Visibility = (isSocks || isHttp) ? Visibility.Visible : Visibility.Collapsed;
+                rowPassword.Visibility = (isSs || isHysteria2 || isTrojan || isSocks || isHttp)
                     ? Visibility.Visible
                     : Visibility.Collapsed;
                 rowUuid.Visibility = (isVmess || isVless) ? Visibility.Visible : Visibility.Collapsed;
@@ -405,7 +406,7 @@ namespace XrayUI.Services
                 entry.VlessEncryption = string.Empty;
                 entry.Finalmask = string.Empty;
             }
-            else if (entry.Protocol == "socks")
+            else if (entry.Protocol == "socks" || entry.Protocol == "http")
             {
                 entry.Network = "tcp";
                 entry.Security = "none";
@@ -450,7 +451,7 @@ namespace XrayUI.Services
                 entry.EchForceQuery = string.Empty;
             }
 
-            if (entry.Protocol != "ss" && entry.Protocol != "socks" && entry.Protocol != "wireguard")
+            if (entry.Protocol != "ss" && entry.Protocol != "socks" && entry.Protocol != "http" && entry.Protocol != "wireguard")
             {
                 entry.Encryption = entry.Security == "reality" ? "Reality"
                     : entry.Security == "tls" ? "TLS"

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -302,6 +302,7 @@ namespace XrayUI.Services
                 "hysteria2" => BuildHysteria2Outbound(server, tag),
                 "trojan" => BuildTrojanOutbound(server, tag),
                 "socks" => BuildSocksOutbound(server, tag),
+                "http" => BuildHttpOutbound(server, tag),
                 "wireguard" => BuildWireguardOutbound(server, tag),
                 _ => BuildSsOutbound(server, tag)
             };
@@ -480,6 +481,40 @@ namespace XrayUI.Services
             {
                 ["tag"] = tag,
                 ["protocol"] = "socks",
+                ["settings"] = new JsonObject
+                {
+                    ["servers"] = servers
+                }
+            };
+        }
+
+        private static JsonObject BuildHttpOutbound(ServerEntry server, string tag)
+        {
+            var serverObject = new JsonObject
+            {
+                ["address"] = server.Host,
+                ["port"] = server.Port,
+            };
+
+            if (!string.IsNullOrWhiteSpace(server.Username)
+                || !string.IsNullOrWhiteSpace(server.Password))
+            {
+                var users = new JsonArray();
+                AddNode(users, new JsonObject
+                {
+                    ["user"] = server.Username,
+                    ["pass"] = server.Password,
+                });
+                serverObject["users"] = users;
+            }
+
+            var servers = new JsonArray();
+            AddNode(servers, serverObject);
+
+            return new JsonObject
+            {
+                ["tag"] = tag,
+                ["protocol"] = "http",
                 ["settings"] = new JsonObject
                 {
                     ["servers"] = servers

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -489,7 +489,7 @@
     <value>This will overwrite all current servers and routing rules. We strongly recommend exporting a backup first. Continue?</value>
   </data>
   <data name="EditServer_SocksUsername" xml:space="preserve">
-    <value>Username (SOCKS)</value>
+    <value>Username</value>
   </data>
   <data name="EditServer_EchPlaceholder" xml:space="preserve">
     <value>e.g. udp://1.1.1.1 or server-generated ECHConfig</value>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -489,7 +489,7 @@
     <value>此操作将覆盖您当前的全部节点和路由规则,强烈建议先导出备份。是否继续?</value>
   </data>
   <data name="EditServer_SocksUsername" xml:space="preserve">
-    <value>用户名 (SOCKS)</value>
+    <value>用户名</value>
   </data>
   <data name="EditServer_EchPlaceholder" xml:space="preserve">
     <value>例如 udp://1.1.1.1 或服务端生成的 ECHConfig</value>

--- a/ViewModels/ServerDetailViewModel.cs
+++ b/ViewModels/ServerDetailViewModel.cs
@@ -74,6 +74,7 @@ namespace XrayUI.ViewModels
             {
                 "ss"    => L.ServerDetail_Encryption,
                 "socks" => L.ServerDetail_AuthLabel,
+                "http"  => L.ServerDetail_AuthLabel,
                 "chain" => L.ServerDetail_ChainLabel,
                 _       => L.ServerDetail_Security
             };
@@ -86,6 +87,7 @@ namespace XrayUI.ViewModels
                 switch (SelectedServer.Protocol?.ToLowerInvariant())
                 {
                     case "socks":
+                    case "http":
                         return string.IsNullOrWhiteSpace(SelectedServer.Username)
                                && string.IsNullOrWhiteSpace(SelectedServer.Password)
                             ? L.ServerDetail_NoAuth


### PR DESCRIPTION
## Summary
- Extend outbound protocols with HTTP support in `XrayConfigBuilder`
- Update models, views, and strings (en-US/zh-CN) to expose HTTP as a configurable outbound option
- Add conditional field visibility for HTTP in the Add/Edit server dialog

## Test plan
- [x] Build with `.\BuildAndRun.ps1` and add a server with the new HTTP outbound protocol
- [x] Verify generated xray config produces a valid `http` outbound
- [x] Verify Add/Edit dialog shows/hides fields correctly when switching to/from HTTP