### PR TITLE
feat: preserve VLESS-XHTTP mode/extra from import to config and share link

### DIFF
--- a/Models/ServerEntry.cs
+++ b/Models/ServerEntry.cs
@@ -22,6 +22,8 @@ namespace XrayUI.Models
             Network = "tcp";
             Path = string.Empty;
             WsHost = string.Empty;
+            XhttpMode = string.Empty;
+            XhttpExtra = string.Empty;
             Security = string.Empty;
             Sni = string.Empty;
             Fingerprint = string.Empty;
@@ -102,6 +104,14 @@ namespace XrayUI.Models
 
         [ObservableProperty]
         public partial string WsHost { get; set; }
+
+        /// <summary>XHTTP mode: auto | packet-up | stream-up | stream-one. Empty = xray default (auto).</summary>
+        [ObservableProperty]
+        public partial string XhttpMode { get; set; }
+
+        /// <summary>Raw xhttpSettings.extra JSON (padding/xmux settings), shared as the "extra" URI parameter.</summary>
+        [ObservableProperty]
+        public partial string XhttpExtra { get; set; }
 
         [ObservableProperty]
         public partial int AlterId { get; set; }
@@ -248,6 +258,8 @@ namespace XrayUI.Models
             Network            = source.Network;
             Path               = source.Path;
             WsHost             = source.WsHost;
+            XhttpMode          = source.XhttpMode;
+            XhttpExtra         = source.XhttpExtra;
             AlterId            = source.AlterId;
             Security           = source.Security;
             Sni                = source.Sni;

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -146,6 +146,14 @@ namespace XrayUI.Services
 
             var txtPath = new TextBox { Header = L.EditServer_Path, Text = existing?.Path ?? string.Empty };
             var txtWsHost = new TextBox { Header = L.EditServer_WsHost, Text = existing?.WsHost ?? string.Empty };
+            // Literal English headers — technical fields, same convention as SNI / Finalmask (JSON).
+            // Blank first item = "not set": omitted from the config so xray defaults to auto.
+            var cmbXhttpMode = new ComboBox { Header = "XHTTP Mode", MinWidth = 200 };
+            cmbXhttpMode.Items.Add(string.Empty);
+            foreach (var m in XhttpSettings.Modes)
+                cmbXhttpMode.Items.Add(m);
+            cmbXhttpMode.SelectedItem = XhttpSettings.NormalizeMode(existing?.XhttpMode);
+            var txtXhttpExtra = CreateJsonTextBox("XHTTP Extra (JSON)", existing?.XhttpExtra);
             var cmbSecurity = new ComboBox { Header = L.EditServer_Security, MinWidth = 200 };
             foreach (var s in new[] { "none", "tls", "reality" })
                 cmbSecurity.Items.Add(s);
@@ -183,16 +191,7 @@ namespace XrayUI.Services
                 Text = existing?.VlessEncryption ?? string.Empty,
                 TextWrapping = TextWrapping.Wrap
             };
-            var txtFinalmask = new TextBox
-            {
-                Header = "Finalmask (JSON)",
-                // AcceptsReturn must be set BEFORE Text — initializer assigns properties in
-                // declared order, and Text setter in single-line mode truncates at the first \r.
-                AcceptsReturn = true,
-                Height = 104,
-                TextWrapping = TextWrapping.NoWrap,
-                Text = (existing?.Finalmask ?? string.Empty).Replace("\r\n", "\r").Replace("\n", "\r"),
-            };
+            var txtFinalmask = CreateJsonTextBox("Finalmask (JSON)", existing?.Finalmask);
 
             // WireGuard. Literal English headers, matching the other technical fields above
             // (SNI / UUID / PublicKey (Reality) / Flow (VLESS)).
@@ -223,6 +222,8 @@ namespace XrayUI.Services
             var rowAlterId = Wrap(numAlterId);
             var rowPath = Wrap(txtPath);
             var rowWsHost = Wrap(txtWsHost);
+            var rowXhttpMode = Wrap(cmbXhttpMode);
+            var rowXhttpExtra = Wrap(txtXhttpExtra);
             var rowSni = Wrap(txtSni);
             var rowFp = Wrap(txtFp);
             var rowAllowInsecure = Wrap(chkAllowInsecure);
@@ -275,6 +276,8 @@ namespace XrayUI.Services
                 rowAlterId.Visibility = isVmess ? Visibility.Visible : Visibility.Collapsed;
                 rowPath.Visibility = (hasWs || hasXhttp || hasGrpc) ? Visibility.Visible : Visibility.Collapsed;
                 rowWsHost.Visibility = (hasWs || hasXhttp) ? Visibility.Visible : Visibility.Collapsed;
