### PR TITLE
Feat/double column list (draft)

### DIFF
--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -221,7 +221,9 @@ public static class L
     public static string ServerList_Share            => Loc.GetString("ServerList_Share");
     public static string ServerList_AddFavorite      => Loc.GetString("ServerList_AddFavorite");
     public static string ServerList_RemoveFavorite   => Loc.GetString("ServerList_RemoveFavorite");
+    public static string ServerList_DoubleColumnTooltip => Loc.GetString("ServerList_DoubleColumnTooltip");
     public static string ServerList_FilterTooltip    => Loc.GetString("ServerList_FilterTooltip");
+    public static string ServerList_SingleColumnTooltip => Loc.GetString("ServerList_SingleColumnTooltip");
     public static string ServerList_SortTooltip      => Loc.GetString("ServerList_SortTooltip");
     public static string ServerList_TestLatencyTooltip => Loc.GetString("ServerList_TestLatencyTooltip");
     public static string ServerList_SortActiveHint   => Loc.GetString("ServerList_SortActiveHint");

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ namespace XrayUI
         private readonly FrameworkElement _rootElement;
         private readonly Border _miniDragRegion;
         private readonly Button _miniExpandButton;
+        private readonly WindowManager _windowManager;
         private readonly WindowMessageMonitor _windowMessageMonitor;
         // We own the tray icon directly (rather than WindowManager.IsVisibleInTray) so the
         // tooltip can track connection state; see ConfigureTray.
@@ -49,6 +50,8 @@ namespace XrayUI
         private const int HtCaption = 0x0002;
         private const int FullWindowWidth = 950;
         private const int FullWindowHeight = 600;
+        private const int FullModeMinWidth = 430;
+        private const int FullModeMinHeight = 260;
         private const int MiniWindowWidth = 330;
         private const int MiniWindowHeight = 136;
         // Unique id for our own tray icon, independent of WinUIEx's WindowManager tray.
@@ -86,7 +89,9 @@ namespace XrayUI
             // Get attaches WinUIEx window management to this window for its side effects
             // (min-size clamping, placement); we don't keep the reference — the tray icon is
             // owned directly via _trayIcon so we can drive its tooltip from connection state.
-            WindowManager.Get(this);
+            _windowManager = WindowManager.Get(this);
+            _windowManager.MinWidth = FullModeMinWidth;
+            _windowManager.MinHeight = FullModeMinHeight;
             _windowMessageMonitor = new WindowMessageMonitor(this);
             _windowMessageMonitor.WindowMessageReceived += OnWindowMessageReceived;
             GlobalHotkeyStore.HotkeysChanged += OnGlobalHotkeysChanged;

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -788,6 +788,12 @@
   <data name="ServerList_FilterTooltip" xml:space="preserve">
     <value>Group and sort</value>
   </data>
+  <data name="ServerList_DoubleColumnTooltip" xml:space="preserve">
+    <value>Switch to double-column layout</value>
+  </data>
+  <data name="ServerList_SingleColumnTooltip" xml:space="preserve">
+    <value>Switch to single-column layout</value>
+  </data>
   <data name="ServerList_SortTooltip" xml:space="preserve">
     <value>Sort</value>
   </data>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -788,6 +788,12 @@
   <data name="ServerList_FilterTooltip" xml:space="preserve">
     <value>分组和排序</value>
   </data>
+  <data name="ServerList_DoubleColumnTooltip" xml:space="preserve">
+    <value>切换为双栏</value>
+  </data>
+  <data name="ServerList_SingleColumnTooltip" xml:space="preserve">
+    <value>切换为单栏</value>
+  </data>
   <data name="ServerList_SortTooltip" xml:space="preserve">
     <value>排序</value>
   </data>

--- a/Views/ServerListControl.xaml
+++ b/Views/ServerListControl.xaml
@@ -9,8 +9,18 @@
              xmlns:vm="using:XrayUI.ViewModels"
              xmlns:views="using:XrayUI.Views"
              mc:Ignorable="d"
+             Loaded="ServerListControl_Loaded"
              d:DesignHeight="500"
              d:DesignWidth="420">
