### PR TITLE
fix: pin real-latency speed test to physical NIC under TUN mode

### DIFF
--- a/Services/RealLatencyProbeService.cs
+++ b/Services/RealLatencyProbeService.cs
@@ -24,6 +24,23 @@ namespace XrayUI.Services
     /// </summary>
     public sealed class RealLatencyProbeService
     {
+        private readonly SettingsService _settings;
+        private readonly TunService _tunService;
+
+        /// <summary>
+        /// Live "a TUN session currently owns the default route" check, wired by the composition
+        /// root (same callback pattern as ControlPanelViewModel.GetSelectedServer). Preferred over
+        /// settings.IsTunMode, which is persisted runtime state that lags the UI toggle and can
+        /// survive a crash as a stale true.
+        /// </summary>
+        public Func<bool> IsTunActive { get; set; } = () => false;
+
+        public RealLatencyProbeService(SettingsService settings, TunService tunService)
+        {
+            _settings = settings;
+            _tunService = tunService;
+        }
+
         private const string TestUrl = "http://www.gstatic.com/generate_204";
 
         // Overall budget for one server's whole warm-up-then-measure cycle. 7s (vs v2rayN's 10s):
@@ -96,8 +113,17 @@ namespace XrayUI.Services
             foreach (var s in servers)
                 entries.Add((s, GetFreeLoopbackPort()));
 
-            // 2. Build + write the dedicated multi-inbound speed-test config.
-            string configJson = XrayConfigBuilder.BuildSpeedtestConfig(entries);
+            // 2. Bind the throwaway core to the physical egress while TUN owns the default
+            // route. autoOutboundsInterface belongs to the live core's TUN inbound and does not
+            // protect this second xray process, so its proxy outbounds need an explicit sockopt.
+            var settings = await _settings.LoadSettingsAsync().ConfigureAwait(false);
+            var outboundInterface = IsTunActive()
+                ? _tunService.ResolveOutboundInterface(settings.TunOutboundInterface)
+                : null;
+            Debug.WriteLine($"[RealLatencyProbe] 测速出口网卡: {outboundInterface ?? "系统默认路由"}");
+
+            // 3. Build + write the dedicated multi-inbound speed-test config.
+            string configJson = XrayConfigBuilder.BuildSpeedtestConfig(entries, outboundInterface);
             Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
             await File.WriteAllTextAsync(ConfigPath, configJson, ct).ConfigureAwait(false);
 
@@ -107,7 +133,7 @@ namespace XrayUI.Services
 
             try
             {
-                // 3. Launch the throwaway core.
+                // 4. Launch the throwaway core.
                 var psi = new ProcessStartInfo
                 {
                     FileName = XrayService.ExePath,
@@ -136,7 +162,7 @@ namespace XrayUI.Services
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
 
-                // 4. Wait until the core reports every inbound is up. An early exit falls
+                // 5. Wait until the core reports every inbound is up. An early exit falls
                 // through to the HasExited check below, which reads the captured log.
                 await readySignal.WaitAsync(CoreReadyCap, ct).ConfigureAwait(false);
 
@@ -152,7 +178,7 @@ namespace XrayUI.Services
                     return;
                 }
 
-                // 5. Probe each server through its own socks port (capped concurrency).
+                // 6. Probe each server through its own socks port (capped concurrency).
                 using var throttle = new SemaphoreSlim(MaxConcurrency);
                 var tasks = new List<Task>(entries.Count);
                 foreach (var (server, port) in entries)
@@ -172,7 +198,7 @@ namespace XrayUI.Services
             }
             finally
             {
-                // 6. Tear down the throwaway core and its temp config.
+                // 7. Tear down the throwaway core and its temp config.
                 try
                 {
                     if (process is not null && !process.HasExited)

--- a/Services/TunService.cs
+++ b/Services/TunService.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using XrayUI.Helpers;
 
@@ -37,6 +39,101 @@ public class TunService
 
     /// <summary>Gets the expected wintun.dll path for error messages.</summary>
     public string GetExpectedWintunPath() => Path.Combine(_engineDirectory, "wintun.dll");
+
+    /// <summary>
+    /// Resolves the interface that helper cores must bind to while TUN owns the default route.
+    /// An explicitly configured interface wins when it still exists, is up and is not the TUN
+    /// adapter itself; a stale name falls back to automatic selection instead of pinning every
+    /// outbound to a dead adapter. In automatic mode, choose an active non-TUN interface with a
+    /// real default gateway; virtual host-only adapters normally have none and are therefore
+    /// ignored. Returning <see langword="null"/> preserves the old process-routing fallback when
+    /// Windows exposes no usable interface.
+    /// </summary>
+    public string? ResolveOutboundInterface(string? configuredInterface)
+    {
+        var configured = XrayConfigBuilder.NormalizeTunOutboundInterface(configuredInterface);
+
+        try
+        {
+            var interfaces = NetworkInterface.GetAllNetworkInterfaces();
+
+            if (configured is not null)
+            {
+                var match = interfaces.FirstOrDefault(ni =>
+                    string.Equals(ni.Name, configured, StringComparison.OrdinalIgnoreCase)
+                    && ni.OperationalStatus == OperationalStatus.Up
+                    && !IsTunLikeInterface(ni));
+                if (match is not null)
+                    return match.Name;
+                Debug.WriteLine($"[TunService] 配置的测速出口网卡不可用,回退自动选择: {configured}");
+            }
+
+            var candidate = interfaces
+                .Where(IsAutomaticOutboundCandidate)
+                // Prefer an IPv4 gateway because the speed-test target and most node endpoints
+                // are IPv4-capable. Speed provides a deterministic tie-break for multi-NIC PCs.
+                .OrderByDescending(HasIPv4Gateway)
+                .ThenByDescending(ni => ni.Speed)
+                .ThenBy(ni => ni.Name, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+
+            if (candidate is not null)
+                return candidate.Name;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[TunService] 自动选择测速出口网卡失败: {ex.Message}");
+            // Enumeration itself failed, so the stale-name check never ran — an explicit user
+            // choice is still the best remaining guess.
+            if (configured is not null)
+                return configured;
+        }
+
+        Debug.WriteLine("[TunService] 未找到可用于测速的物理出口网卡");
+        return null;
+    }
+
+    /// <summary>Adapters that must never carry pinned helper-core traffic: loopback, tunnels,
+    /// and the xray-tun/wintun adapter itself (pinning to it recreates the proxy loop). Also used
+    /// by <see cref="Views.TunConfirmationDialog"/> to keep the interface picker in sync with what
+    /// <see cref="ResolveOutboundInterface"/> will actually accept.</summary>
+    internal static bool IsTunLikeInterface(NetworkInterface networkInterface) =>
+        networkInterface.NetworkInterfaceType is NetworkInterfaceType.Loopback
+            or NetworkInterfaceType.Tunnel
+        || string.Equals(networkInterface.Name, TunInterfaceName, StringComparison.OrdinalIgnoreCase)
+        || networkInterface.Description.Contains("Xray Tunnel", StringComparison.OrdinalIgnoreCase)
+        || networkInterface.Description.Contains("Wintun", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsAutomaticOutboundCandidate(NetworkInterface networkInterface)
+    {
+        if (networkInterface.OperationalStatus != OperationalStatus.Up
+            || IsTunLikeInterface(networkInterface))
+        {
+            return false;
+        }
+
+        // IPv6 default routers legitimately appear as link-local (fe80::) gateways via router
+        // advertisements, so they count — but only when the adapter also holds a global IPv6
+        // address. A lone fe80 gateway without one (stale RA on an isolated segment) is no
+        // evidence of an internet path and must not beat the null fallback.
+        var ipProperties = networkInterface.GetIPProperties();
+        return ipProperties.GatewayAddresses.Any(gateway =>
+            !gateway.Address.Equals(IPAddress.Any)
+            && !gateway.Address.Equals(IPAddress.IPv6Any)
+            && !IPAddress.IsLoopback(gateway.Address)
+            && (!gateway.Address.IsIPv6LinkLocal || HasGlobalIPv6Address(ipProperties)));
+    }
+
+    private static bool HasGlobalIPv6Address(IPInterfaceProperties ipProperties) =>
+        ipProperties.UnicastAddresses.Any(address =>
+            address.Address.AddressFamily == AddressFamily.InterNetworkV6
+            && !address.Address.IsIPv6LinkLocal
+            && !IPAddress.IsLoopback(address.Address));
+
+    private static bool HasIPv4Gateway(NetworkInterface networkInterface) =>
+        networkInterface.GetIPProperties().GatewayAddresses.Any(gateway =>
+            gateway.Address.AddressFamily == AddressFamily.InterNetwork
+            && !gateway.Address.Equals(IPAddress.Any));
 
     /// <summary>
     /// Best-effort reset of stale DNS server entries that Windows can persist on the

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -215,9 +215,7 @@ namespace XrayUI.Services
                 foreach (var outbound in list.OfType<JsonObject>())
                 {
                     var tag = outbound["tag"]?.GetValue<string>();
-                    var protocol = outbound["protocol"]?.GetValue<string>();
-                    if (tag is ProxyOutboundTag or DirectOutboundTag or ChainEntryOutboundTag
-                        && !string.Equals(protocol, "wireguard", StringComparison.OrdinalIgnoreCase))
+                    if (tag is ProxyOutboundTag or DirectOutboundTag or ChainEntryOutboundTag)
                     {
                         ApplyOutboundInterface(outbound, outboundInterface);
                     }
@@ -227,7 +225,7 @@ namespace XrayUI.Services
             return list;
         }
 
-        private static string? NormalizeTunOutboundInterface(string? interfaceName)
+        internal static string? NormalizeTunOutboundInterface(string? interfaceName)
         {
             if (string.IsNullOrWhiteSpace(interfaceName))
                 return null;
@@ -280,6 +278,13 @@ namespace XrayUI.Services
 
         private static void ApplyOutboundInterface(JsonObject outbound, string interfaceName)
         {
+            // Wireguard outbounds carry no streamSettings, so a sockopt pin cannot apply there —
+            // the process-routing rule stays their only cover. Centralized here so every caller
+            // gets the exemption without repeating it.
+            var protocol = outbound["protocol"]?.GetValue<string>();
+            if (string.Equals(protocol, "wireguard", StringComparison.OrdinalIgnoreCase))
+                return;
+
             var streamSettings = outbound["streamSettings"] as JsonObject;
             if (streamSettings is null)
             {
@@ -861,7 +866,9 @@ namespace XrayUI.Services
             {
                 ["type"] = "field",
                 ["outboundTag"] = DirectOutboundTag,
-                ["process"] = CreateStringArray("self/", "xray/")
+                // Keep the plain process-name fallback as well as Xray's path sugars. Process
+                // attribution for a second helper core can occasionally lack the full path.
+                ["process"] = CreateStringArray("self/", "xray/", "xray")
             });
         }
 
@@ -1083,8 +1090,14 @@ namespace XrayUI.Services
         /// the caller must filter them out.
         /// </summary>
         /// <param name="entries">Each server paired with the local socks port it should listen on.</param>
+        /// <param name="outboundInterface">Resolved physical interface name to pin every proxy
+        /// outbound to (see <see cref="TunService.ResolveOutboundInterface"/>), or null for no
+        /// pin. The pin is required when another Xray process owns a full-route TUN, otherwise
+        /// this helper core's node connections can be captured and proxy-looped. Taken verbatim —
+        /// callers resolve the "auto" sentinel first.</param>
         public static string BuildSpeedtestConfig(
-            IReadOnlyList<(ServerEntry server, int port)> entries)
+            IReadOnlyList<(ServerEntry server, int port)> entries,
+            string? outboundInterface)
         {
             var inbounds = new JsonArray();
             var outbounds = new JsonArray();
@@ -1109,7 +1122,12 @@ namespace XrayUI.Services
                     }
                 });
 
-                AddNode(outbounds, BuildProxyOutbound(server, outTag));
+                var outbound = BuildProxyOutbound(server, outTag);
+                if (outboundInterface is not null)
+                {
+                    ApplyOutboundInterface(outbound, outboundInterface);
+                }
+                AddNode(outbounds, outbound);
 
                 AddNode(rules, new JsonObject
                 {

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -77,7 +77,7 @@ namespace XrayUI.ViewModels
             var latencyProbe = new LatencyProbeService(
                 new TcpConnectProbeService(),
                 new PingProbeService());
-            var realLatencyProbe = new RealLatencyProbeService();
+            var realLatencyProbe = new RealLatencyProbeService(settings, tunService);
             var aiUnlockCheck = new AiUnlockCheckService();
 
             Title = "Proxy Console";
@@ -94,6 +94,9 @@ namespace XrayUI.ViewModels
             ServerDetail.GetAllServers = () => ServerList.Servers;
             ServerList.RequestSwitchToSelectedServer = ControlPanel.SwitchToSelectedServerAsync;
             Personalize.IsProxyRunning = () => ControlPanel.IsRunning;
+            // Live TUN state for the speed test's egress pin — settings.IsTunMode alone lags
+            // the UI toggle and can survive a crash as a stale true (see IDialogService remarks).
+            realLatencyProbe.IsTunActive = () => ControlPanel.IsRunning && ControlPanel.IsTunMode;
 
             ServerList.PropertyChanged   += OnServerListPropertyChanged;
             ControlPanel.PropertyChanged += OnControlPanelPropertyChanged;

--- a/Views/TunConfirmationDialog.xaml.cs
+++ b/Views/TunConfirmationDialog.xaml.cs
@@ -84,7 +84,7 @@ namespace XrayUI.Views
             {
                 return NetworkInterface.GetAllNetworkInterfaces()
                     .Where(ni => ni.OperationalStatus == OperationalStatus.Up
-                                 && ni.NetworkInterfaceType != NetworkInterfaceType.Loopback)
+                                 && !TunService.IsTunLikeInterface(ni))
                     .Select(ni => ni.Name)
                     .OrderBy(name => name)
                     .ToList();


### PR DESCRIPTION
## Summary
- The "real delay" speed test spawns a throwaway second xray core on its own loopback socks ports. While the live core owns a full-route TUN, that helper core's outbound traffic was captured by the TUN and looped through the live proxy — the test either measured the wrong thing or timed out.
- `TunService.ResolveOutboundInterface` resolves the physical NIC the helper core should bind to: an explicitly configured interface (validated for existence/Up state/not-the-TUN-adapter, with fallback to auto-selection when stale), or an automatically chosen NIC with a real default gateway (IPv4 preferred; an IPv6 link-local gateway only counts when the adapter also holds a global IPv6 address).
- `RealLatencyProbeService` gates the pin on a live `IsTunActive` callback (wired from `MainViewModel` to `ControlPanel.IsRunning && ControlPanel.IsTunMode`) instead of the persisted `settings.IsTunMode`, since the persisted flag lags the UI toggle and can stay stuck `true` after a crash.
- `XrayConfigBuilder.BuildSpeedtestConfig` applies the resolved interface as a `sockopt.interface` pin on each proxy outbound; the wireguard no-op (those outbounds carry no `streamSettings`) is now centralized inside `ApplyOutboundInterface` instead of duplicated at each call site.
- The live TUN config's process-routing fallback gained a bare `"xray"` entry alongside the existing `"self/"`/`"xray/"` path sugars, as defense-in-depth for the rare case where the resolver finds no usable physical NIC.
- `TunConfirmationDialog`'s adapter picker now shares `TunService`'s TUN-adapter exclusion filter, so it no longer lists interfaces (Tunnel-type adapters, the xray-tun adapter itself) that the resolver would later silently reject.

## Reviewer notes
- Went through a max-effort `/code-review` pass (10 finder angles + verification) that surfaced several real gaps in the initial version — most notably a stale/unpinned explicit interface, IPv6 link-local gateways wrongly disqualifying IPv6-only networks, and duplicated wireguard-exclusion logic — all fixed in this branch. A `/simplify` pass on top cleaned up a nullable-callback pattern and duplicate diagnostic logging.
- Deliberately **not** included: using the real Windows routing table (via `GetIpForwardTable2`) instead of the link-speed heuristic for automatic NIC selection when multiple non-TUN adapters have default gateways ([flagged by Codex](https://github.com/PhoenixNil/XrayUI-dev/pull/92#discussion_r3563566379)) — a real remaining gap on multi-NIC hardware, needs dedicated hardware to test rather than a blind fix.
- ~~A `dns` block for the speed-test config to cover FakeDNS + domain-named nodes under TUN~~ — [Codex flagged this](https://github.com/PhoenixNil/XrayUI-dev/pull/92#discussion_r3563566378) as a plausible theoretical gap, but it doesn't reproduce: tested live with FakeDNS on + TUN connected, real-latency test against multiple domain-hostname nodes all returned correct, varied round-trip times. The live core's FakeDNS capture rule is scoped to `inboundTag: ["tun-in"]`, and `sockopt.interface` pinning appears to also cover the helper outbound's own hostname resolution (Xray's `sockopt.domainStrategy` — which governs resolving an outbound's own server hostname — lives in the same `sockopt` object as `interface`), so the helper's DNS traffic for its own server address never reaches the TUN inbound in the first place. See [reply on the review thread](https://github.com/PhoenixNil/XrayUI-dev/pull/92#discussion_r3563609812) for detail.
- No automated tests exist in this repo; verified via `dotnet build` / `BuildAndRun.ps1 -SkipRun` only. TUN-mode speed test behavior itself was manually smoke-tested (connect via TUN with FakeDNS on, run "test all real latencies" against domain-hostname nodes — succeeded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)