+                rowXhttpMode.Visibility = hasXhttp ? Visibility.Visible : Visibility.Collapsed;
+                rowXhttpExtra.Visibility = hasXhttp ? Visibility.Visible : Visibility.Collapsed;
                 rowSni.Visibility = (hasTls || isHysteria2) ? Visibility.Visible : Visibility.Collapsed;
                 rowFp.Visibility = hasTls ? Visibility.Visible : Visibility.Collapsed;
                 rowAllowInsecure.Visibility = (hasTls || isHysteria2) ? Visibility.Visible : Visibility.Collapsed;
@@ -317,7 +320,7 @@ namespace XrayUI.Services
                 {
                     txtName, txtHost, numPort, cmbProtocol,
                     rowEncryption, rowUsername, rowPassword, rowUuid, rowAlterId,
-                    cmbNetwork, rowPath, rowWsHost,
+                    cmbNetwork, rowPath, rowWsHost, rowXhttpMode, rowXhttpExtra,
                     cmbSecurity, rowSni, rowFp, rowAllowInsecure, rowEchConfigList, rowEchForceQuery,
                     rowPk, rowSid, rowSpx, rowFlow, rowVlessEncryption,
                     rowWgPrivateKey, rowWgPublicKey, rowWgPreSharedKey, rowWgLocalAddress, rowWgMtu, rowWgReserved,
@@ -361,6 +364,8 @@ namespace XrayUI.Services
             entry.Network = cmbNetwork.SelectedItem?.ToString() ?? "tcp";
             entry.Path = txtPath.Text.Trim();
             entry.WsHost = txtWsHost.Text.Trim();
+            entry.XhttpMode = cmbXhttpMode.SelectedItem?.ToString() ?? string.Empty;
+            entry.XhttpExtra = FinalmaskJson.NormalizeForStorage(txtXhttpExtra.Text);
             entry.Security = cmbSecurity.SelectedItem?.ToString() ?? "none";
             entry.Sni = txtSni.Text.Trim();
             entry.Fingerprint = txtFp.Text.Trim();
@@ -395,6 +400,8 @@ namespace XrayUI.Services
                 entry.AlterId = 0;
                 entry.Path = string.Empty;
                 entry.WsHost = string.Empty;
+                entry.XhttpMode = string.Empty;
+                entry.XhttpExtra = string.Empty;
                 entry.Sni = string.Empty;
                 entry.Fingerprint = string.Empty;
                 entry.AllowInsecure = false;
@@ -416,6 +423,8 @@ namespace XrayUI.Services
                 entry.AlterId = 0;
                 entry.Path = string.Empty;
                 entry.WsHost = string.Empty;
+                entry.XhttpMode = string.Empty;
+                entry.XhttpExtra = string.Empty;
                 entry.Sni = string.Empty;
                 entry.Fingerprint = string.Empty;
                 entry.AllowInsecure = false;
@@ -442,6 +451,14 @@ namespace XrayUI.Services
                 entry.WgLocalAddress = string.Empty;
                 entry.WgReserved = string.Empty;
                 entry.WgMtu = 0;
+            }
+
+            // XHTTP-only fields must not survive a transport switch (ws/grpc/tcp reuse Path/WsHost,
+            // but mode/extra are meaningless outside xhttp and would silently reappear on switch-back).
+            if (!string.Equals(entry.Network, "xhttp", StringComparison.OrdinalIgnoreCase))
+            {
+                entry.XhttpMode = string.Empty;
+                entry.XhttpExtra = string.Empty;
             }
 
             if (!string.Equals(entry.Protocol, "vless", StringComparison.OrdinalIgnoreCase)
@@ -1245,6 +1262,18 @@ namespace XrayUI.Services
 
         private static Border Wrap(FrameworkElement child) =>
             new Border { Child = child };
+
+        /// <summary>Multi-line raw-JSON editor box (Finalmask / XHTTP extra).</summary>
+        private static TextBox CreateJsonTextBox(string header, string? value) => new()
+        {
+            Header = header,
+            // AcceptsReturn must be set BEFORE Text — initializer assigns properties in
+            // declared order, and Text setter in single-line mode truncates at the first \r.
+            AcceptsReturn = true,
+            Height = 104,
+            TextWrapping = TextWrapping.NoWrap,
+            Text = (value ?? string.Empty).Replace("\r\n", "\r").Replace("\n", "\r"),
+        };
 
         /// <summary>
         /// The protocol ComboBox shows display names (e.g. "Shadowsocks") but stores the

--- a/Services/NodeLinkParser.cs
+++ b/Services/NodeLinkParser.cs
@@ -238,6 +238,16 @@ namespace XrayUI.Services
                 var finalmask = FinalmaskJson.NormalizeForStorage(Q(query, "fm"));
                 var allowInsecure = IsTruthy(Q(query, "allowInsecure")) || IsTruthy(Q(query, "insecure"));
 
+                // Gated on xhttp: grpc links reuse the "mode" key for gun/multi. Case-insensitive
+                // because network keeps the URI's original casing (only the builder lowercases).
+                var xhttpMode  = string.Empty;
+                var xhttpExtra = string.Empty;
+                if (string.Equals(network, "xhttp", StringComparison.OrdinalIgnoreCase))
+                {
+                    xhttpMode  = XhttpSettings.NormalizeMode(Q(query, "mode"));
+                    xhttpExtra = FinalmaskJson.NormalizeForStorage(Q(query, "extra"));
+                }
+
                 return new ServerEntry
                 {
                     Name        = name,
@@ -257,6 +267,8 @@ namespace XrayUI.Services
                     SpiderX     = spx,
                     Path        = path,
                     WsHost      = wsHost,
+                    XhttpMode   = xhttpMode,
+                    XhttpExtra  = xhttpExtra,
                     Flow        = flow,
                     VlessEncryption = vlessEncryption == "none" ? string.Empty : vlessEncryption,
                     Finalmask   = finalmask,

--- a/Services/NodeLinkSerializer.cs
+++ b/Services/NodeLinkSerializer.cs
@@ -133,6 +133,12 @@ namespace XrayUI.Services
             if (network == "ws" || network == "xhttp")
                 AppendIfNotEmpty(sb, "host", s.WsHost);
 
+            if (network == "xhttp")
+            {
+                AppendIfNotEmpty(sb, "mode", XhttpSettings.NormalizeMode(s.XhttpMode));
+                AppendIfNotEmpty(sb, "extra", FinalmaskJson.NormalizeForShare(s.XhttpExtra));
+            }
+
             // VLESS-level encryption (Xray PR #5067). Always emit, matching v2rayN parity & spec.
             var vlessEnc = string.IsNullOrEmpty(s.VlessEncryption) ? "none" : s.VlessEncryption;
             AppendParam(sb, "encryption", vlessEnc, first: false);

--- a/Services/XhttpSettings.cs
+++ b/Services/XhttpSettings.cs
@@ -1,0 +1,29 @@
+namespace XrayUI.Services
+{
+    /// <summary>
+    /// Shared constants and normalization for the XHTTP transport mode.
+    /// Used by parser, serializer, config builder, and dialog.
+    /// </summary>
+    internal static class XhttpSettings
+    {
+        public const string Auto = "auto";
+        public const string PacketUp = "packet-up";
+        public const string StreamUp = "stream-up";
+        public const string StreamOne = "stream-one";
+
+        /// <summary>Canonical mode values, in the order the edit dialog offers them.</summary>
+        public static readonly string[] Modes = [Auto, PacketUp, StreamUp, StreamOne];
+
+        /// <summary>
+        /// Returns the canonical mode if value matches one (after trim + lower-invariant);
+        /// otherwise empty — the model stores "not set" (xray defaults to auto) as empty string.
+        /// A typo or a foreign "mode" value (grpc links reuse the key for gun/multi) can then
+        /// never produce an xray config that fails to load.
+        /// </summary>
+        public static string NormalizeMode(string? value)
+        {
+            value = value?.Trim().ToLowerInvariant();
+            return value is Auto or PacketUp or StreamUp or StreamOne ? value : string.Empty;
+        }
+    }
+}

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -740,6 +740,28 @@ namespace XrayUI.Services
                     settings["host"] = server.WsHost;
                 }
 
+                var mode = XhttpSettings.NormalizeMode(server.XhttpMode);
+
+                if (FinalmaskJson.Parse(server.XhttpExtra) is JsonObject extra)
+                {
+                    NormalizeXhttpDownloadSettings(extra);
+                    settings["extra"] = extra;
+
+                    // xray refuses to load stream-one combined with a download split ("Can not
+                    // use "downloadSettings" in "stream-one" mode"). The split server is the
+                    // intent-bearing half of that contradiction, so keep it and omit the mode —
+                    // auto picks a split-compatible one.
+                    if (mode == XhttpSettings.StreamOne && extra["downloadSettings"] is JsonObject)
+                    {
+                        mode = string.Empty;
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(mode))
+                {
+                    settings["mode"] = mode;
+                }
+
                 stream["xhttpSettings"] = settings;
             }
 
@@ -753,6 +775,52 @@ namespace XrayUI.Services
             if (finalmask is JsonObject)
             {
                 streamSettings["finalmask"] = finalmask;
+            }
+        }
+
+        // v2board panels emit v2rayN-compact downloadSettings inside extra ({"server","servername","path","port"}),
+        // but xray-core wants a StreamConfig-shaped object (address + network/security/tlsSettings/xhttpSettings).
+        // xray silently ignores the unknown compact keys, leaving address empty — the download leg never comes up
+        // even though `-test` reports Configuration OK. Translated at emit time only, so the stored/shared extra
+        // stays byte-faithful to what the subscription sent.
+        private static void NormalizeXhttpDownloadSettings(JsonObject extra)
+        {
+            if (extra["downloadSettings"] is not JsonObject download)
+                return;
+
+            var isCompact = download["server"] is not null
+                || download["servername"] is not null
+                || download["path"] is not null;
+            if (!isCompact)
+                return;
+
+            if (download["address"] is null && download["server"] is JsonNode address)
+            {
+                // Detach before re-parenting — JsonNode enforces a single parent.
+                download.Remove("server");
+                download["address"] = address;
+            }
+
+            if (download["network"] is null)
+            {
+                download["network"] = "xhttp";
+            }
+
+            if (download["xhttpSettings"] is null && download["path"] is JsonNode path)
+            {
+                download.Remove("path");
+                // The download leg carries no mode — only the upload leg negotiates it.
+                download["xhttpSettings"] = new JsonObject { ["path"] = path };
+            }
+
+            if (download["tlsSettings"] is null && download["servername"] is JsonNode serverName)
+            {
+                download.Remove("servername");
+                if (download["security"] is null)
+                {
+                    download["security"] = "tls";
+                }
+                download["tlsSettings"] = new JsonObject { ["serverName"] = serverName };
             }
         }
 

