### PR TITLE
Merge Personalize display settings, add unsaved-changes hint, fix SNI fallback

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -51,6 +51,8 @@ namespace XrayUI.Models
         public string? ColorFallback  { get; set; }
         public bool ShowLatencyInDetails { get; set; } = true;
         public bool ShowAiUnlockInDetails { get; set; } = true;
+        /// <summary>Expand the server-list filter bar when the app starts.</summary>
+        public bool OpenServerFilterPanelOnStartup { get; set; } = false;
 
         // ── Global hotkeys ────────────────────────────────────────────────────
         // No separate enabled flag — a hotkey is active whenever a combo is assigned, matching

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -650,7 +650,13 @@ namespace XrayUI.Services
 
             if (security == "tls")
             {
-                var sni = string.IsNullOrWhiteSpace(server.Sni) ? server.Host : server.Sni;
+                // CDN/tunnel nodes (Host header != connect address) need the SNI to match the
+                // Host header when no explicit SNI is given, or the edge can't route the TLS
+                // handshake. Same fallback rule as v2rayN; only ws/xhttp carry a Host header.
+                var hostHeader = (network == "ws" || network == "xhttp") ? server.WsHost : null;
+                var sni = !string.IsNullOrWhiteSpace(server.Sni) ? server.Sni
+                    : !string.IsNullOrWhiteSpace(hostHeader) ? hostHeader
+                    : server.Host;
                 var fingerprint = string.IsNullOrWhiteSpace(server.Fingerprint) ? "chrome" : server.Fingerprint;
                 var tlsSettings = new JsonObject
                 {

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -956,8 +956,8 @@
   <data name="Personalize_ProtocolColorsDesc.Text" xml:space="preserve">
     <value>Customize the color indicator for each protocol</value>
   </data>
-  <data name="Personalize_DetailSettings.Text" xml:space="preserve">
-    <value>Detail Settings</value>
+  <data name="Personalize_DisplaySettings.Text" xml:space="preserve">
+    <value>Display</value>
   </data>
   <data name="Personalize_DetailsHeader.Text" xml:space="preserve">
     <value>Server info display</value>
@@ -976,6 +976,15 @@
   </data>
   <data name="Personalize_DetailAiUnlockDesc.Text" xml:space="preserve">
     <value>Show AI unlock status on the node card</value>
+  </data>
+  <data name="Personalize_OpenFilterPanelOnStartup.Text" xml:space="preserve">
+    <value>Expand filter bar on startup</value>
+  </data>
+  <data name="Personalize_OpenFilterPanelOnStartupDesc.Text" xml:space="preserve">
+    <value>Show the group and sort options by default</value>
+  </data>
+  <data name="Personalize_DisplaySettingsUnsavedBar.Message" xml:space="preserve">
+    <value>Applied — click "Done" below to save it</value>
   </data>
   <data name="Personalize_Hotkeys.Text" xml:space="preserve">
     <value>Hotkeys</value>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -956,8 +956,8 @@
   <data name="Personalize_ProtocolColorsDesc.Text" xml:space="preserve">
     <value>自定义不同协议的颜色标识</value>
   </data>
-  <data name="Personalize_DetailSettings.Text" xml:space="preserve">
-    <value>详情设置</value>
+  <data name="Personalize_DisplaySettings.Text" xml:space="preserve">
+    <value>显示设置</value>
   </data>
   <data name="Personalize_DetailsHeader.Text" xml:space="preserve">
     <value>服务器信息显示</value>
@@ -976,6 +976,15 @@
   </data>
   <data name="Personalize_DetailAiUnlockDesc.Text" xml:space="preserve">
     <value>节点卡片上展示AI的解锁状态</value>
+  </data>
+  <data name="Personalize_OpenFilterPanelOnStartup.Text" xml:space="preserve">
+    <value>启动时展开筛选栏</value>
+  </data>
+  <data name="Personalize_OpenFilterPanelOnStartupDesc.Text" xml:space="preserve">
+    <value>默认显示分组和排序选项</value>
+  </data>
+  <data name="Personalize_DisplaySettingsUnsavedBar.Message" xml:space="preserve">
+    <value>已生效，记得点击下方「完成」保存</value>
   </data>
   <data name="Personalize_Hotkeys.Text" xml:space="preserve">
     <value>快捷键</value>

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -133,6 +133,7 @@ namespace XrayUI.ViewModels
             Personalize.LoadRegion(s);
             ServerDetail.ShowLatencyInDetails = s.ShowLatencyInDetails;
             ServerDetail.ShowAiUnlockInDetails = s.ShowAiUnlockInDetails;
+            ServerList.IsFilterPanelOpen = s.OpenServerFilterPanelOnStartup;
 
             // Reconcile external state vs persisted setting (external is ground truth)
             var externalEnabled = await Task.Run(_startupService.IsStartupEnabled);
@@ -310,6 +311,10 @@ namespace XrayUI.ViewModels
             else if (e.PropertyName == nameof(PersonalizeViewModel.ShowAiUnlockInDetails))
             {
                 ServerDetail.ShowAiUnlockInDetails = Personalize.ShowAiUnlockInDetails;
+            }
+            else if (e.PropertyName == nameof(PersonalizeViewModel.OpenServerFilterPanelOnStartup))
+            {
+                ServerList.IsFilterPanelOpen = Personalize.OpenServerFilterPanelOnStartup;
             }
         }
 

--- a/ViewModels/PersonalizeViewModel.cs
+++ b/ViewModels/PersonalizeViewModel.cs
@@ -175,8 +175,33 @@ namespace XrayUI.ViewModels
         [ObservableProperty]
         public partial bool ShowLatencyInDetails { get; set; }
 
+        partial void OnShowLatencyInDetailsChanged(bool value) => UpdateDisplaySettingsUnsavedHint();
+
         [ObservableProperty]
         public partial bool ShowAiUnlockInDetails { get; set; }
+
+        partial void OnShowAiUnlockInDetailsChanged(bool value) => UpdateDisplaySettingsUnsavedHint();
+
+        [ObservableProperty]
+        public partial bool OpenServerFilterPanelOnStartup { get; set; }
+
+        partial void OnOpenServerFilterPanelOnStartupChanged(bool value) => UpdateDisplaySettingsUnsavedHint();
+
+        /// <summary>True once any of the three display toggles above diverges from the
+        /// last-loaded/last-saved baseline. All three apply live immediately (see
+        /// MainViewModel's PropertyChanged wiring), but only persist to disk when "完成" is
+        /// clicked — same live-now/persist-on-Done split as hotkeys — so this drives an InfoBar
+        /// reminder instead of leaving a silent toggle as the only feedback.</summary>
+        [ObservableProperty]
+        public partial bool ShowDisplaySettingsUnsavedHint { get; set; }
+
+        private (bool Latency, bool AiUnlock, bool FilterPanel)? _displaySettingsBaseline;
+
+        private void UpdateDisplaySettingsUnsavedHint()
+        {
+            ShowDisplaySettingsUnsavedHint = _displaySettingsBaseline is { } baseline &&
+                baseline != (ShowLatencyInDetails, ShowAiUnlockInDetails, OpenServerFilterPanelOnStartup);
+        }
 
         // ── Global hotkeys ────────────────────────────────────────────────────
         // No separate enabled flag — a hotkey is active whenever it has a combo assigned,
@@ -300,6 +325,12 @@ namespace XrayUI.ViewModels
             s.BackdropSetting = ThemeHelper.CurrentBackdrop;
             s.ShowLatencyInDetails = ShowLatencyInDetails;
             s.ShowAiUnlockInDetails = ShowAiUnlockInDetails;
+            s.OpenServerFilterPanelOnStartup = OpenServerFilterPanelOnStartup;
+            // Re-baseline so the unsaved-changes hint clears now that these three match disk —
+            // otherwise reopening Personalize later would show a stale "unsaved" hint for
+            // values that were, in fact, already saved here.
+            _displaySettingsBaseline = (ShowLatencyInDetails, ShowAiUnlockInDetails, OpenServerFilterPanelOnStartup);
+            ShowDisplaySettingsUnsavedHint = false;
             // Language and region don't take effect until the next process start, but Done
             // still persists them — otherwise the user would have to click the restart hint
             // to save at all, which is surprising compared to how Theme / Backdrop behave.
@@ -336,6 +367,8 @@ namespace XrayUI.ViewModels
         {
             ShowLatencyInDetails = settings.ShowLatencyInDetails;
             ShowAiUnlockInDetails = settings.ShowAiUnlockInDetails;
+            OpenServerFilterPanelOnStartup = settings.OpenServerFilterPanelOnStartup;
+            _displaySettingsBaseline = (ShowLatencyInDetails, ShowAiUnlockInDetails, OpenServerFilterPanelOnStartup);
         }
 
         public void LoadLanguage(AppSettings settings)

--- a/Views/PersonalizeControl.xaml
+++ b/Views/PersonalizeControl.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <UserControl x:Class="XrayUI.Views.PersonalizeControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -510,11 +510,11 @@
 
                 <!-- Spacing="2", not the section-level 10: these two cards are one grouped
                      settings block (PowerToys-style), so they should sit near-flush. -->
-                <StackPanel Spacing="2">
+                <StackPanel Spacing="4">
                     <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
                             BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
                             BorderThickness="1"
-                            CornerRadius="{ThemeResource OverlayCornerRadius}">
+                            >
                         <!-- Right padding 6, not 16: ToggleSwitch's template reserves a fixed 12px
                              trailing spacer, so 6+12 lines the pill up with the Expander chevrons (~18px). -->
                         <Grid Padding="16,13,6,13"
@@ -563,7 +563,7 @@
 
                     <Expander HorizontalAlignment="Stretch"
                               HorizontalContentAlignment="Stretch"
-                              CornerRadius="{ThemeResource OverlayCornerRadius}"
+                              
                               Background="{ThemeResource LayerFillColorDefaultBrush}"
                               BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}">
                         <Expander.Header>

