### PR TITLE
feat(UI): move latency test to search toolbar

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1250,10 +1250,10 @@ Path: {0}</value>
     <value>Downloading {0} … {1:0.0} MB</value>
   </data>
   <data name="ServerList_TestModeConnect.Text" xml:space="preserve">
-    <value>Connection latency</value>
+    <value>Tcping Latency</value>
   </data>
   <data name="ServerList_TestModeReal.Text" xml:space="preserve">
-    <value>Test real delay</value>
+    <value>Real Connection Latency</value>
   </data>
   <data name="Personalize_RoutingRegionTitle.Text" xml:space="preserve">
     <value>Region</value>
@@ -1283,3 +1283,4 @@ Path: {0}</value>
     <value>Click the box below, then press the combination you want</value>
   </data>
 </root>
+

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -786,7 +786,7 @@
     <value>Remove from Favorites</value>
   </data>
   <data name="ServerList_FilterTooltip" xml:space="preserve">
-    <value>Filter</value>
+    <value>Group and sort</value>
   </data>
   <data name="ServerList_SortTooltip" xml:space="preserve">
     <value>Sort</value>
@@ -1283,4 +1283,3 @@ Path: {0}</value>
     <value>Click the box below, then press the combination you want</value>
   </data>
 </root>
-

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -786,7 +786,7 @@
     <value>取消收藏</value>
   </data>
   <data name="ServerList_FilterTooltip" xml:space="preserve">
-    <value>筛选</value>
+    <value>分组和排序</value>
   </data>
   <data name="ServerList_SortTooltip" xml:space="preserve">
     <value>排序</value>
@@ -1286,4 +1286,3 @@
     <value>点击下方区域，然后按下想要绑定的组合键</value>
   </data>
 </root>
-

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1253,10 +1253,10 @@
     <value>正在下载 {0} … {1:0.0} MB</value>
   </data>
   <data name="ServerList_TestModeConnect.Text" xml:space="preserve">
-    <value>一键测试延迟</value>
+    <value>Tcping延迟</value>
   </data>
   <data name="ServerList_TestModeReal.Text" xml:space="preserve">
-    <value>真连接测试</value>
+    <value>真连接延迟</value>
   </data>
   <data name="Personalize_RoutingRegionTitle.Text" xml:space="preserve">
     <value>区域设置</value>
@@ -1286,3 +1286,4 @@
     <value>点击下方区域，然后按下想要绑定的组合键</value>
   </data>
 </root>
+

--- a/Views/ServerListControl.xaml
+++ b/Views/ServerListControl.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <UserControl x:Class="XrayUI.Views.ServerListControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -98,10 +98,9 @@
         </StackPanel>
         <Grid Grid.Row="1"
               Margin="0,16,0,0"
-              ColumnSpacing="8"
-              HorizontalAlignment="Left">
+              ColumnSpacing="8">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
@@ -109,9 +108,7 @@
             <AutoSuggestBox x:Name="ServerSearchBox"
                             x:Uid="ServerList_SearchBox"
                             Grid.Column="0"
-                            Width="300"
                             PlaceholderText="搜索服务器"
-                            HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             UpdateTextOnSelect="False"
                             QueryIcon="Find"
@@ -125,13 +122,25 @@
                 </AutoSuggestBox.ItemTemplate>
             </AutoSuggestBox>
 
+            <ToggleButton x:Name="FilterToggle"
+                          Grid.Column="1"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          Padding="6"
+                          IsChecked="{x:Bind ViewModel.IsFilterPanelOpen, Mode=TwoWay}"
+                          Visibility="{x:Bind ViewModel.IsChipBarVisible, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
+                          VerticalAlignment="Center">
+                <FontIcon Glyph="&#xE8A9;"
+                          FontSize="16" />
+            </ToggleButton>
+
             <Button x:Name="TestLatencyButton"
-                    Grid.Column="1"
+                    Grid.Column="2"
                     VerticalAlignment="Center"
                     Command="{x:Bind ViewModel.TestAllLatenciesCommand}"
                     Background="Transparent"
                     BorderBrush="Transparent"
-                    Padding="8">
+                    Padding="6">
                 <Grid>
                     <Grid Visibility="{x:Bind ViewModel.IsTestingLatencies, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
                         <FontIcon Glyph="&#xEC4A;"
@@ -164,18 +173,6 @@
                     </MenuFlyout>
                 </Button.ContextFlyout>
             </Button>
