### PR TITLE
Add global hotkeys for start/stop proxy and restore from tray

### DIFF
--- a/Helpers/GlobalHotkeyStore.cs
+++ b/Helpers/GlobalHotkeyStore.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Text;
+using XrayUI.Models;
+
+namespace XrayUI.Helpers
+{
+    /// <summary>
+    /// Runtime mutable store for the two global hotkeys (toggle start/stop, restore from tray).
+    /// Loaded from AppSettings at startup; updated live by the Personalize page so MainWindow
+    /// can re-register with user32 immediately, before Done persists the change — mirrors
+    /// <see cref="ProtocolColorStore"/>. No separate enabled flag: a hotkey is active whenever
+    /// its VirtualKey is non-zero (assigned), matching PowerToys' shortcut behavior.
+    /// </summary>
+    public static class GlobalHotkeyStore
+    {
+        public const int ToggleId = 1;
+        public const int RestoreId = 2;
+
+        public const uint ModAlt = 0x0001;
+        public const uint ModControl = 0x0002;
+        public const uint ModShift = 0x0004;
+        public const uint ModWin = 0x0008;
+
+        public static uint ToggleModifiers { get; set; }
+        public static uint ToggleVirtualKey { get; set; }
+
+        public static uint RestoreModifiers { get; set; }
+        public static uint RestoreVirtualKey { get; set; }
+
+        public static event EventHandler? HotkeysChanged;
+        public static void NotifyHotkeysChanged() => HotkeysChanged?.Invoke(null, EventArgs.Empty);
+
+        /// <summary>Reads the combo for <see cref="ToggleId"/> or <see cref="RestoreId"/> — lets
+        /// callers that already branch on id (MainWindow's registration loop, the Personalize
+        /// hotkey dialog) avoid a separate Toggle/Restore branch just to pick the right fields.</summary>
+        public static (uint Mods, uint Vk) GetCombo(int id) => id switch
+        {
+            ToggleId => (ToggleModifiers, ToggleVirtualKey),
+            RestoreId => (RestoreModifiers, RestoreVirtualKey),
+            _ => (0, 0),
+        };
+
+        /// <summary>See <see cref="GetCombo"/>.</summary>
+        public static void SetCombo(int id, uint mods, uint vk)
+        {
+            if (id == ToggleId) { ToggleModifiers = mods; ToggleVirtualKey = vk; }
+            else if (id == RestoreId) { RestoreModifiers = mods; RestoreVirtualKey = vk; }
+        }
+
+        public static void LoadFrom(AppSettings s)
+        {
+            (ToggleModifiers, ToggleVirtualKey) = ParseCombo(s.HotkeyToggleCombo);
+            (RestoreModifiers, RestoreVirtualKey) = ParseCombo(s.HotkeyRestoreCombo);
+        }
+
+        public static void SaveTo(AppSettings s)
+        {
+            s.HotkeyToggleCombo = FormatCombo(ToggleModifiers, ToggleVirtualKey);
+            s.HotkeyRestoreCombo = FormatCombo(RestoreModifiers, RestoreVirtualKey);
+        }
+
+        private static (uint mods, uint vk) ParseCombo(string? raw)
+        {
+            if (string.IsNullOrEmpty(raw)) return (0, 0);
+            var parts = raw.Split(':');
+            if (parts.Length == 2 &&
+                uint.TryParse(parts[0], out var mods) &&
+                uint.TryParse(parts[1], out var vk))
+                return (mods, vk);
+            return (0, 0);
+        }
+
+        private static string? FormatCombo(uint mods, uint vk) =>
+            vk == 0 ? null : $"{mods}:{vk}";
+
+        /// <summary>Friendly display like "Ctrl+Alt+S" — deliberately not localized; keyboard
+        /// shortcuts are conventionally shown in Latin abbreviations even on non-English Windows.
+        /// Returns "" when no key is set.</summary>
+        public static string FormatDisplay(uint mods, uint vk)
+        {
+            if (vk == 0) return "";
+
+            var sb = new StringBuilder();
+            if ((mods & ModControl) != 0) sb.Append("Ctrl+");
+            if ((mods & ModAlt) != 0) sb.Append("Alt+");
+            if ((mods & ModShift) != 0) sb.Append("Shift+");
+            if ((mods & ModWin) != 0) sb.Append("Win+");
+            sb.Append(KeyName(vk));
+            return sb.ToString();
+        }
+
+        // VK_OEM_* codes are positional (US QWERTY) rather than character-based, so ToUnicode/
+        // the active keyboard layout would be needed for a fully layout-correct label. Hardcoding
+        // the US QWERTY glyph is the same simplification most editors' keybinding UIs make, and is
+        // good enough for a 2-hotkey feature — not worth pulling in MapVirtualKey/ToUnicode interop.
+        private static string KeyName(uint vk) => vk switch
+        {
+            >= 0x30 and <= 0x39 => ((char)vk).ToString(), // 0-9
+            >= 0x41 and <= 0x5A => ((char)vk).ToString(), // A-Z
+            >= 0x70 and <= 0x87 => $"F{vk - 0x6F}",        // F1-F24
+            >= 0x60 and <= 0x69 => $"Num{vk - 0x60}",      // Numpad 0-9
+            0x6A => "Num*",
+            0x6B => "Num+",
+            0x6D => "Num-",
+            0x6E => "Num.",
+            0x6F => "Num/",
+            0x08 => "Backspace",
+            0x09 => "Tab",
+            0x0D => "Enter",
+            0x14 => "CapsLock",
+            0x20 => "Space",
+            0x21 => "PageUp",
+            0x22 => "PageDown",
+            0x23 => "End",
+            0x24 => "Home",
+            0x25 => "Left",
+            0x26 => "Up",
+            0x27 => "Right",
+            0x28 => "Down",
+            0x2C => "PrtScn",
+            0x2D => "Insert",
+            0x2E => "Delete",
+            0xBA => ";",
+            0xBB => "=",
+            0xBC => ",",
+            0xBD => "-",
+            0xBE => ".",
+            0xBF => "/",
+            0xC0 => "`",
+            0xDB => "[",
+            0xDC => "\\",
+            0xDD => "]",
+            0xDE => "'",
+            _ => $"Key{vk}"
+        };
+    }
+}