--- a/Views/PersonalizeControl.xaml
+++ b/Views/PersonalizeControl.xaml
@@ -501,27 +501,33 @@
                 </Border>
             </StackPanel>
 
-            <!-- Detail settings -->
+            <!-- Display settings -->
             <StackPanel Spacing="10">
-                <TextBlock x:Uid="Personalize_DetailSettings"
-                           Text="详情设置"
+                <TextBlock x:Uid="Personalize_DisplaySettings"
+                           Text="显示设置"
                            FontSize="15"
                            FontWeight="SemiBold" />
 
-                <Expander HorizontalAlignment="Stretch"
-                          HorizontalContentAlignment="Stretch"
-                          CornerRadius="{ThemeResource OverlayCornerRadius}"
-                          Background="{ThemeResource LayerFillColorDefaultBrush}"
-                          BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}">
-                    <Expander.Header>
-                        <Grid Padding="0,12" ColumnSpacing="12">
+                <!-- Spacing="2", not the section-level 10: these two cards are one grouped
+                     settings block (PowerToys-style), so they should sit near-flush. -->
+                <StackPanel Spacing="2">
+                    <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+                            BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                            BorderThickness="1"
+                            CornerRadius="{ThemeResource OverlayCornerRadius}">
+                        <!-- Right padding 6, not 16: ToggleSwitch's template reserves a fixed 12px
+                             trailing spacer, so 6+12 lines the pill up with the Expander chevrons (~18px). -->
+                        <Grid Padding="16,13,6,13"
+                              ColumnSpacing="12">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
 
                             <FontIcon Grid.Column="0"