--- a/ViewModels/ServerDetailViewModel.cs
+++ b/ViewModels/ServerDetailViewModel.cs
@@ -203,6 +203,14 @@ namespace XrayUI.ViewModels
 
         private void OnSelectedServerPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
+            if (string.IsNullOrEmpty(e.PropertyName))
+            {
+                CancelPendingLatencyTest();
+                NotifySelectedServerFieldsChanged();
+                ResetLatencyDisplay();
+                return;
+            }
+
             switch (e.PropertyName)
             {
                 case nameof(ServerEntry.Name):
@@ -229,15 +237,11 @@ namespace XrayUI.ViewModels
                     OnPropertyChanged(nameof(SelectedSecurityLabel));
                     OnPropertyChanged(nameof(SelectedTransport));
                     OnPropertyChanged(nameof(SelectedTransportVisibility));
-                    OnPropertyChanged(nameof(SelectedShareLink));
-                    OnPropertyChanged(nameof(CanCopyShareLink));
                     break;
                 case nameof(ServerEntry.Encryption):
                 case nameof(ServerEntry.Username):
                 case nameof(ServerEntry.Password):
                     OnPropertyChanged(nameof(SelectedEncryption));
-                    OnPropertyChanged(nameof(SelectedShareLink));
-                    OnPropertyChanged(nameof(CanCopyShareLink));
                     break;
                 case nameof(ServerEntry.ChainEntryServerId):
                     OnPropertyChanged(nameof(SelectedHost));
@@ -247,22 +251,23 @@ namespace XrayUI.ViewModels
                     OnPropertyChanged(nameof(SelectedPort));
                     OnPropertyChanged(nameof(SelectedEncryption));
                     break;
-                case nameof(ServerEntry.Security):
-                case nameof(ServerEntry.VlessEncryption):
-                case nameof(ServerEntry.EchConfigList):
-                case nameof(ServerEntry.EchForceQuery):
-                    OnPropertyChanged(nameof(SelectedShareLink));
-                    OnPropertyChanged(nameof(CanCopyShareLink));
-                    break;
                 case nameof(ServerEntry.Network):
                     OnPropertyChanged(nameof(SelectedTransport));
                     break;
-                case null:
-                case "":
-                    CancelPendingLatencyTest();
-                    NotifySelectedServerFieldsChanged();
-                    ResetLatencyDisplay();
-                    break;
+            }
+
+            // Any persisted config field can feed NodeLinkSerializer, so refresh the share link
+            // for everything except runtime/display-only notifications — a field added to
+            // ServerEntry later then can't silently leave the copied link stale.
+            if (e.PropertyName is not (nameof(ServerEntry.IsActive)
+                or nameof(ServerEntry.LatencyMs)
+                or nameof(ServerEntry.LatencyText)
+                or nameof(ServerEntry.HasLatency)
+                or nameof(ServerEntry.DisplayProtocol)
+                or nameof(ServerEntry.IsChain)))
+            {
+                OnPropertyChanged(nameof(SelectedShareLink));
+                OnPropertyChanged(nameof(CanCopyShareLink));
             }
         }
 