--- a/Helpers/GlobalHotkeyStore.cs
+++ b/Helpers/GlobalHotkeyStore.cs
@@ -21,6 +21,12 @@ namespace XrayUI.Helpers
         public const uint ModShift = 0x0004;
         public const uint ModWin = 0x0008;
 
+        /// <summary>Win32 MOD_NOREPEAT — suppresses repeated WM_HOTKEY messages from keyboard
+        /// auto-repeat while the combo is held. Applied at RegisterHotKey call sites only, never
+        /// stored/persisted alongside the user-facing modifiers above (it isn't part of the combo
+        /// the user picked, just a registration-time flag).</summary>
+        public const uint ModNoRepeat = 0x4000;
+
         public static uint ToggleModifiers { get; set; }
         public static uint ToggleVirtualKey { get; set; }
 

--- a/Helpers/HotkeyInterop.cs
+++ b/Helpers/HotkeyInterop.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace XrayUI.Helpers
+{
+    /// <summary>
+    /// Thin wrapper over user32's global hotkey APIs. Source-generated (LibraryImport) to match
+    /// the AOT-friendly interop convention already used in <see cref="JobObjectGuard"/>.
+    /// </summary>
+    internal static partial class HotkeyInterop
+    {
+        [LibraryImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+        [LibraryImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool UnregisterHotKey(IntPtr hWnd, int id);
+    }
+}

--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -141,6 +141,19 @@ public static class L
     public static string Personalize_ClashImportFailed         => Loc.GetString("Personalize_ClashImportFailed");
     public static string Personalize_ImportBlockedTitle        => Loc.GetString("Personalize_ImportBlockedTitle");
     public static string Personalize_ImportBlockedMsg          => Loc.GetString("Personalize_ImportBlockedMsg");
+    public static string Personalize_HotkeyNotSet              => Loc.GetString("Personalize_HotkeyNotSet");
+    public static string Personalize_HotkeyConflictTitle       => Loc.GetString("Personalize_HotkeyConflictTitle");
+    public static string Personalize_HotkeyConflictMsg         => Loc.GetString("Personalize_HotkeyConflictMsg");
+    public static string Personalize_HotkeySavedMsg            => Loc.GetString("Personalize_HotkeySavedMsg");
+    public static string Personalize_HotkeyClearedMsg          => Loc.GetString("Personalize_HotkeyClearedMsg");
+    public static string Personalize_HotkeyInvalidTitle        => Loc.GetString("Personalize_HotkeyInvalidTitle");
+    public static string Personalize_HotkeyInvalidMsg          => Loc.GetString("Personalize_HotkeyInvalidMsg");
+    public static string Personalize_HotkeyRecordTooltip       => Loc.GetString("Personalize_HotkeyRecordTooltip");
+    public static string Personalize_HotkeyDialogClear         => Loc.GetString("Personalize_HotkeyDialogClear");
+    public static string Personalize_HotkeyRecorderPlaceholder => Loc.GetString("Personalize_HotkeyRecorderPlaceholder");
+    public static string Personalize_HotkeyToggleAutomationName  => Loc.GetString("Personalize_HotkeyToggleAutomationName");
+    public static string Personalize_HotkeyRestoreAutomationName => Loc.GetString("Personalize_HotkeyRestoreAutomationName");
+    public static string Personalize_HotkeysDialogTitle         => Loc.GetString("Personalize_HotkeysDialogTitle");
     public static string Error_ExportFailed                => Loc.GetString("Error_ExportFailed");
 
     // ── CustomRules / AddRule ──────────────────────────────────────────────

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -317,9 +317,14 @@ namespace XrayUI
             {
                 HotkeyInterop.UnregisterHotKey(hWnd, id);
 
+                // On failure, the combo is left in the store as-is (not cleared) — a conflict may
+                // be temporary (another app releases it, or the system state changes), and the
+                // next call to this method retries with the same combo. Nothing else reads a
+                // "successfully registered" flag: the UI only reflects whether a combo is assigned,
+                // and WM_HOTKEY simply never arrives for an id Windows didn't actually register.
                 var (mods, vk) = GlobalHotkeyStore.GetCombo(id);
-                if (vk != 0 && !TryRegisterGlobalHotkey(hWnd, id, mods, vk))
-                    GlobalHotkeyStore.SetCombo(id, 0, 0);
+                if (vk != 0)
+                    TryRegisterGlobalHotkey(hWnd, id, mods, vk);
             }
         }
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -43,6 +43,7 @@ namespace XrayUI
 
         private const uint WmQueryEndSession = 0x0011;
         private const uint WmEndSession = 0x0016;
+        private const uint WmHotkey = 0x0312;
         private const uint WmNclButtonDown   = 0x00A1;
         private const uint WmNclButtonDblClk = 0x00A3;
         private const int HtCaption = 0x0002;
@@ -88,6 +89,7 @@ namespace XrayUI
             WindowManager.Get(this);
             _windowMessageMonitor = new WindowMessageMonitor(this);
             _windowMessageMonitor.WindowMessageReceived += OnWindowMessageReceived;
+            GlobalHotkeyStore.HotkeysChanged += OnGlobalHotkeysChanged;
 
             _rootElement = (FrameworkElement)Content;
             ThemeHelper.RootElement = _rootElement;
@@ -140,6 +142,7 @@ namespace XrayUI
             }
 
             await ViewModel.InitializeAsync(isBootLaunch: _startMinimized);