-
-            <ToggleButton x:Name="FilterToggle"
-                          Grid.Column="2"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          Padding="6"
-                          IsChecked="{x:Bind ViewModel.IsFilterPanelOpen, Mode=TwoWay}"
-                          Visibility="{x:Bind ViewModel.IsChipBarVisible, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
-                          VerticalAlignment="Center">
-                <FontIcon Glyph="&#xE8A9;"
-                          FontSize="16" />
-            </ToggleButton>
         </Grid>
         <Grid Grid.Row="2"
               Margin="0,12,0,0"
@@ -202,6 +199,7 @@
             </StackPanel>
 
             <ComboBox Grid.Column="1"
+                      MaxWidth="180"
                       ItemsSource="{x:Bind ViewModel.GroupChips, Mode=OneWay}"
                       SelectedItem="{x:Bind ViewModel.SelectedChip, Mode=TwoWay}">
                 <ComboBox.ItemTemplate>

--- a/Views/ServerListControl.xaml
+++ b/Views/ServerListControl.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <UserControl x:Class="XrayUI.Views.ServerListControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -103,12 +103,13 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
             <AutoSuggestBox x:Name="ServerSearchBox"
                             x:Uid="ServerList_SearchBox"
                             Grid.Column="0"
-                            Width="350"
+                            Width="300"
                             PlaceholderText="搜索服务器"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
@@ -124,8 +125,48 @@
                 </AutoSuggestBox.ItemTemplate>
             </AutoSuggestBox>
 
+            <Button x:Name="TestLatencyButton"
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Command="{x:Bind ViewModel.TestAllLatenciesCommand}"
+                    Background="Transparent"
+                    BorderBrush="Transparent"
+                    Padding="8">
+                <Grid>
+                    <Grid Visibility="{x:Bind ViewModel.IsTestingLatencies, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
+                        <FontIcon Glyph="&#xEC4A;"
+                                  FontSize="16"
+                                  Visibility="{x:Bind views:ServerListControl.ConnectModeIconVisibility(ViewModel.LatencyTestMode), Mode=OneWay}" />
+                        <Viewbox Width="16"
+                                 Height="16"
+                                 Visibility="{x:Bind views:ServerListControl.RealModeIconVisibility(ViewModel.LatencyTestMode), Mode=OneWay}">
+                            <PathIcon Data="M6.54322 5.48256C7.84003 4.39564 9.46603 3.6886 11.25 3.53263V5.25C11.25 5.66421 11.5858 6 12 6C12.4142 6 12.75 5.66421 12.75 5.25V3.53263C16.929 3.89798 20.2412 7.28742 20.4855 11.5H18.75C18.3358 11.5 18 11.8358 18 12.25C18 12.6642 18.3358 13 18.75 13H20.4444C20.1837 15.3116 19.0211 17.2483 17.2765 18.6683C16.9553 18.9298 16.9068 19.4022 17.1683 19.7235C17.4298 20.0447 17.9022 20.0932 18.2235 19.8317C20.45 18.0194 21.8936 15.4382 21.9944 12.3473C21.9985 12.3154 22.0006 12.283 22.0006 12.25C22.0006 12.2301 21.9998 12.2103 21.9983 12.1907C21.9994 12.1274 22 12.0638 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 15.2522 3.52303 17.9538 5.76986 19.8262C6.08807 20.0913 6.56099 20.0483 6.82617 19.7301C7.09134 19.4119 7.04835 18.939 6.73014 18.6738C5.01891 17.2478 3.82673 15.3069 3.55764 13H5.24963C5.66385 13 5.99963 12.6642 5.99963 12.25C5.99963 11.8358 5.66385 11.5 5.24963 11.5H3.51446C3.62363 9.61804 4.34508 7.90037 5.48256 6.54322L6.71967 7.78033C7.01256 8.07322 7.48744 8.07322 7.78033 7.78033C8.07322 7.48744 8.07322 7.01256 7.78033 6.71967L6.54322 5.48256ZM16.7589 6.63409C16.5207 6.44971 16.1824 6.45611 15.9516 6.64937L15.7344 6.83167C15.596 6.9479 15.3979 7.1145 15.1588 7.31609C14.6808 7.71919 14.0386 8.26249 13.3826 8.82286C12.727 9.38283 12.0555 9.96154 11.5197 10.4349C11.2521 10.6713 11.0157 10.8838 10.831 11.0556C10.6593 11.2154 10.4986 11.3707 10.4112 11.4787C9.75823 12.2863 9.89798 13.4588 10.7234 14.0977C11.5488 14.7365 12.7472 14.5998 13.4002 13.7923C13.4876 13.6842 13.6051 13.4955 13.7245 13.2953C13.8529 13.0799 14.0099 12.8059 14.1835 12.4967C14.5311 11.8777 14.9523 11.1053 15.3585 10.3522C15.7649 9.59869 16.1576 8.86226 16.4486 8.31438C16.5941 8.04039 16.7142 7.81345 16.798 7.65496L16.9294 7.40617C17.0685 7.14203 16.9971 6.81847 16.7589 6.63409Z" />
+                        </Viewbox>
+                    </Grid>
+                    <ProgressRing Width="16"
+                                  Height="16"
+                                  IsActive="{x:Bind ViewModel.IsTestingLatencies, Mode=OneWay}"
+                                  Visibility="{x:Bind ViewModel.IsTestingLatencies, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </Grid>
+                <Button.ContextFlyout>
+                    <MenuFlyout>
+                        <RadioMenuFlyoutItem x:Name="TestModeConnectItem"
+                                             x:Uid="ServerList_TestModeConnect"
+                                             Text="Tcping延迟"
+                                             GroupName="LatencyTestMode"
+                                             IsChecked="True"
+                                             Click="TestModeConnectItem_Click" />
+                        <RadioMenuFlyoutItem x:Name="TestModeRealItem"
+                                             x:Uid="ServerList_TestModeReal"
+                                             Text="真连接延迟"
+                                             GroupName="LatencyTestMode"
+                                             Click="TestModeRealItem_Click" />
+                    </MenuFlyout>
+                </Button.ContextFlyout>
+            </Button>
+
             <ToggleButton x:Name="FilterToggle"