### PR DESCRIPTION
## What

VLESS share links with XHTTP transport carry `mode=` and `extra=<json>` query params (padding obfuscation, xmux tuning, download split). XrayUI dropped both on import, so subscriptions whose servers enforce them — e.g. `mode=stream-one` with `xPaddingObfsMode`/`xPaddingKey`/`xPaddingPlacement` anti-probe padding — imported fine but every node timed out, while the same links worked in v2rayN. This PR carries both fields end to end:

- **`ServerEntry.XhttpMode` / `XhttpExtra`** — persisted fields, included in `CopyConfigFrom`, so a plain subscription refresh heals already-imported nodes. Not part of the node identity key (same treatment as Fingerprint/ECH/Finalmask).
- **`NodeLinkParser` / `NodeLinkSerializer`** — parse and re-emit both params on `vless://` links for full round-trip. Gated on `type=xhttp` (case-insensitive; gRPC links reuse the `mode` key for `gun`/`multi`) with a whitelist normalizer.
- **`XrayConfigBuilder`** — emits `xhttpSettings.mode`/`extra`. Two emit-time normalizations, keeping stored/shared bytes faithful to the subscription:
  - v2board-style compact `downloadSettings` keys (`server`/`servername`/top-level `path`) are translated into the native StreamConfig shape (`address`, `tlsSettings.serverName`, nested `xhttpSettings.path`) — xray silently ignores the compact keys and the download leg never comes up otherwise.
  - `mode` is omitted when `stream-one` meets a download split: xray 26.6.1 refuses that combo with `Can not use "downloadSettings" in "stream-one" mode`, and the split server is the intent-bearing half.