+            RegisterGlobalHotkeys();
 
             if (_startMinimized && !HideToTray())
             {
@@ -287,6 +290,48 @@ namespace XrayUI
             Activate();
         }
 
+        private void HandleHotkeyMessage(int id)
+        {
+            if (id == GlobalHotkeyStore.ToggleId)
+            {
+                var cmd = ViewModel.ControlPanel.StartStopCommand;
+                if (cmd.CanExecute(null))
+                    _ = cmd.ExecuteAsync(null);
+            }
+            else if (id == GlobalHotkeyStore.RestoreId)
+            {
+                RestoreFromTray();
+            }
+        }
+
+        private void OnGlobalHotkeysChanged(object? sender, EventArgs e) => RegisterGlobalHotkeys();
+
+        // Idempotent: always unregisters both ids first, then re-registers whichever have a
+        // combo assigned (no separate enabled flag — presence of a combo means active). Safe to
+        // call at startup and any time the Personalize page commits a hotkey change.
+        private void RegisterGlobalHotkeys()
+        {
+            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+
+            foreach (var id in new[] { GlobalHotkeyStore.ToggleId, GlobalHotkeyStore.RestoreId })
+            {
+                HotkeyInterop.UnregisterHotKey(hWnd, id);
+
+                var (mods, vk) = GlobalHotkeyStore.GetCombo(id);
+                if (vk != 0 && !TryRegisterGlobalHotkey(hWnd, id, mods, vk))
+                    GlobalHotkeyStore.SetCombo(id, 0, 0);
+            }
+        }
+
+        private static bool TryRegisterGlobalHotkey(IntPtr hWnd, int id, uint modifiers, uint virtualKey)
+        {
+            if (HotkeyInterop.RegisterHotKey(hWnd, id, modifiers, virtualKey))
+                return true;
+
+            Debug.WriteLine($"[Hotkey] Failed to register hotkey id={id} ({modifiers}:{virtualKey}). LastWin32Error={Marshal.GetLastWin32Error()}");
+            return false;
+        }
+
         private void CenterOnPrimaryDisplay()
         {
             var displayArea = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Primary);
@@ -432,6 +477,10 @@ namespace XrayUI
             _rootElement.ActualThemeChanged -= OnRootElementActualThemeChanged;
             _windowMessageMonitor.WindowMessageReceived -= OnWindowMessageReceived;
             _windowMessageMonitor.Dispose();
+            GlobalHotkeyStore.HotkeysChanged -= OnGlobalHotkeysChanged;
+            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            HotkeyInterop.UnregisterHotKey(hWnd, GlobalHotkeyStore.ToggleId);
+            HotkeyInterop.UnregisterHotKey(hWnd, GlobalHotkeyStore.RestoreId);
             AppWindow.IsShownInSwitchers = true;
         }
 
@@ -475,6 +524,13 @@ namespace XrayUI
         {
             if (e.Message.MessageId == WmNclButtonDblClk && ViewModel.IsMiniMode)
             {
+                e.Handled = true;
+                return;
+            }
+
+            if (e.Message.MessageId == WmHotkey)
+            {
+                HandleHotkeyMessage(unchecked((int)e.Message.WParam));
                 e.Handled = true;
                 return;
             }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -325,7 +325,7 @@ namespace XrayUI
 
         private static bool TryRegisterGlobalHotkey(IntPtr hWnd, int id, uint modifiers, uint virtualKey)
         {
-            if (HotkeyInterop.RegisterHotKey(hWnd, id, modifiers, virtualKey))
+            if (HotkeyInterop.RegisterHotKey(hWnd, id, modifiers | GlobalHotkeyStore.ModNoRepeat, virtualKey))
                 return true;
 
             Debug.WriteLine($"[Hotkey] Failed to register hotkey id={id} ({modifiers}:{virtualKey}). LastWin32Error={Marshal.GetLastWin32Error()}");

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -48,6 +48,14 @@ namespace XrayUI.Models
         public bool ShowLatencyInDetails { get; set; } = true;
         public bool ShowAiUnlockInDetails { get; set; } = true;
 
+        // ── Global hotkeys ────────────────────────────────────────────────────
+        // No separate enabled flag — a hotkey is active whenever a combo is assigned, matching
+        // PowerToys' shortcut behavior. Assign via the recorder button, clear via its right-click menu.
+        /// <summary>"mods:vk" — Win32 RegisterHotKey MOD_* flags and virtual-key code, or null if never set.</summary>
+        public string? HotkeyToggleCombo { get; set; }
+        /// <summary>"mods:vk", or null if never set.</summary>
+        public string? HotkeyRestoreCombo { get; set; }
+
         // ── DNS ───────────────────────────────────────────────────────────────
         /// <summary>Direct DNS for domestic domains (geosite:cn). null = choose the default based on TUN mode.</summary>
         public string? DirectDnsServer { get; set; }

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -575,6 +575,31 @@ namespace XrayUI.Services
             return true;
         }
 
+        public async Task<(bool cleared, uint mods, uint vk)?> ShowHotkeyRecorderDialogAsync(string title, uint currentMods, uint currentVk)
+        {
+            var content = new HotkeyRecorderControl(currentMods, currentVk);
+
+            var dialog = CreateDialog();
+            dialog.Title = title;
+            dialog.Content = content;
+            dialog.PrimaryButtonText = L.Dialog_Save;
+            dialog.SecondaryButtonText = L.Personalize_HotkeyDialogClear;
+            dialog.CloseButtonText = L.Dialog_Cancel;
+            dialog.IsPrimaryButtonEnabled = currentVk != 0;
+            dialog.IsSecondaryButtonEnabled = currentVk != 0;
+            dialog.DefaultButton = ContentDialogButton.Primary;
+
+            content.ComboCaptured += (_, _) => dialog.IsPrimaryButtonEnabled = true;
+
+            var result = await dialog.ShowAsync();
+            return result switch
+            {
+                ContentDialogResult.Primary   => (false, content.Mods, content.Vk),
+                ContentDialogResult.Secondary => (true, 0u, 0u),
+                _                              => null,
+            };
+        }
+
         public async Task ShowErrorAsync(string title, string message, XamlRoot? xamlRoot = null)
         {
             var dialog = CreateDialog(xamlRoot);

--- a/Services/IDialogService.cs
+++ b/Services/IDialogService.cs
@@ -46,5 +46,14 @@ namespace XrayUI.Services
         /// the persisted runtime state and lags behind the UI toggle until the next connect).
         /// Used to gate FakeDNS availability in the dialog.</param>
         Task<bool> ShowDnsSettingsDialogAsync(AppSettings settings, bool isTunMode);
+
+        /// <summary>
+        /// Shows the hotkey recorder dialog for setting/editing a global hotkey. Returns null if
+        /// cancelled. Otherwise <c>cleared: true</c> means the user chose to remove the hotkey
+        /// entirely; <c>cleared: false</c> carries the captured (or unchanged) combo. This dialog
+        /// has no Win32 knowledge — the caller is responsible for probing/registering with
+        /// user32 and only persisting on success.
+        /// </summary>
+        Task<(bool cleared, uint mods, uint vk)?> ShowHotkeyRecorderDialogAsync(string title, uint currentMods, uint currentVk);
     }
 }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -974,6 +974,54 @@
   <data name="Personalize_DetailAiUnlockDesc.Text" xml:space="preserve">
     <value>Show AI unlock status on the node card</value>
   </data>