-                                      Glyph="&#xE946;"
+                                      Glyph="&#xE8A9;"
                                       FontSize="16"
                                       VerticalAlignment="Center"
                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -529,59 +535,113 @@
                             <StackPanel Grid.Column="1"
                                         VerticalAlignment="Center"
                                         Spacing="2">
-                                <TextBlock x:Uid="Personalize_DetailsHeader"
-                                           Text="服务器信息显示"
+                                <TextBlock x:Name="OpenFilterPanelLabel"
+                                           x:Uid="Personalize_OpenFilterPanelOnStartup"
+                                           Text="启动时展开筛选栏"
                                            FontSize="14" />
-                                <TextBlock x:Uid="Personalize_DetailsDesc"
-                                           Text="选择详情卡片上的信息展示"
+                                <TextBlock x:Uid="Personalize_OpenFilterPanelOnStartupDesc"
+                                           Text="默认显示分组和排序选项"
                                            FontSize="12"
                                            TextWrapping="Wrap"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                             </StackPanel>
+
+                            <TextBlock Grid.Column="2"
+                                       AutomationProperties.AccessibilityView="Raw"
+                                       Text="{x:Bind OnOffLabel(ViewModel.OpenServerFilterPanelOnStartup), Mode=OneWay}"
+                                       VerticalAlignment="Center" />
+
+                            <ToggleSwitch Grid.Column="3"
+                                          AutomationProperties.LabeledBy="{x:Bind OpenFilterPanelLabel}"
+                                          IsOn="{x:Bind ViewModel.OpenServerFilterPanelOnStartup, Mode=TwoWay}"
+                                          OnContent=""
+                                          OffContent=""
+                                          MinWidth="0"
+                                          VerticalAlignment="Center" />
                         </Grid>