- **`DialogService`** — "XHTTP Mode" combo + "XHTTP Extra (JSON)" editor, visible for xhttp entries (v2rayN-editor parity). JSON boxes share a new `CreateJsonTextBox` factory with the Finalmask box. Fields are cleared when the transport is switched away from xhttp.
- **`XhttpSettings`** — shared mode constants + `NormalizeMode`, following the existing `EchSettings` pattern; consumed by parser, serializer, builder, and dialog so the value set lives in one place.
- **`ServerDetailViewModel`** — the copy-share-link button previously served a stale URL after editing many fields (`Path`, `Sni`, `Uuid`, `Finalmask`, …, pre-existing gap). Invalidation is now inverted: the link refreshes on any property change except a small deny-list of runtime-only notifications, so future `ServerEntry` fields are covered automatically.

## Why

Reported with a live subscription (dogegg): all nodes timeout in XrayUI, work in v2rayN. Root cause A/B-tested against the bundled xray 26.6.1 with hand-built configs through a loopback SOCKS probe:

| config | result |
| --- | --- |
| `xhttpSettings` with `path`+`host` only (old builder output) | timeout (HTTP 000) |
| same + `mode=stream-one` + `extra={xPadding…, xmux…}` (new output) | **HTTP 204** |

## Reviewer notes

- Storage semantics mirror Finalmask exactly: invalid `extra` JSON is stored verbatim (visible/fixable in the edit dialog), never emitted to the config, exported as-is.
- The stream-one/download-split conflict and the native `downloadSettings` shape were both validated with `xray run -test` (the split config parses with both TLS legs when translated; the conflict reproduces xray's exact load error).
- `vmess://` is intentionally out of scope — the v2 JSON share format has no field for mode/extra, so v2rayN can't round-trip them either. A manually edited VMess+xhttp entry still gets both fields in its config since `BuildStreamSettings` is protocol-agnostic.
- Dialog headers are literal English ("XHTTP Mode", "XHTTP Extra (JSON)") per the documented technical-field convention (same as SNI / Flow (VLESS) / Finalmask (JSON)); no `.resw` entries added.
- No new `AppJsonSerializerContext` registrations needed — `ServerEntry` is already registered whole; old `servers.json` files deserialize with empty defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