+  <data name="Personalize_Hotkeys.Text" xml:space="preserve">
+    <value>Hotkeys</value>
+  </data>
+  <data name="Personalize_HotkeysHeader.Text" xml:space="preserve">
+    <value>Activation Hotkeys</value>
+  </data>
+  <data name="Personalize_HotkeysDialogTitle" xml:space="preserve">
+    <value>Activation Hotkeys</value>
+  </data>
+  <data name="Personalize_HotkeysDesc.Text" xml:space="preserve">
+    <value>Quickly trigger common functions using hotkeys</value>
+  </data>
+  <data name="Personalize_HotkeyToggleTitle.Text" xml:space="preserve">
+    <value>Start/Stop Proxy</value>
+  </data>
+  <data name="Personalize_HotkeyRestoreTitle.Text" xml:space="preserve">
+    <value>Restore Window from Tray</value>
+  </data>
+  <data name="Personalize_HotkeyNotSet" xml:space="preserve">
+    <value>Assign shortcut</value>
+  </data>
+  <data name="Personalize_HotkeyConflictTitle" xml:space="preserve">
+    <value>Failed to Set Hotkey</value>
+  </data>
+  <data name="Personalize_HotkeyConflictMsg" xml:space="preserve">
+    <value>This combination is already in use by the system or another app — try a different one.</value>
+  </data>
+  <data name="Personalize_HotkeySavedMsg" xml:space="preserve">
+    <value>Hotkey is active — click "Done" below to save it</value>
+  </data>
+  <data name="Personalize_HotkeyClearedMsg" xml:space="preserve">
+    <value>Hotkey cleared — click "Done" below to save it</value>
+  </data>
+  <data name="Personalize_HotkeyInvalidTitle" xml:space="preserve">
+    <value>Invalid Combination</value>
+  </data>
+  <data name="Personalize_HotkeyInvalidMsg" xml:space="preserve">
+    <value>Include at least one of Ctrl, Alt, Shift, or Win.</value>
+  </data>
+  <data name="Personalize_HotkeyRecordTooltip" xml:space="preserve">
+    <value>Click to set a shortcut</value>
+  </data>
+  <data name="Personalize_HotkeyToggleAutomationName" xml:space="preserve">
+    <value>Start/stop proxy hotkey</value>
+  </data>
+  <data name="Personalize_HotkeyRestoreAutomationName" xml:space="preserve">
+    <value>Restore window from tray hotkey</value>
+  </data>
   <data name="Personalize_ImportExportTitle.Text" xml:space="preserve">
     <value>Import and Export your data</value>
   </data>
@@ -1221,5 +1269,14 @@ Path: {0}</value>
   </data>
   <data name="Personalize_RoutingRegionDesc.Text" xml:space="preserve">
     <value>Region routed setting</value>
+  </data>
+  <data name="Personalize_HotkeyDialogClear" xml:space="preserve">
+    <value>Clear shortcut</value>
+  </data>
+  <data name="Personalize_HotkeyRecorderPlaceholder" xml:space="preserve">
+    <value>Press a key combination…</value>
+  </data>
+  <data name="HotkeyRecorder_Instruction.Text" xml:space="preserve">
+    <value>Click the box below, then press the combination you want</value>
   </data>
 </root>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -974,6 +974,57 @@
   <data name="Personalize_DetailAiUnlockDesc.Text" xml:space="preserve">
     <value>节点卡片上展示AI的解锁状态</value>
   </data>