-                    </Expander.Header>
+                    </Border>
 
-                    <StackPanel Margin="-16,-12,-16,-12">
-                        <!-- Delay Display -->
-                        <CheckBox IsChecked="{x:Bind ViewModel.ShowLatencyInDetails, Mode=TwoWay}"
-                                  HorizontalAlignment="Stretch"
-                                  HorizontalContentAlignment="Stretch"
-                                  Margin="42,10,16,10">
-                            <StackPanel VerticalAlignment="Center"
-                                        Spacing="2">
-                                <TextBlock x:Uid="Personalize_DetailLatency"
-                                           Text="延迟"
-                                           FontSize="14" />
-                                <TextBlock x:Uid="Personalize_DetailLatencyDesc"
-                                           Text="节点卡片上展示延迟"
-                                           FontSize="12"
-                                           TextWrapping="Wrap"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                            </StackPanel>
-                        </CheckBox>
+                    <Expander HorizontalAlignment="Stretch"
+                              HorizontalContentAlignment="Stretch"
+                              CornerRadius="{ThemeResource OverlayCornerRadius}"
+                              Background="{ThemeResource LayerFillColorDefaultBrush}"
+                              BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}">
+                        <Expander.Header>
+                            <Grid Padding="0,12" ColumnSpacing="12">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
 
-                        <Rectangle Height="1"
-                                   Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
+                                <FontIcon Grid.Column="0"
+                                          Glyph="&#xE946;"
+                                          FontSize="16"
+                                          VerticalAlignment="Center"
+                                          Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
 