-                          Grid.Column="1"
+                          Grid.Column="2"
                           Background="Transparent"
                           BorderBrush="Transparent"
                           Padding="6"
@@ -144,7 +185,6 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
             <StackPanel Grid.Column="0"
@@ -204,46 +244,6 @@
                     </MenuFlyout>
                 </DropDownButton.Flyout>
             </DropDownButton>
-            <Button Grid.Column="3"
-                    x:Name="TestLatencyButton"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Center"
-                    Command="{x:Bind ViewModel.TestAllLatenciesCommand}"
-                    Background="Transparent"
-                    BorderBrush="Transparent"
-                    Padding="8">
-                <Grid>
-                    <Grid Visibility="{x:Bind ViewModel.IsTestingLatencies, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
-                        <FontIcon Glyph="&#xEC4A;"
-                                  FontSize="16"
-                                  Visibility="{x:Bind views:ServerListControl.ConnectModeIconVisibility(ViewModel.LatencyTestMode), Mode=OneWay}" />
-                        <Viewbox Width="16"
-                                 Height="16"
-                                 Visibility="{x:Bind views:ServerListControl.RealModeIconVisibility(ViewModel.LatencyTestMode), Mode=OneWay}">
-                            <PathIcon Data="M6.54322 5.48256C7.84003 4.39564 9.46603 3.6886 11.25 3.53263V5.25C11.25 5.66421 11.5858 6 12 6C12.4142 6 12.75 5.66421 12.75 5.25V3.53263C16.929 3.89798 20.2412 7.28742 20.4855 11.5H18.75C18.3358 11.5 18 11.8358 18 12.25C18 12.6642 18.3358 13 18.75 13H20.4444C20.1837 15.3116 19.0211 17.2483 17.2765 18.6683C16.9553 18.9298 16.9068 19.4022 17.1683 19.7235C17.4298 20.0447 17.9022 20.0932 18.2235 19.8317C20.45 18.0194 21.8936 15.4382 21.9944 12.3473C21.9985 12.3154 22.0006 12.283 22.0006 12.25C22.0006 12.2301 21.9998 12.2103 21.9983 12.1907C21.9994 12.1274 22 12.0638 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 15.2522 3.52303 17.9538 5.76986 19.8262C6.08807 20.0913 6.56099 20.0483 6.82617 19.7301C7.09134 19.4119 7.04835 18.939 6.73014 18.6738C5.01891 17.2478 3.82673 15.3069 3.55764 13H5.24963C5.66385 13 5.99963 12.6642 5.99963 12.25C5.99963 11.8358 5.66385 11.5 5.24963 11.5H3.51446C3.62363 9.61804 4.34508 7.90037 5.48256 6.54322L6.71967 7.78033C7.01256 8.07322 7.48744 8.07322 7.78033 7.78033C8.07322 7.48744 8.07322 7.01256 7.78033 6.71967L6.54322 5.48256ZM16.7589 6.63409C16.5207 6.44971 16.1824 6.45611 15.9516 6.64937L15.7344 6.83167C15.596 6.9479 15.3979 7.1145 15.1588 7.31609C14.6808 7.71919 14.0386 8.26249 13.3826 8.82286C12.727 9.38283 12.0555 9.96154 11.5197 10.4349C11.2521 10.6713 11.0157 10.8838 10.831 11.0556C10.6593 11.2154 10.4986 11.3707 10.4112 11.4787C9.75823 12.2863 9.89798 13.4588 10.7234 14.0977C11.5488 14.7365 12.7472 14.5998 13.4002 13.7923C13.4876 13.6842 13.6051 13.4955 13.7245 13.2953C13.8529 13.0799 14.0099 12.8059 14.1835 12.4967C14.5311 11.8777 14.9523 11.1053 15.3585 10.3522C15.7649 9.59869 16.1576 8.86226 16.4486 8.31438C16.5941 8.04039 16.7142 7.81345 16.798 7.65496L16.9294 7.40617C17.0685 7.14203 16.9971 6.81847 16.7589 6.63409Z" />
-                        </Viewbox>
-                    </Grid>
-                    <ProgressRing Width="16"
-                                  Height="16"
-                                  IsActive="{x:Bind ViewModel.IsTestingLatencies, Mode=OneWay}"
-                                  Visibility="{x:Bind ViewModel.IsTestingLatencies, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                </Grid>
-                <Button.ContextFlyout>
-                    <MenuFlyout>
-                        <RadioMenuFlyoutItem x:Name="TestModeConnectItem"
-                                             x:Uid="ServerList_TestModeConnect"
-                                             Text="测试延迟"
-                                             GroupName="LatencyTestMode"
-                                             IsChecked="True"
-                                             Click="TestModeConnectItem_Click" />
-                        <RadioMenuFlyoutItem x:Name="TestModeRealItem"
-                                             x:Uid="ServerList_TestModeReal"
-                                             Text="真连接测试"
-                                             GroupName="LatencyTestMode"
-                                             Click="TestModeRealItem_Click" />
-                    </MenuFlyout>
-                </Button.ContextFlyout>
-            </Button>
         </Grid>
 
         <ListView Grid.Row="3"