+  <data name="Personalize_Hotkeys.Text" xml:space="preserve">
+    <value>快捷键</value>
+  </data>
+  <data name="Personalize_HotkeysHeader.Text" xml:space="preserve">
+    <value>激活快捷键</value>
+  </data>
+  <data name="Personalize_HotkeysDialogTitle" xml:space="preserve">
+    <value>激活快捷键</value>
+    <comment>Same text as Personalize_HotkeysHeader.Text above — separate key because a resw entry
+    can't be both a plain value and a scope. This one is the shared dialog title for both hotkey
+    recorder dialogs (read from C#); the .Text one is the section header (read from XAML).</comment>
+  </data>
+  <data name="Personalize_HotkeysDesc.Text" xml:space="preserve">
+    <value>配置快捷键操作触发常用功能</value>
+  </data>
+  <data name="Personalize_HotkeyToggleTitle.Text" xml:space="preserve">
+    <value>启动/停止代理</value>
+  </data>
+  <data name="Personalize_HotkeyRestoreTitle.Text" xml:space="preserve">
+    <value>从托盘恢复窗口</value>
+  </data>
+  <data name="Personalize_HotkeyNotSet" xml:space="preserve">
+    <value>分配快捷方式</value>
+  </data>
+  <data name="Personalize_HotkeyConflictTitle" xml:space="preserve">
+    <value>快捷键设置失败</value>
+  </data>
+  <data name="Personalize_HotkeyConflictMsg" xml:space="preserve">
+    <value>该组合键已被系统或其他程序占用，请更换一个组合。</value>
+  </data>
+  <data name="Personalize_HotkeySavedMsg" xml:space="preserve">
+    <value>快捷键已生效，记得点击下方「完成」保存</value>
+  </data>
+  <data name="Personalize_HotkeyClearedMsg" xml:space="preserve">
+    <value>快捷键已清除，记得点击下方「完成」保存</value>
+  </data>
+  <data name="Personalize_HotkeyInvalidTitle" xml:space="preserve">
+    <value>组合键无效</value>
+  </data>
+  <data name="Personalize_HotkeyInvalidMsg" xml:space="preserve">
+    <value>请至少包含一个 Ctrl、Alt、Shift 或 Win 键。</value>
+  </data>
+  <data name="Personalize_HotkeyRecordTooltip" xml:space="preserve">
+    <value>点击设置快捷键</value>
+  </data>
+  <data name="Personalize_HotkeyToggleAutomationName" xml:space="preserve">
+    <value>启动/停止代理快捷键</value>
+  </data>
+  <data name="Personalize_HotkeyRestoreAutomationName" xml:space="preserve">
+    <value>从托盘恢复窗口快捷键</value>
+  </data>
   <data name="Personalize_ImportExportTitle.Text" xml:space="preserve">
     <value>配置导入与导出</value>
   </data>
@@ -1221,5 +1272,14 @@
   </data>
   <data name="Personalize_RoutingRegionDesc.Text" xml:space="preserve">
     <value>选择智能路由的国家或地区</value>
+  </data>
+  <data name="Personalize_HotkeyDialogClear" xml:space="preserve">
+    <value>清除快捷键</value>
+  </data>
+  <data name="Personalize_HotkeyRecorderPlaceholder" xml:space="preserve">
+    <value>请按下组合键…</value>
+  </data>
+  <data name="HotkeyRecorder_Instruction.Text" xml:space="preserve">
+    <value>点击下方区域，然后按下想要绑定的组合键</value>
   </data>
 </root>

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -783,6 +783,7 @@ namespace XrayUI.ViewModels
         public void InitializePersonalize(AppSettings settings)
         {
             ProtocolColorStore.LoadFrom(settings);
+            GlobalHotkeyStore.LoadFrom(settings);
 
             var theme = settings.ThemeSetting switch
             {

--- a/ViewModels/PersonalizeViewModel.cs
+++ b/ViewModels/PersonalizeViewModel.cs
@@ -12,6 +12,11 @@ namespace XrayUI.ViewModels
         private readonly SettingsService _settings;
         private readonly IDialogService _dialogs;
 
+        /// <summary>Exposed so PersonalizeControl code-behind can show the hotkey recorder
+        /// dialog — the actual Win32 register/unregister probe stays in code-behind (needs the
+        /// Window handle), so this VM doesn't own that flow end-to-end.</summary>
+        public IDialogService Dialogs => _dialogs;
+
         private int _initialLanguageIndex = -1;
         private bool _suppressLanguageRestartHint;
         private int _initialRegionIndex = -1;
@@ -173,6 +178,57 @@ namespace XrayUI.ViewModels
         [ObservableProperty]
         public partial bool ShowAiUnlockInDetails { get; set; }
 
+        // ── Global hotkeys ────────────────────────────────────────────────────
+        // No separate enabled flag — a hotkey is active whenever it has a combo assigned,
+        // matching PowerToys' shortcut behavior. Assign via the recorder button (which auto-sets
+        // on capture); clear via its right-click "清除快捷键" menu item (PersonalizeControl.xaml.cs).
+
+        [ObservableProperty]
+        public partial string HotkeyToggleDisplay { get; set; } = "";
+
+        [ObservableProperty]
+        public partial string HotkeyRestoreDisplay { get; set; } = "";
+
+        /// <summary>True once a combo is recorded — drives the "+" assign-shortcut icon shown
+        /// only in the unset state (PowerToys-style), hidden once a real combo is displayed.</summary>
+        [ObservableProperty]
+        public partial bool HotkeyToggleIsSet { get; set; }
+
+        [ObservableProperty]
+        public partial bool HotkeyRestoreIsSet { get; set; }
+
+        /// <summary>Assigns the combo for <see cref="GlobalHotkeyStore.ToggleId"/> or
+        /// <see cref="GlobalHotkeyStore.RestoreId"/> and notifies MainWindow to re-register.
+        /// Caller (code-behind) is responsible for the actual user32 register/unregister probe.</summary>
+        public void SetHotkey(int id, uint mods, uint vk)
+        {
+            GlobalHotkeyStore.SetCombo(id, mods, vk);
+            RefreshDisplay(id);
+            GlobalHotkeyStore.NotifyHotkeysChanged();
+        }
+
+        /// <summary>Resets the given hotkey back to unset. See <see cref="SetHotkey"/>.</summary>
+        public void ClearHotkey(int id) => SetHotkey(id, 0, 0);
+
+        private void RefreshDisplay(int id)
+        {
+            var (mods, vk) = GlobalHotkeyStore.GetCombo(id);
+            var text = GlobalHotkeyStore.FormatDisplay(mods, vk);
+            var isSet = !string.IsNullOrEmpty(text);
+            var display = isSet ? text : L.Personalize_HotkeyNotSet;
+
+            if (id == GlobalHotkeyStore.ToggleId)
+            {
+                HotkeyToggleIsSet = isSet;
+                HotkeyToggleDisplay = display;
+            }
+            else
+            {
+                HotkeyRestoreIsSet = isSet;
+                HotkeyRestoreDisplay = display;
+            }
+        }
+
         // ── Commands ──────────────────────────────────────────────────────────
 
         [RelayCommand]
@@ -234,6 +290,7 @@ namespace XrayUI.ViewModels
         {
             var s = await _settings.LoadSettingsAsync();
             ProtocolColorStore.SaveTo(s);
+            GlobalHotkeyStore.SaveTo(s);
             s.ThemeSetting = ThemeHelper.CurrentTheme switch
             {
                 ElementTheme.Light   => "Light",
@@ -270,6 +327,9 @@ namespace XrayUI.ViewModels
             };
 
             SelectedBackdropIndex = ThemeHelper.CurrentBackdrop == "Acrylic" ? 1 : 0;
+
+            RefreshDisplay(GlobalHotkeyStore.ToggleId);
+            RefreshDisplay(GlobalHotkeyStore.RestoreId);
         }
 
         public void LoadDisplayOptions(AppSettings settings)

--- a/Views/HotkeyRecorderControl.xaml
+++ b/Views/HotkeyRecorderControl.xaml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<UserControl
+    x:Class="XrayUI.Views.HotkeyRecorderControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <StackPanel Spacing="12" Width="300">
+        <TextBlock x:Uid="HotkeyRecorder_Instruction"
+                   Text="点击下方区域，然后按下想要绑定的组合键"
+                   TextWrapping="Wrap"
+                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+
+        <Button x:Name="RecorderButton"
+                HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Center"
+                MinHeight="44"
+                KeyDown="RecorderButton_KeyDown">
+            <TextBlock x:Name="RecorderText" FontSize="16" />
+        </Button>
+
+        <InfoBar x:Name="ErrorInfoBar"
+                 IsOpen="False"
+                 Severity="Warning"
+                 IsClosable="False" />
+    </StackPanel>
+</UserControl>

--- a/Views/HotkeyRecorderControl.xaml.cs
+++ b/Views/HotkeyRecorderControl.xaml.cs
@@ -1,0 +1,79 @@
+using System;
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
+using Windows.UI.Core;
+using XrayUI.Helpers;
+
+namespace XrayUI.Views
+{
+    /// <summary>
+    /// Pure capture UI for a global hotkey combo — no Win32/registration knowledge. The caller
+    /// (PersonalizeControl code-behind) is responsible for probing/registering with user32 after
+    /// the hosting dialog closes, and only committing on success.
+    /// </summary>
+    public sealed partial class HotkeyRecorderControl : UserControl
+    {
+        public uint Mods { get; private set; }
+        public uint Vk { get; private set; }
+
+        /// <summary>Fires the first time a valid combo (has at least one modifier) is captured —
+        /// lets the hosting dialog enable its Save button.</summary>
+        public event EventHandler? ComboCaptured;
+
+        public HotkeyRecorderControl(uint initialMods, uint initialVk)
+        {
+            InitializeComponent();
+            Mods = initialMods;
+            Vk = initialVk;
+            UpdateDisplay();
+        }
+
+        private void UpdateDisplay()
+        {
+            RecorderText.Text = Vk == 0
+                ? L.Personalize_HotkeyRecorderPlaceholder
+                : GlobalHotkeyStore.FormatDisplay(Mods, Vk);
+        }
+
+        private void RecorderButton_KeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            if (IsModifierKey(e.Key)) { e.Handled = true; return; }
+
+            e.Handled = true;
+            var mods = CurrentModifiers();
+            if (mods == 0)
+            {
+                ErrorInfoBar.Message = L.Personalize_HotkeyInvalidMsg;
+                ErrorInfoBar.IsOpen = true;
+                return;
+            }
+
+            ErrorInfoBar.IsOpen = false;
+            Mods = mods;
+            Vk = (uint)e.Key;
+            UpdateDisplay();
+            ComboCaptured?.Invoke(this, EventArgs.Empty);
+        }
+
+        private static bool IsModifierKey(VirtualKey key) => key is
+            VirtualKey.Control or VirtualKey.LeftControl or VirtualKey.RightControl or
+            VirtualKey.Menu or VirtualKey.LeftMenu or VirtualKey.RightMenu or
+            VirtualKey.Shift or VirtualKey.LeftShift or VirtualKey.RightShift or
+            VirtualKey.LeftWindows or VirtualKey.RightWindows;
+
+        private static uint CurrentModifiers()
+        {
+            uint mods = 0;
+            if (IsDown(VirtualKey.Control)) mods |= GlobalHotkeyStore.ModControl;
+            if (IsDown(VirtualKey.Menu)) mods |= GlobalHotkeyStore.ModAlt;
+            if (IsDown(VirtualKey.Shift)) mods |= GlobalHotkeyStore.ModShift;
+            if (IsDown(VirtualKey.LeftWindows) || IsDown(VirtualKey.RightWindows)) mods |= GlobalHotkeyStore.ModWin;
+            return mods;
+
+            static bool IsDown(VirtualKey key) =>
+                InputKeyboardSource.GetKeyStateForCurrentThread(key).HasFlag(CoreVirtualKeyStates.Down);
+        }
+    }
+}

--- a/Views/PersonalizeControl.xaml
+++ b/Views/PersonalizeControl.xaml
@@ -584,6 +584,122 @@
                 </Expander>
             </StackPanel>
 
+            <!-- Hotkeys -->
+            <StackPanel Spacing="10">
+                <TextBlock x:Uid="Personalize_Hotkeys"
+                           Text="快捷键"
+                           FontSize="15"
+                           FontWeight="SemiBold" />
+
+                <Expander HorizontalAlignment="Stretch"
+                          HorizontalContentAlignment="Stretch"
+                          CornerRadius="{ThemeResource OverlayCornerRadius}"
+                          Background="{ThemeResource LayerFillColorDefaultBrush}"
+                          BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}">
+                    <Expander.Header>
+                        <Grid Padding="0,12" ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+
+                            <FontIcon Grid.Column="0"
+                                      Glyph="&#xE92E;"
+                                      FontSize="16"
+                                      VerticalAlignment="Center"
+                                      Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+
+                            <StackPanel Grid.Column="1"
+                                        VerticalAlignment="Center"
+                                        Spacing="2">
+                                <TextBlock x:Uid="Personalize_HotkeysHeader"
+                                           Text="激活快捷键"
+                                           FontSize="14" />
+                                <TextBlock x:Uid="Personalize_HotkeysDesc"
+                                           Text="自定义全局快捷键，随时随地生效"
+                                           FontSize="12"
+                                           TextWrapping="Wrap"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                        </Grid>
+                    </Expander.Header>
+
+                    <StackPanel Margin="-16,-12,-16,-12">
+                        <!-- Toggle start/stop -->
+                        <Grid Padding="42,10,16,10" ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock Grid.Column="0"
+                                       x:Uid="Personalize_HotkeyToggleTitle"
+                                       Text="启动/停止代理"
+                                       FontSize="14"
+                                       VerticalAlignment="Center" />
+
+                            <Button Grid.Column="1"
+                                    x:Name="ToggleHotkeyButton"
+                                    MinWidth="150"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Click="HotkeyButton_Click">
+                                <StackPanel Orientation="Horizontal"
+                                            Spacing="6">
+                                    <FontIcon Glyph="&#xE710;"
+                                              FontSize="12"
+                                              Visibility="{x:Bind ViewModel.HotkeyToggleIsSet, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                                    <TextBlock Text="{x:Bind ViewModel.HotkeyToggleDisplay, Mode=OneWay}" />
+                                    <FontIcon Glyph="&#xE70F;"
+                                              FontSize="12"
+                                              Visibility="{x:Bind ViewModel.HotkeyToggleIsSet, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                </StackPanel>
+                            </Button>
+                        </Grid>
+
+                        <Rectangle Height="1"
+                                   Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
+
+                        <!-- Restore from tray -->
+                        <Grid Padding="42,10,16,10" ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock Grid.Column="0"
+                                       x:Uid="Personalize_HotkeyRestoreTitle"
+                                       Text="从托盘恢复窗口"
+                                       FontSize="14"
+                                       VerticalAlignment="Center" />
+
+                            <Button Grid.Column="1"
+                                    x:Name="RestoreHotkeyButton"
+                                    MinWidth="150"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Click="HotkeyButton_Click">
+                                <StackPanel Orientation="Horizontal"
+                                            Spacing="6">
+                                    <FontIcon Glyph="&#xE710;"
+                                              FontSize="12"
+                                              Visibility="{x:Bind ViewModel.HotkeyRestoreIsSet, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                                    <TextBlock Text="{x:Bind ViewModel.HotkeyRestoreDisplay, Mode=OneWay}" />
+                                    <FontIcon Glyph="&#xE70F;"
+                                              FontSize="12"
+                                              Visibility="{x:Bind ViewModel.HotkeyRestoreIsSet, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                </StackPanel>
+                            </Button>
+                        </Grid>
+                    </StackPanel>
+                </Expander>
+
+                <InfoBar x:Name="HotkeySavedInfoBar"
+                         IsOpen="False"
+                         Severity="Informational"
+                         IsClosable="True" />
+            </StackPanel>
+
             <!-- Data management -->
             <StackPanel Spacing="10">
                 <TextBlock x:Uid="Personalize_DataManagement"

--- a/Views/PersonalizeControl.xaml.cs
+++ b/Views/PersonalizeControl.xaml.cs
@@ -18,6 +18,11 @@ namespace XrayUI.Views
             AutomationProperties.SetName(AppLanguageExpander, L.Personalize_LanguageRegionExpanderAutomationName);
             AutomationProperties.SetName(ExportPresetButton, L.Personalize_ExportTooltip);
             AutomationProperties.SetName(ImportDropDownButton, L.Personalize_ImportTooltip);
+
+            AutomationProperties.SetName(ToggleHotkeyButton, L.Personalize_HotkeyToggleAutomationName);
+            AutomationProperties.SetName(RestoreHotkeyButton, L.Personalize_HotkeyRestoreAutomationName);
+            ToolTipService.SetToolTip(ToggleHotkeyButton, L.Personalize_HotkeyRecordTooltip);
+            ToolTipService.SetToolTip(RestoreHotkeyButton, L.Personalize_HotkeyRecordTooltip);
         }
 
         private async void ExportPresetButton_Click(object sender, RoutedEventArgs e)