+
+    <UserControl.Resources>
+        <ItemsPanelTemplate x:Key="SingleColumnItemsPanel">
+            <ItemsStackPanel />
+        </ItemsPanelTemplate>
+        <ItemsPanelTemplate x:Key="DoubleColumnItemsPanel">
+            <ItemsWrapGrid Orientation="Horizontal" />
+        </ItemsPanelTemplate>
+    </UserControl.Resources>
 
     <Grid>
         <Grid.RowDefinitions>
@@ -103,6 +113,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
             <AutoSuggestBox x:Name="ServerSearchBox"
@@ -122,8 +133,62 @@
                 </AutoSuggestBox.ItemTemplate>
             </AutoSuggestBox>
 
-            <ToggleButton x:Name="FilterToggle"
+            <ToggleButton x:Name="LayoutToggleButton"
                           Grid.Column="1"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          Padding="6"
+                          VerticalAlignment="Center"
+                          Checked="LayoutToggleButton_Checked"
+                          Unchecked="LayoutToggleButton_Unchecked">
+                <Grid Width="16"
+                      Height="16">
+                    <StackPanel x:Name="SingleColumnLayoutIcon"
+                                Orientation="Vertical"
+                                Spacing="2"
+                                VerticalAlignment="Center">
+                        <Border Height="4"
+                                CornerRadius="1"
+                                Background="{ThemeResource TextFillColorPrimaryBrush}" />
+                        <Border Height="4"
+                                CornerRadius="1"
+                                Background="{ThemeResource TextFillColorPrimaryBrush}" />
+                        <Border Height="4"
+                                CornerRadius="1"
+                                Background="{ThemeResource TextFillColorPrimaryBrush}" />
+                    </StackPanel>
+                    <Grid x:Name="DoubleColumnLayoutIcon"
+                          Visibility="Collapsed">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Border Margin="0,0,1,1"
+                                CornerRadius="1"
+                                Background="{ThemeResource TextFillColorPrimaryBrush}" />
+                        <Border Grid.Column="1"
+                                Margin="1,0,0,1"
+                                CornerRadius="1"
+                                Background="{ThemeResource TextFillColorPrimaryBrush}" />
+                        <Border Grid.Row="1"
+                                Margin="0,1,1,0"
+                                CornerRadius="1"
+                                Background="{ThemeResource TextFillColorPrimaryBrush}" />
+                        <Border Grid.Row="1"
+                                Grid.Column="1"
+                                Margin="1,1,0,0"
+                                CornerRadius="1"
+                                Background="{ThemeResource TextFillColorPrimaryBrush}" />
+                    </Grid>
+                </Grid>
+            </ToggleButton>
+
+            <ToggleButton x:Name="FilterToggle"
+                          Grid.Column="2"
                           Background="Transparent"
                           BorderBrush="Transparent"
                           Padding="6"
@@ -135,7 +200,7 @@
             </ToggleButton>
 
             <Button x:Name="TestLatencyButton"
-                    Grid.Column="2"
+                    Grid.Column="3"
                     VerticalAlignment="Center"
                     Command="{x:Bind ViewModel.TestAllLatenciesCommand}"
                     Background="Transparent"
@@ -248,12 +313,14 @@
                   x:Name="ServersListView"
                   Margin="0,8,0,0"
                   ItemsSource="{x:Bind ViewModel.VisibleServers, Mode=OneWay}"
+                  ItemsPanel="{StaticResource SingleColumnItemsPanel}"
                   SelectedItem="{x:Bind ViewModel.SelectedServer, Mode=TwoWay}"
                   CanDragItems="{x:Bind ViewModel.CanReorderInCurrentChip, Mode=OneWay}"
                   CanReorderItems="{x:Bind ViewModel.CanReorderInCurrentChip, Mode=OneWay}"
                   AllowDrop="{x:Bind ViewModel.CanReorderInCurrentChip, Mode=OneWay}"
                   DragItemsCompleted="ServersListView_DragItemsCompleted"
                   SelectionChanged="ServersListView_SelectionChanged"
+                  SizeChanged="ServersListView_SizeChanged"
                   SelectionMode="Extended"
                   ScrollViewer.VerticalScrollBarVisibility="Auto">
 

