### PR TITLE
fix: avoid global hotkey registration race after process takeover

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -334,6 +334,7 @@ namespace XrayUI
 
         private async Task TakeOverPreviousInstanceAsync(int parentPid, bool registerSingleInstanceAfterTakeover)
         {
+            var previousInstanceExited = false;
             try
             {
                 if (parentPid <= 0 || parentPid == Environment.ProcessId)
@@ -357,14 +358,32 @@ namespace XrayUI
 
                     if (!previousInstance.WaitForExit(350))
                     {
-                        previousInstance.Kill(entireProcessTree: true);
-                        previousInstance.WaitForExit(3000);
+                        try
+                        {
+                            previousInstance.Kill(entireProcessTree: true);
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            // It exited in the narrow gap between WaitForExit and Kill.
+                        }
+
+                        previousInstanceExited = previousInstance.HasExited
+                            || previousInstance.WaitForExit(3000);
                     }
+                    else
+                    {
+                        previousInstanceExited = true;
+                    }
+                }
+                else
+                {
+                    previousInstanceExited = true;
                 }
             }
             catch (ArgumentException)
             {
                 // The previous instance already exited.
+                previousInstanceExited = true;
             }
             catch (Exception ex)
             {
@@ -375,6 +394,15 @@ namespace XrayUI
                 if (registerSingleInstanceAfterTakeover)
                 {
                     await RegisterCurrentAsMainInstanceAfterTakeoverAsync();
+                }
+
+                // Startup registration can race with the outgoing process, which still owns
+                // the same global hotkeys until it exits. Retry only after its handles have
+                // actually been released; otherwise RegisterHotKey returns
+                // ERROR_HOTKEY_ALREADY_REGISTERED and this process stays unbound.
+                if (previousInstanceExited && _window is MainWindow mainWindow)
+                {
+                    mainWindow.RegisterGlobalHotkeysAfterProcessTakeover();
                 }
             }
         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -309,6 +309,23 @@ namespace XrayUI
 
         private void OnGlobalHotkeysChanged(object? sender, EventArgs e) => RegisterGlobalHotkeys();
 
+        /// <summary>
+        /// Re-register after an elevation/process handoff. The outgoing process can still own
+        /// the configured combinations when this window performs its normal startup registration;
+        /// once App confirms that process has exited, retry on this window's UI thread.
+        /// </summary>
+        internal void RegisterGlobalHotkeysAfterProcessTakeover()
+        {
+            if (DispatcherQueue.HasThreadAccess)
+            {
+                RegisterGlobalHotkeys();
+                return;
+            }
+
+            if (!DispatcherQueue.TryEnqueue(RegisterGlobalHotkeys))
+                Debug.WriteLine("[Hotkey] Failed to enqueue post-takeover hotkey registration.");
+        }
+
         // Idempotent: always unregisters both ids first, then re-registers whichever have a
         // combo assigned (no separate enabled flag — presence of a combo means active). Safe to
         // call at startup and any time the Personalize page commits a hotkey change.


### PR DESCRIPTION
### Summary
Fixes a race condition during startup process takeover where the outgoing instance still holds onto the global hotkeys, causing the new instance to fail to register them (returning `ERROR_HOTKEY_ALREADY_REGISTERED`).

### Changes
- **App.xaml.cs**: Track whether the previous instance successfully exited. If it did, invoke `RegisterGlobalHotkeysAfterProcessTakeover()` on the main window.
- **MainWindow.xaml.cs**: Implement `RegisterGlobalHotkeysAfterProcessTakeover()` to safely re-register global hotkeys on the UI thread once the takeover is complete.