@@ -132,6 +137,53 @@ namespace XrayUI.Views
         {
             await ViewModel.ApplyPendingChangesAsync();
             App.Restart();
+        }
+
+        // ── Hotkeys ───────────────────────────────────────────────────────────
+        // Capture happens in a dialog (HotkeyRecorderControl, shown via IDialogService) rather
+        // than inline on the row — easier to discover than "click then press keys" for users
+        // unfamiliar with the pattern. The dialog itself has no Win32 knowledge; the actual
+        // RegisterHotKey probe happens here, after it closes, so a conflict can be reported and
+        // the previous (unchanged) binding re-asserted without the dialog needing to know about it.
+
+        private async void HotkeyButton_Click(object sender, RoutedEventArgs e)
+        {
+            var id = ReferenceEquals(sender, ToggleHotkeyButton) ? GlobalHotkeyStore.ToggleId : GlobalHotkeyStore.RestoreId;
+            var (mods, vk) = GlobalHotkeyStore.GetCombo(id);
+            var result = await ViewModel.Dialogs.ShowHotkeyRecorderDialogAsync(L.Personalize_HotkeysDialogTitle, mods, vk);
+            if (result is null) return; // cancelled — nothing touched
+
+            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(ThemeHelper.MainWindow);
+
+            if (result.Value.cleared)
+            {
+                HotkeyInterop.UnregisterHotKey(hWnd, id);
+                ViewModel.ClearHotkey(id);
+                ShowHotkeySaved(L.Personalize_HotkeyClearedMsg);
+                return;
+            }
+
+            HotkeyInterop.UnregisterHotKey(hWnd, id);
+            if (!HotkeyInterop.RegisterHotKey(hWnd, id, result.Value.mods, result.Value.vk))
+            {
+                await ViewModel.Dialogs.ShowErrorAsync(L.Personalize_HotkeyConflictTitle, L.Personalize_HotkeyConflictMsg);
+                // Store wasn't mutated — re-assert whatever was previously registered for this id.
+                GlobalHotkeyStore.NotifyHotkeysChanged();
+                return;
+            }
+
+            ViewModel.SetHotkey(id, result.Value.mods, result.Value.vk);
+            ShowHotkeySaved(L.Personalize_HotkeySavedMsg);
+        }
+
+        // The hotkey is live the moment this fires (RegisterHotKey already succeeded above) —
+        // independent of the page's "完成" button, which only persists it to disk for next
+        // launch. This confirms that to the user instead of leaving the button's silent text
+        // change as the only feedback.
+        private void ShowHotkeySaved(string message)
+        {
+            HotkeySavedInfoBar.Message = message;
+            HotkeySavedInfoBar.IsOpen = true;
         }
     }
 }

