### PR TITLE
Add verbose log option for Xray log level

### DIFF
--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -194,6 +194,7 @@ public static class L
     public static string Log_PrivacySaved  => Loc.GetString("Log_PrivacySaved");
     public static string Log_IpMask        => Loc.GetString("Log_IpMask");
     public static string Log_MaskOff       => Loc.GetString("Log_MaskOff");
+    public static string Log_Verbose       => Loc.GetString("Log_Verbose");
     public static string Log_AutoScroll    => Loc.GetString("Log_AutoScroll");
     public static string Log_CopyAll       => Loc.GetString("Log_CopyAll");
     public static string Log_Clear         => Loc.GetString("Log_Clear");

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -30,6 +30,10 @@ namespace XrayUI.Models
         public string? LastAutoConnectServerName { get; set; }
         /// <summary>"" | "quarter" | "half" | "full"; controls Xray log IP masking.</summary>
         public string LogMaskAddress { get; set; } = string.Empty;
+        /// <summary>Verbose xray error log: true = loglevel "info" (per-connection sniffing/routing/
+        /// transport detail), false (default) = "warning". Independent of the access log, which
+        /// always prints one [inbound -> outbound] verdict line per connection.</summary>
+        public bool VerboseXrayLog { get; set; } = false;
 
         // ── Internationalization ──────────────────────────────────────────────
         /// <summary>BCP-47 tag from <see cref="XrayUI.Helpers.LanguageHelper.SupportedLanguages"/>, or null to follow system.</summary>

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -14,10 +14,11 @@ namespace XrayUI.Services
     /// </summary>
     public static class XrayConfigBuilder
     {
-        // Must stay at debug/info/warning: XrayReadySignal detects core readiness via the
+        // Both must stay at debug/info/warning: XrayReadySignal detects core readiness via the
         // Warning-level "core: Xray x.y.z started" log line, which "error"/"none" would
         // suppress — degrading every connect/switch/reapply to the 3s timeout fallback.
-        private const string DefaultLogLevel = "info";
+        private const string DefaultLogLevel = "warning";
+        private const string VerboseLogLevel = "info";
         private const string ProxyOutboundTag = "proxy";
         private const string DirectOutboundTag = "direct";
         private const string BlockOutboundTag = "block";
@@ -69,7 +70,10 @@ namespace XrayUI.Services
         {
             var log = new JsonObject
             {
-                ["loglevel"] = DefaultLogLevel
+                // loglevel governs the error log only. The access log ("access" unset = stdout)
+                // keeps printing one [inbound -> outbound] verdict line per connection either way,
+                // so proxy/direct visibility survives the quiet default.
+                ["loglevel"] = settings.VerboseXrayLog ? VerboseLogLevel : DefaultLogLevel
             };
 
             if (LogMaskAddress.IsEnabled(settings.LogMaskAddress))

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -324,13 +324,16 @@
     <value>({0} lines)</value>
   </data>
   <data name="Log_PrivacyTooltip" xml:space="preserve">
-    <value>Log privacy settings</value>
+    <value>Log settings</value>
   </data>
   <data name="Log_IpMask" xml:space="preserve">
     <value>IP Address Mask</value>
   </data>
   <data name="Log_MaskOff" xml:space="preserve">
     <value>Off</value>
+  </data>
+  <data name="Log_Verbose" xml:space="preserve">
+    <value>Verbose logging</value>
   </data>
   <data name="Log_AutoScroll" xml:space="preserve">
     <value>Auto Scroll</value>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -324,13 +324,16 @@
     <value>({0} 行)</value>
   </data>
   <data name="Log_PrivacyTooltip" xml:space="preserve">
-    <value>日志隐私设置</value>
+    <value>日志设置</value>
   </data>
   <data name="Log_IpMask" xml:space="preserve">
     <value>IP地址遮罩</value>
   </data>
   <data name="Log_MaskOff" xml:space="preserve">
     <value>关闭</value>
+  </data>
+  <data name="Log_Verbose" xml:space="preserve">
+    <value>详细日志</value>
   </data>
   <data name="Log_AutoScroll" xml:space="preserve">
     <value>自动滚动</value>

--- a/Views/LogWindow.xaml
+++ b/Views/LogWindow.xaml
@@ -85,6 +85,8 @@
                                                          Tag="full"
                                                          Click="MaskAddressMenuItem_Click" />
                                 </MenuFlyoutSubItem>
+                                <ToggleMenuFlyoutItem x:Name="VerboseLogMenuItem"
+                                                      Click="VerboseLogMenuItem_Click" />
                             </MenuFlyout>
                         </Button.Flyout>
                     </Button>

--- a/Views/LogWindow.xaml.cs
+++ b/Views/LogWindow.xaml.cs
@@ -52,6 +52,7 @@ namespace XrayUI.Views
 			ToolTipService.SetToolTip(LogPrivacyButton, L.Log_PrivacyTooltip);
             MaskAddressSubMenu.Text = L.Log_IpMask;
             MaskOffMenuItem.Text    = L.Log_MaskOff;
+            VerboseLogMenuItem.Text = L.Log_Verbose;
             AutoScrollToggle.Content = L.Log_AutoScroll;
             CopyButton.Content       = L.Log_CopyAll;
             ClearButton.Content      = L.Log_Clear;
@@ -61,7 +62,7 @@ namespace XrayUI.Views
 
             RenderLog();
             UpdateStatus();
-            _ = InitializeMaskAddressMenuAsync();
+            _ = InitializeLogSettingsMenuAsync();
 
             _flushTimer = _queue.CreateTimer();
             _flushTimer.Interval = FlushInterval;
@@ -137,16 +138,18 @@ namespace XrayUI.Views
             _prevBufferCount = lines.Count;
         }
 
-        private async Task InitializeMaskAddressMenuAsync()
+        private async Task InitializeLogSettingsMenuAsync()
         {
             try
             {
                 var settings = await _settings.LoadSettingsAsync();
                 SetMaskAddressSelection(LogMaskAddress.Normalize(settings.LogMaskAddress));
+                VerboseLogMenuItem.IsChecked = settings.VerboseXrayLog;
             }
             catch
             {
                 SetMaskAddressSelection(LogMaskAddress.Off);
+                VerboseLogMenuItem.IsChecked = false;
             }
         }
 
@@ -218,6 +221,41 @@ namespace XrayUI.Views
             catch (Exception ex)
             {
                 await ShowInfoAsync(L.Log_PrivacyTitle, Loc.Format("Log_PrivacyFailed", ex.Message));
+            }
+        }
+
+        private async void VerboseLogMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            // ToggleMenuFlyoutItem has already flipped IsChecked by the time Click fires.
+            var value = VerboseLogMenuItem.IsChecked;
+
+            try
+            {
+                var settings = await _settings.LoadSettingsAsync();
+                if (settings.VerboseXrayLog == value)
+                {
+                    return;
+                }
+
+                settings.VerboseXrayLog = value;
+                await _settings.SaveSettingsAsync(settings);
+
+                if (!_xray.IsRunning)
+                {
+                    return;
+                }
+
+                if (settings.IsTunMode)
+                {
+                    await ShowInfoAsync(L.Log_Verbose, L.Log_PrivacySaved);
+                    return;
+                }
+
+                await _reapplyConfigAsync();
+            }
+            catch (Exception ex)
+            {
+                await ShowInfoAsync(L.Log_Verbose, Loc.Format("Log_PrivacyFailed", ex.Message));
             }
         }
 


### PR DESCRIPTION
## Summary
- Add a "Verbose logging" toggle in the Log window that switches Xray's `loglevel` between `warning` (new default) and `info`
- Lower the default log level from `info` to `warning` to cut noise; the access log (per-connection `[inbound -> outbound]` verdict lines) is unaffected either way
- Setting persists via `AppSettings.VerboseXrayLog` and reapplies to the running config immediately, or shows a "reconnect to apply" notice in TUN mode

## Test plan
- [x] Toggle "Verbose logging" in the Log window menu and confirm the running xray process's log verbosity changes accordingly
- [x] Confirm the toggle state persists across app restarts
- [x] Confirm access log connection lines still appear with verbose logging off
- [x] Verify TUN mode shows the info dialog instead of live-reapplying the config