--- a/Views/ServerListControl.xaml.cs
+++ b/Views/ServerListControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Numerics;
 using Microsoft.UI.Xaml.Automation;
@@ -22,7 +22,9 @@ namespace XrayUI.Views
 
             // Localize attached properties that x:Uid does not address cleanly.
             AutomationProperties.SetName(FilterToggle, L.ServerList_FilterTooltip);
+            AutomationProperties.SetName(TestLatencyButton, L.ServerList_TestLatencyTooltip);
             AutomationProperties.SetName(SortButton,   L.ServerList_SortTooltip);
+            ToolTipService.SetToolTip(TestLatencyButton, L.ServerList_TestLatencyTooltip);
             ToolTipService.SetToolTip(SortActiveItem,  L.ServerList_SortActiveHint);
         }
 

--- a/Views/ServerListControl.xaml.cs
+++ b/Views/ServerListControl.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Numerics;
 using Microsoft.UI.Xaml.Automation;
@@ -24,6 +24,7 @@ namespace XrayUI.Views
             AutomationProperties.SetName(FilterToggle, L.ServerList_FilterTooltip);
             AutomationProperties.SetName(TestLatencyButton, L.ServerList_TestLatencyTooltip);
             AutomationProperties.SetName(SortButton,   L.ServerList_SortTooltip);
+            ToolTipService.SetToolTip(FilterToggle, L.ServerList_FilterTooltip);
             ToolTipService.SetToolTip(TestLatencyButton, L.ServerList_TestLatencyTooltip);
             ToolTipService.SetToolTip(SortActiveItem,  L.ServerList_SortActiveHint);
         }


### PR DESCRIPTION
把延迟测试移动到二级菜单外，去掉了选项按钮，延迟测试模型还是在右键菜单，并修正了延迟测试的描述

<img width="412" height="133" alt="image" src="https://github.com/user-attachments/assets/f89e155f-b62e-418d-99ba-a2cae96941d0" />
