### PR TITLE
fix: add constrain when resize window

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -20,7 +20,6 @@ namespace XrayUI
         private readonly FrameworkElement _rootElement;
         private readonly Border _miniDragRegion;
         private readonly Button _miniExpandButton;
-        private readonly WindowManager _windowManager;
         private readonly WindowMessageMonitor _windowMessageMonitor;
         // We own the tray icon directly (rather than WindowManager.IsVisibleInTray) so the
         // tooltip can track connection state; see ConfigureTray.
@@ -85,11 +84,11 @@ namespace XrayUI
             ToolTipService.SetToolTip(MiniExpandButton,  L.MainWindow_ExpandFull);
             ToolTipService.SetToolTip(MinicloseButton,   L.MainWindow_Close);
 
-            // Initial size is established by ApplyWindowMode(isMini: false) below.
-            // Get attaches WinUIEx window management to this window for its side effects
-            // (min-size clamping, placement); we don't keep the reference — the tray icon is
-            // owned directly via _trayIcon so we can drive its tooltip from connection state.
-            _windowManager = WindowManager.Get(this);
+			// Initial size is established by ApplyWindowMode(isMini: false) below.
+			// Get attaches WinUIEx window management to this window for its side effects
+			// (min-size clamping, placement); we don't keep the reference — the tray icon is
+			// owned directly via _trayIcon so we can drive its tooltip from connection state.
+			var _windowManager = WindowManager.Get(this);
             _windowManager.MinWidth = FullModeMinWidth;
             _windowManager.MinHeight = FullModeMinHeight;
             _windowMessageMonitor = new WindowMessageMonitor(this);

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ namespace XrayUI
         private readonly FrameworkElement _rootElement;
         private readonly Border _miniDragRegion;
         private readonly Button _miniExpandButton;
+        private readonly WindowManager _windowManager;
         private readonly WindowMessageMonitor _windowMessageMonitor;
         // We own the tray icon directly (rather than WindowManager.IsVisibleInTray) so the
         // tooltip can track connection state; see ConfigureTray.
@@ -49,6 +50,8 @@ namespace XrayUI
         private const int HtCaption = 0x0002;
         private const int FullWindowWidth = 950;
         private const int FullWindowHeight = 600;
+        private const int FullModeMinWidth = 430;
+        private const int FullModeMinHeight = 260;
         private const int MiniWindowWidth = 330;
         private const int MiniWindowHeight = 136;
         // Unique id for our own tray icon, independent of WinUIEx's WindowManager tray.
@@ -86,7 +89,9 @@ namespace XrayUI
             // Get attaches WinUIEx window management to this window for its side effects
             // (min-size clamping, placement); we don't keep the reference — the tray icon is
             // owned directly via _trayIcon so we can drive its tooltip from connection state.
-            WindowManager.Get(this);
+            _windowManager = WindowManager.Get(this);
+            _windowManager.MinWidth = FullModeMinWidth;
+            _windowManager.MinHeight = FullModeMinHeight;
             _windowMessageMonitor = new WindowMessageMonitor(this);
             _windowMessageMonitor.WindowMessageReceived += OnWindowMessageReceived;
             GlobalHotkeyStore.HotkeysChanged += OnGlobalHotkeysChanged;


### PR DESCRIPTION
Avoid unlimited small window when resizing. Now the minimal window in Full-Mode keeps server list and one node.

<img width="539" height="408" alt="image" src="https://github.com/user-attachments/assets/86b75037-cbb9-418e-83f0-ad7a5cfc82dc" />
