### PR TITLE
fix(UI): align control panel icon group

### DIFF
--- a/Views/ControlPanelControl.xaml
+++ b/Views/ControlPanelControl.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <UserControl x:Class="XrayUI.Views.ControlPanelControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -10,7 +10,7 @@
              Unloaded="UserControl_Unloaded">
 
     <Grid RowSpacing="10"
-          Margin="8,0,0,0">
+          Margin="8,0,12,0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -196,3 +196,4 @@
 
     </Grid>
 </UserControl>
+


### PR DESCRIPTION
# 修复Github按钮和信息卡片右端未对齐的美观问题

## 修复前
<img width="522" height="506" alt="image" src="https://github.com/user-attachments/assets/fee0025e-1749-49df-984c-130a455e6dd2" />

## 修复后
<img width="508" height="503" alt="Screenshot 2026-07-05 170420" src="https://github.com/user-attachments/assets/3861a9c1-93f9-4569-8080-aa19c4b59216" />
