### PR TITLE
Revert list diff-sync: restore Clear+rebuild for VisibleServers

### DIFF
--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -512,6 +512,7 @@ namespace XrayUI.ViewModels
         private void RebuildGroupedView()
         {
             var previousSelection = SelectedServer;
+            VisibleServers.Clear();
 
             var query = (SearchQuery ?? string.Empty).Trim();
             bool MatchesSearch(ServerEntry s) =>
@@ -546,12 +547,13 @@ namespace XrayUI.ViewModels
                 _ => filtered,
             };
 
-            SyncVisibleServers(ordered.ToList());
+            foreach (var server in ordered)
+                VisibleServers.Add(server);
 
-            // Diff sync keeps the selected row alive unless it actually left the view, but
-            // the ListView's TwoWay selection binding can still null SelectedServer on a
-            // Remove/Move touching the selected row; put it back whenever the entry is
-            // still visible so no rebuild silently drops the selection.
+            // Clearing VisibleServers nulls SelectedServer through the ListView's TwoWay
+            // selection binding; put it back whenever the entry is still visible so no
+            // rebuild (search, chip switch, subscription edit/refresh) silently drops
+            // the selection.
             if (previousSelection != null && SelectedServer == null &&
                 VisibleServers.Contains(previousSelection))
             {
@@ -559,42 +561,6 @@ namespace XrayUI.ViewModels
             }
 
             OnPropertyChanged(nameof(CanReorderInCurrentChip));
-        }
-
-        // Reshapes VisibleServers into the target sequence with per-item Remove/Move/Insert
-        // deltas instead of Clear + re-Add. Rows that didn't change position produce no
-        // collection notification at all, so the ListView keeps their containers (and the
-        // selection) — a latency restream or a search keystroke only pays for the entries
-        // that actually moved. Entries are unique instances, so reference identity is the key.
-        private void SyncVisibleServers(List<ServerEntry> target)
-        {
-            if (target.Count == 0)
-            {
-                VisibleServers.Clear();
-                return;
-            }
-
-            var targetSet = new HashSet<ServerEntry>(target);
-            for (int i = VisibleServers.Count - 1; i >= 0; i--)
-            {
-                if (!targetSet.Contains(VisibleServers[i]))
-                    VisibleServers.RemoveAt(i);
-            }
-
-            // Invariant: after step i, VisibleServers[0..i] == target[0..i]; any survivor
-            // of the removal pass that is out of place is therefore always found at an
-            // index > i, so Move never disturbs the already-synced prefix.
-            for (int i = 0; i < target.Count; i++)
-            {
-                if (i < VisibleServers.Count && ReferenceEquals(VisibleServers[i], target[i]))
-                    continue;
-
-                var currentIdx = VisibleServers.IndexOf(target[i]);
-                if (currentIdx >= 0)
-                    VisibleServers.Move(currentIdx, i);
-                else
-                    VisibleServers.Insert(i, target[i]);
-            }
         }
 
         // Latency sort ordering buckets: 0 = a real measurement (sorted by ms),


### PR DESCRIPTION
## Summary
- Reverts the per-item Remove/Insert/Move diff-sync added in #68 for `RebuildGroupedView`/`VisibleServers`, restoring the previous `Clear()` + bulk `Add` rebuild.
- Atomic save (the other half of #68) is untouched.

## Why
The diff-sync targeted a theoretical hot path (latency-restream while sorted by latency) but made real, reported-slower cases worse: switching chips and refreshing subscriptions are near-total swaps of `VisibleServers`, and each individual Remove/Insert/Move fires its own ListView animation — Insert especially, since it has to create and bind a brand-new container. Patching this with overlap-ratio / absolute-count thresholds kept surfacing new edge cases (asymmetric chip-switch direction, subscription refresh while viewing "All", sort-mode reshuffles) without ever fully closing them.

At this list's actual scale, full Clear+repopulate was never reported as slow — it's fast enough that the diff-sync's real-world benefit didn't justify the added complexity and edge cases.

## Validation
- `dotnet build` (Debug, x64) succeeds.
- Manually tested chip switching (All ↔ Favorites ↔ subscription) after the revert — no perceived slowdown in either direction.