--- a/Views/PersonalizeControl.xaml.cs
+++ b/Views/PersonalizeControl.xaml.cs
@@ -164,7 +164,7 @@ namespace XrayUI.Views
             }
 
             HotkeyInterop.UnregisterHotKey(hWnd, id);
-            if (!HotkeyInterop.RegisterHotKey(hWnd, id, result.Value.mods, result.Value.vk))
+            if (!HotkeyInterop.RegisterHotKey(hWnd, id, result.Value.mods | GlobalHotkeyStore.ModNoRepeat, result.Value.vk))
             {
                 await ViewModel.Dialogs.ShowErrorAsync(L.Personalize_HotkeyConflictTitle, L.Personalize_HotkeyConflictMsg);
                 // Store wasn't mutated — re-assert whatever was previously registered for this id.


### PR DESCRIPTION
## Summary
- Adds two user-configurable global hotkeys under Personalize > Activation Hotkeys: toggle start/stop proxy, and restore the main window from the tray
- Registration goes through user32 `RegisterHotKey`/`UnregisterHotKey` (`HotkeyInterop`), combos are captured via a dedicated recorder dialog (`HotkeyRecorderControl`), and persisted as `"mods:vk"` strings on `AppSettings` (no separate enabled flag - a hotkey is active whenever a combo is assigned, matching PowerToys' behavior)
- Includes a cleanup pass on the new code: reused the existing `BooleanToVisibilityConverter`/`InverseBooleanToVisibilityConverter` instead of adding bespoke visibility helpers, collapsed six near-duplicate per-hotkey ViewModel methods into id-parameterized ones backed by `GlobalHotkeyStore.GetCombo`/`SetCombo`, deduped `MainWindow`'s register/unregister blocks into a single loop, and dropped the redundant subtitle text under each hotkey row in the settings UI

## Test plan
- [x] `BuildAndRun.ps1 -SkipRun` builds clean (only pre-existing, unrelated `WMC1510` warnings in `AppSettingsExpander.xaml`)
- [x] Manually verify: set each hotkey via the recorder dialog, confirm it fires immediately (before clicking Done), confirm conflict handling shows an error and doesn't clobber the previous binding, confirm both hotkeys persist across restart, confirm clearing a hotkey via the dialog's "Clear" button unregisters it

🤖 Generated with [Claude Code](https://claude.com/claude-code)