--- a/Views/ServerListControl.xaml.cs
+++ b/Views/ServerListControl.xaml.cs
@@ -13,6 +13,8 @@ namespace XrayUI.Views
 {
     public sealed partial class ServerListControl
     {
+        private const double DoubleColumnItemWidthDivisor = 2d;
+
         public ServerListViewModel ViewModel { get; set; } = null!;
         public IAsyncRelayCommand? SwitchToSelectedServerCommand { get; set; }
 
@@ -21,13 +23,18 @@ namespace XrayUI.Views
             this.InitializeComponent();
 
             // Localize attached properties that x:Uid does not address cleanly.
+            AutomationProperties.SetName(LayoutToggleButton, L.ServerList_DoubleColumnTooltip);
             AutomationProperties.SetName(FilterToggle, L.ServerList_FilterTooltip);
             AutomationProperties.SetName(TestLatencyButton, L.ServerList_TestLatencyTooltip);
             AutomationProperties.SetName(SortButton,   L.ServerList_SortTooltip);
+            ToolTipService.SetToolTip(LayoutToggleButton, L.ServerList_DoubleColumnTooltip);
             ToolTipService.SetToolTip(FilterToggle, L.ServerList_FilterTooltip);
             ToolTipService.SetToolTip(TestLatencyButton, L.ServerList_TestLatencyTooltip);
             ToolTipService.SetToolTip(SortActiveItem,  L.ServerList_SortActiveHint);
         }
+
+        private void ServerListControl_Loaded(object sender, RoutedEventArgs e)
+            => ApplyLayoutMode(LayoutToggleButton.IsChecked == true);
 
         private void ServerSearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
         {
@@ -88,6 +95,18 @@ namespace XrayUI.Views
         private void ServersListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             ViewModel.SetSelectedServers(ServersListView.SelectedItems.OfType<ServerEntry>().ToArray());
+        }
+
+        private void LayoutToggleButton_Checked(object sender, RoutedEventArgs e)
+            => ApplyLayoutMode(true);
+
+        private void LayoutToggleButton_Unchecked(object sender, RoutedEventArgs e)
+            => ApplyLayoutMode(false);
+
+        private void ServersListView_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (LayoutToggleButton.IsChecked == true)
+                UpdateDoubleColumnItemWidth();
         }
 
         private void ActiveBadge_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -210,6 +229,35 @@ namespace XrayUI.Views
 
         public static Vector3 ActiveBadgeScale(bool isActive)
             => isActive ? Vector3.One : new Vector3(0.92f, 0.92f, 1f);
+
+        private void ApplyLayoutMode(bool isDoubleColumn)
+        {
+            ServersListView.ItemsPanel = (ItemsPanelTemplate)Resources[isDoubleColumn
+                ? "DoubleColumnItemsPanel"
+                : "SingleColumnItemsPanel"];
+
+            SingleColumnLayoutIcon.Visibility = isDoubleColumn ? Visibility.Collapsed : Visibility.Visible;
+            DoubleColumnLayoutIcon.Visibility = isDoubleColumn ? Visibility.Visible : Visibility.Collapsed;
+
+            var tooltip = isDoubleColumn
+                ? L.ServerList_SingleColumnTooltip
+                : L.ServerList_DoubleColumnTooltip;
+            AutomationProperties.SetName(LayoutToggleButton, tooltip);
+            ToolTipService.SetToolTip(LayoutToggleButton, tooltip);
+
+            if (isDoubleColumn)
+                UpdateDoubleColumnItemWidth();
+        }
+
+        private void UpdateDoubleColumnItemWidth()
+        {
+            ServersListView.UpdateLayout();
+
+            if (ServersListView.ItemsPanelRoot is not ItemsWrapGrid wrapGrid)
+                return;
+
+            wrapGrid.ItemWidth = Math.Max(0d, ServersListView.ActualWidth / DoubleColumnItemWidthDivisor);
+        }
 
         // Foreground for the per-row latency number, keyed off the measured value:
         // failed probe (negative, e.g. -1) → critical, ≥200 ms → caution, else success.


### PR DESCRIPTION
Add double column mode

### Example 

<img width="883" height="600" alt="image" src="https://github.com/user-attachments/assets/5c42b010-7984-479f-af62-617a324faef1" />


### TODO: 
1. icon is same as filter menu, need to change

2. some text will be covered, too many text in the node list.  Perhaps remove URL and port in small card, only keep them in details? 