-                        <!-- AI Unlock Display -->
-                        <CheckBox IsChecked="{x:Bind ViewModel.ShowAiUnlockInDetails, Mode=TwoWay}"
-                                  HorizontalAlignment="Stretch"
-                                  HorizontalContentAlignment="Stretch"
-                                  Margin="42,10,16,10">
-                            <StackPanel VerticalAlignment="Center"
-                                        Spacing="2">
-                                <TextBlock x:Uid="Personalize_DetailAiUnlock"
-                                           Text="AI 解锁"
-                                           FontSize="14" />
-                                <TextBlock x:Uid="Personalize_DetailAiUnlockDesc"
-                                           Text="节点卡片上展示AI的解锁状态"
-                                           FontSize="12"
-                                           TextWrapping="Wrap"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                            </StackPanel>
-                        </CheckBox>
-                    </StackPanel>
-                </Expander>
+                                <StackPanel Grid.Column="1"
+                                            VerticalAlignment="Center"
+                                            Spacing="2">
+                                    <TextBlock x:Uid="Personalize_DetailsHeader"
+                                               Text="服务器信息显示"
+                                               FontSize="14" />
+                                    <TextBlock x:Uid="Personalize_DetailsDesc"
+                                               Text="选择详情卡片上的信息展示"
+                                               FontSize="12"
+                                               TextWrapping="Wrap"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                </StackPanel>
+                            </Grid>
+                        </Expander.Header>
+
+                        <StackPanel Margin="-16,-12,-16,-12">
+                            <!-- Delay Display -->
+                            <CheckBox IsChecked="{x:Bind ViewModel.ShowLatencyInDetails, Mode=TwoWay}"
+                                      HorizontalAlignment="Stretch"
+                                      HorizontalContentAlignment="Stretch"
+                                      Margin="42,10,16,10">
+                                <StackPanel VerticalAlignment="Center"
+                                            Spacing="2">
+                                    <TextBlock x:Uid="Personalize_DetailLatency"
+                                               Text="延迟"
+                                               FontSize="14" />
+                                    <TextBlock x:Uid="Personalize_DetailLatencyDesc"
+                                               Text="节点卡片上展示延迟"
+                                               FontSize="12"
+                                               TextWrapping="Wrap"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                </StackPanel>
+                            </CheckBox>
+
+                            <Rectangle Height="1"
+                                       Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
+
+                            <!-- AI Unlock Display -->
+                            <CheckBox IsChecked="{x:Bind ViewModel.ShowAiUnlockInDetails, Mode=TwoWay}"
+                                      HorizontalAlignment="Stretch"
+                                      HorizontalContentAlignment="Stretch"
+                                      Margin="42,10,16,10">
+                                <StackPanel VerticalAlignment="Center"
+                                            Spacing="2">
+                                    <TextBlock x:Uid="Personalize_DetailAiUnlock"
+                                               Text="AI 解锁"
+                                               FontSize="14" />
+                                    <TextBlock x:Uid="Personalize_DetailAiUnlockDesc"
+                                               Text="节点卡片上展示AI的解锁状态"
+                                               FontSize="12"
+                                               TextWrapping="Wrap"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                </StackPanel>
+                            </CheckBox>
+                        </StackPanel>
+                    </Expander>
+                </StackPanel>
+
+                <InfoBar x:Uid="Personalize_DisplaySettingsUnsavedBar"
+                         IsOpen="{x:Bind ViewModel.ShowDisplaySettingsUnsavedHint, Mode=TwoWay}"
+                         Severity="Informational"
+                         Message="已生效，记得点击下方「完成」保存"
+                         IsClosable="True" />
             </StackPanel>
 
             <!-- Hotkeys -->

--- a/Views/PersonalizeControl.xaml.cs
+++ b/Views/PersonalizeControl.xaml.cs
@@ -11,6 +11,8 @@ namespace XrayUI.Views
     {
         public PersonalizeViewModel ViewModel { get; set; } = null!;
 
+        public string OnOffLabel(bool isOn) => isOn ? L.Dialog_On : L.Dialog_Off;
+
         public PersonalizeControl()
         {
             this.InitializeComponent();


### PR DESCRIPTION
## Summary

- Merge the "Detail settings" and "Server list" sections in the Personalize page into a single "Display settings" card group (PowerToys-style grouped cards), since each had shrunk to essentially one control.
- Restyle the "expand filter bar on startup" toggle row to match Windows Settings conventions (on/off label left of the pill, right-aligned to the Expander chevron below it).
- Add an InfoBar reminder that appears when any of the three display toggles (latency, AI-unlock, filter-bar-on-startup) diverges from its last-loaded/saved baseline — these apply live immediately but only persist on "完成" (Done), and the back button discards unsaved edits silently, so a flipped toggle could previously be lost without warning. Mirrors the existing hotkey-saved / language-restart-hint patterns already in this file.
- Fix: SNI now falls back to the ws/xhttp Host header (not just the raw connect host) for CDN/tunnel nodes, matching v2rayN's fallback order — otherwise the TLS handshake presents the wrong SNI and the edge can't route it.

## Test plan

- [x] `dotnet build` (via `BuildAndRun.ps1 -SkipRun`) succeeds with no new warnings
- [x] UI-automation smoke test: toggle "expand filter bar on startup" → InfoBar appears, live-applies to the server list, click Done → InfoBar clears and `OpenServerFilterPanelOnStartup` persists correctly to `settings.json`
- [x] Confirmed no false-positive hint on initial panel open (baseline capture happens once at startup before any toggle fires)
- [x] Manual check of the SNI fallback against a real CDN/tunnel node (no automated coverage — repo has no test suite)
