### PR TITLE
Add unit tests for the parser layer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    name: unit tests
+    runs-on: windows-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # Plain net10.0 project (no WinUI/XAML): parser + serialization logic only.
+      - name: Run unit tests
+        run: dotnet test XrayUI.Tests/XrayUI.Tests.csproj -c Release
+
   build-x64:
     name: publish win-x64 (AOT)
     runs-on: windows-latest

--- a/XrayUI-dev.csproj
+++ b/XrayUI-dev.csproj
@@ -42,6 +42,16 @@
     <ApplicationDefinition Remove="updater-rs\**" />
   </ItemGroup>
 
+  <!-- The unit test project (XrayUI.Tests) nests inside this project's root;
+       keep its sources out of the app's default globs the same way updater-rs is. -->
+  <ItemGroup>
+    <Compile Remove="XrayUI.Tests\**" />
+    <Content Remove="XrayUI.Tests\**" />
+    <None Remove="XrayUI.Tests\**" />
+    <Page Remove="XrayUI.Tests\**" />
+    <ApplicationDefinition Remove="XrayUI.Tests\**" />
+  </ItemGroup>
+
   <ItemGroup>
     <!-- Default engine binaries (x64). Used for empty RID (`dotnet build` / BuildAndRun.ps1)
          and explicit -r win-x64 publishes. Explicit form avoids silently matching

--- a/XrayUI-dev.slnx
+++ b/XrayUI-dev.slnx
@@ -10,4 +10,9 @@
     <Platform Solution="*|x86" Project="x86" />
     <Deploy />
   </Project>
+  <Project Path="XrayUI.Tests/XrayUI.Tests.csproj">
+    <Platform Solution="*|ARM64" Project="AnyCPU" />
+    <Platform Solution="*|x64" Project="AnyCPU" />
+    <Platform Solution="*|x86" Project="AnyCPU" />
+  </Project>
 </Solution>

--- a/XrayUI.Tests/ClashConfigParserTests.cs
+++ b/XrayUI.Tests/ClashConfigParserTests.cs
@@ -1,0 +1,232 @@
+using XrayUI.Services;
+
+namespace XrayUI.Tests
+{
+    public class ClashConfigParserTests
+    {
+        [Fact]
+        public void Parse_NoProxiesSection_ReturnsEmptyResult()
+        {
+            var result = ClashConfigParser.Parse("port: 7890\nmode: rule\n");
+
+            Assert.Empty(result.Nodes);
+            Assert.Equal(0, result.Skipped);
+        }
+
+        [Fact]
+        public void Parse_SupportedAndUnsupportedTypes_MapsAndCountsSkipped()
+        {
+            var yaml = """
+                proxies:
+                  - { name: "SS-1", type: ss, server: ss.example.com, port: 8388, cipher: aes-256-gcm, password: pw1 }
+                  - { name: "Snell-1", type: snell, server: sn.example.com, port: 44046, psk: xxx }
+                  - { name: "Tuic-1", type: tuic, server: tu.example.com, port: 443 }
+                rules:
+                  - MATCH,DIRECT
+                """;
+
+            var result = ClashConfigParser.Parse(yaml);
+
+            var node = Assert.Single(result.Nodes);
+            Assert.Equal(2, result.Skipped);
+            Assert.Equal("SS-1", node.Name);
+            Assert.Equal("ss", node.Protocol);
+            Assert.Equal("ss.example.com", node.Host);
+            Assert.Equal(8388, node.Port);
+            Assert.Equal("aes-256-gcm", node.Encryption);
+            Assert.Equal("pw1", node.Password);
+        }
+
+        [Fact]
+        public void Parse_SsWithPlugin_IsSkipped()
+        {
+            var yaml = """
+                proxies:
+                  - name: obfs-node
+                    type: ss
+                    server: ss.example.com
+                    port: 8388
+                    cipher: aes-256-gcm
+                    password: pw
+                    plugin: obfs
+                    plugin-opts: { mode: tls }
+                """;
+
+            var result = ClashConfigParser.Parse(yaml);
+
+            Assert.Empty(result.Nodes);
+            Assert.Equal(1, result.Skipped);
+        }
+
+        [Fact]
+        public void Parse_VmessWs_MapsTransportFromWsOpts()
+        {
+            var yaml = """
+                proxies:
+                  - name: vm-ws
+                    type: vmess
+                    server: vm.example.com
+                    port: 443
+                    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+                    alterId: 0
+                    cipher: auto
+                    tls: true
+                    servername: sni.example.com
+                    skip-cert-verify: true
+                    network: ws
+                    ws-opts:
+                      path: /ws
+                      headers:
+                        Host: cdn.example.com
+                """;
+
+            var node = Assert.Single(ClashConfigParser.Parse(yaml).Nodes);
+
+            Assert.Equal("vmess", node.Protocol);
+            Assert.Equal("ws", node.Network);
+            Assert.Equal("/ws", node.Path);
+            Assert.Equal("cdn.example.com", node.WsHost);
+            Assert.Equal("tls", node.Security);
+            Assert.Equal("sni.example.com", node.Sni);
+            Assert.True(node.AllowInsecure);
+            Assert.Equal("TLS", node.Encryption);
+        }
+
+        [Fact]
+        public void Parse_VmessUnsupportedNetwork_IsSkipped()
+        {
+            var yaml = """
+                proxies:
+                  - { name: vm-h2, type: vmess, server: h.example.com, port: 443, uuid: u, network: h2 }
+                """;
+
+            var result = ClashConfigParser.Parse(yaml);
+
+            Assert.Empty(result.Nodes);
+            Assert.Equal(1, result.Skipped);
+        }
+
+        [Fact]
+        public void Parse_VlessReality_MapsRealityOpts()
+        {
+            var yaml = """
+                proxies:
+                  - name: vl-reality
+                    type: vless
+                    server: r.example.com
+                    port: 443
+                    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+                    network: tcp
+                    tls: true
+                    servername: www.apple.com
+                    client-fingerprint: chrome
+                    flow: xtls-rprx-vision
+                    reality-opts:
+                      public-key: PBK123
+                      short-id: 6ba85179
+                """;
+
+            var node = Assert.Single(ClashConfigParser.Parse(yaml).Nodes);
+
+            Assert.Equal("reality", node.Security);
+            Assert.Equal("PBK123", node.PublicKey);
+            Assert.Equal("6ba85179", node.ShortId);
+            Assert.Equal("chrome", node.Fingerprint);
+            Assert.Equal("xtls-rprx-vision", node.Flow);
+            Assert.Equal("Reality", node.Encryption);
+        }
+
+        [Fact]
+        public void Parse_TrojanGrpc_ServiceNameLandsOnPath()
+        {
+            var yaml = """
+                proxies:
+                  - name: tj-grpc
+                    type: trojan
+                    server: t.example.com
+                    port: 443
+                    password: pw
+                    network: grpc
+                    sni: t.example.com
+                    grpc-opts:
+                      grpc-service-name: svc
+                """;
+
+            var node = Assert.Single(ClashConfigParser.Parse(yaml).Nodes);
+
+            Assert.Equal("trojan", node.Protocol);
+            Assert.Equal("grpc", node.Network);
+            Assert.Equal("svc", node.Path);
+        }
+
+        [Fact]
+        public void Parse_Hysteria2Salamander_BuildsFinalmask()
+        {
+            var yaml = """
+                proxies:
+                  - name: hy2
+                    type: hysteria2
+                    server: hy2.example.com
+                    port: 443
+                    password: pw
+                    obfs: salamander
+                    obfs-password: ob123
+                    sni: hy2.example.com
+                """;
+
+            var node = Assert.Single(ClashConfigParser.Parse(yaml).Nodes);
+
+            Assert.Equal("hysteria2", node.Protocol);
+            Assert.Contains("salamander", node.Finalmask);
+            Assert.Contains("ob123", node.Finalmask);
+        }
+
+        [Fact]
+        public void Parse_WireguardSinglePeer_BuildsCidrLocalAddress()
+        {
+            var yaml = """
+                proxies:
+                  - name: wg
+                    type: wireguard
+                    server: wg.example.com
+                    port: 51820
+                    private-key: PRIV
+                    public-key: PUB
+                    ip: 172.16.0.2
+                    ipv6: fd00::2
+                    reserved: [1, 2, 3]
+                    mtu: 1280
+                """;
+
+            var node = Assert.Single(ClashConfigParser.Parse(yaml).Nodes);
+
+            Assert.Equal("wireguard", node.Protocol);
+            Assert.Equal("PRIV", node.WgPrivateKey);
+            Assert.Equal("PUB", node.WgPublicKey);
+            Assert.Equal("172.16.0.2/32,fd00::2/128", node.WgLocalAddress);
+            Assert.Equal("1,2,3", node.WgReserved);
+            Assert.Equal(1280, node.WgMtu);
+        }
+
+        [Fact]
+        public void Parse_MissingHostOrPort_IsSkipped()
+        {
+            var yaml = """
+                proxies:
+                  - { name: no-port, type: ss, server: ss.example.com, cipher: aes-256-gcm, password: pw }
+                  - { name: no-host, type: ss, port: 8388, cipher: aes-256-gcm, password: pw }
+                """;
+
+            var result = ClashConfigParser.Parse(yaml);
+
+            Assert.Empty(result.Nodes);
+            Assert.Equal(2, result.Skipped);
+        }
+
+        [Fact]
+        public void Parse_InvalidYaml_Throws()
+        {
+            Assert.ThrowsAny<Exception>(() => ClashConfigParser.Parse("proxies:\n  - {unclosed"));
+        }
+    }
+}

--- a/XrayUI.Tests/CustomRuleValueParserTests.cs
+++ b/XrayUI.Tests/CustomRuleValueParserTests.cs
@@ -1,0 +1,50 @@
+using XrayUI.Services;
+
+namespace XrayUI.Tests
+{
+    public class CustomRuleValueParserTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   \r\n  \n ")]
+        public void Parse_EmptyInput_ReturnsEmptyList(string? text)
+        {
+            Assert.Empty(CustomRuleValueParser.Parse(text));
+        }
+
+        [Fact]
+        public void Parse_SplitsOnLineBreaksOnly_CommasStayInsideValues()
+        {
+            var values = CustomRuleValueParser.Parse("domain:a.com,b.com\ngeosite:cn");
+
+            Assert.Equal(["domain:a.com,b.com", "geosite:cn"], values);
+        }
+
+        [Fact]
+        public void Parse_TrimsWhitespaceAndSkipsBlankLines()
+        {
+            var values = CustomRuleValueParser.Parse("  a.com  \r\n\r\n\tb.com\t\n");
+
+            Assert.Equal(["a.com", "b.com"], values);
+        }
+
+        [Fact]
+        public void Parse_DeduplicatesCaseInsensitively_KeepsFirstCasing()
+        {
+            var values = CustomRuleValueParser.Parse("Example.com\nexample.com\nEXAMPLE.COM\nother.net");
+
+            Assert.Equal(["Example.com", "other.net"], values);
+        }
+
+        [Fact]
+        public void Parse_PreservesRegexpAndWindowsPathCharacters()
+        {
+            var values = CustomRuleValueParser.Parse("regexp:\\.goo.*\\.com$;keep\nC:\\Program Files\\app.exe");
+
+            Assert.Equal(2, values.Count);
+            Assert.Equal(@"regexp:\.goo.*\.com$;keep", values[0]);
+            Assert.Equal(@"C:\Program Files\app.exe", values[1]);
+        }
+    }
+}

--- a/XrayUI.Tests/GlobalUsings.cs
+++ b/XrayUI.Tests/GlobalUsings.cs
@@ -1,0 +1,4 @@
+// Mirrors the app's Imports.cs for the linked production sources
+// (ServerEntry uses ObservableObject/[ObservableProperty] unqualified).
+global using CommunityToolkit.Mvvm.ComponentModel;
+global using Xunit;

--- a/XrayUI.Tests/LocalizationStubs.cs
+++ b/XrayUI.Tests/LocalizationStubs.cs
@@ -1,0 +1,17 @@
+namespace XrayUI.Helpers
+{
+    // Test-side stand-ins for the WinAppSDK ResourceLoader-backed localization
+    // facade (Helpers/L.cs, Helpers/Loc.cs). Only the members that linked
+    // production sources actually touch are stubbed; add members here when a
+    // newly linked file references more of L.*.
+    public static class L
+    {
+        public static string ServerDetail_Timeout => "Timeout";
+    }
+
+    public static class Loc
+    {
+        public static string Format(string key, params object?[] args) =>
+            $"{key}({string.Join(",", args)})";
+    }
+}

--- a/XrayUI.Tests/NodeLinkParserTests.cs
+++ b/XrayUI.Tests/NodeLinkParserTests.cs
@@ -1,0 +1,246 @@
+using System.Text;
+using XrayUI.Services;
+
+namespace XrayUI.Tests
+{
+    public class NodeLinkParserTests
+    {
+        private static string B64(string s) => Convert.ToBase64String(Encoding.UTF8.GetBytes(s));
+
+        // ── invalid input ─────────────────────────────────────────────────────
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("http://example.com")]
+        [InlineData("socks5://user:pass@example.com:1080")]
+        [InlineData("vmess://!!!not-base64!!!")]
+        [InlineData("ss://ZZZZ")]
+        public void Parse_InvalidOrUnsupportedInput_ReturnsNull(string? link)
+        {
+            Assert.Null(NodeLinkParser.Parse(link!));
+        }
+
+        // ── Shadowsocks ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void Parse_SsSip002_ExtractsAllFields()
+        {
+            var link = $"ss://{B64("aes-256-gcm:p@ss:w0rd")}@example.com:8388#My%20Node";
+
+            var s = NodeLinkParser.Parse(link);
+
+            Assert.NotNull(s);
+            Assert.Equal("ss", s.Protocol);
+            Assert.Equal("aes-256-gcm", s.Encryption);
+            // Only the FIRST colon separates method from password.
+            Assert.Equal("p@ss:w0rd", s.Password);
+            Assert.Equal("example.com", s.Host);
+            Assert.Equal(8388, s.Port);
+            Assert.Equal("My Node", s.Name);
+            Assert.Equal("tcp", s.Network);
+        }
+
+        [Fact]
+        public void Parse_SsLegacyWholeBase64_ExtractsAllFields()
+        {
+            var link = $"ss://{B64("aes-128-gcm:secret@10.0.0.1:443")}#Legacy";
+
+            var s = NodeLinkParser.Parse(link);
+
+            Assert.NotNull(s);
+            Assert.Equal("aes-128-gcm", s.Encryption);
+            Assert.Equal("secret", s.Password);
+            Assert.Equal("10.0.0.1", s.Host);
+            Assert.Equal(443, s.Port);
+            Assert.Equal("Legacy", s.Name);
+        }
+
+        [Fact]
+        public void Parse_SsRawPercentEncodedUserinfo_Ss2022KeySurvives()
+        {
+            // SS2022 keys carry '+' '/' '=' which generators percent-encode instead of base64-wrapping.
+            var key = "8JmyO+3Sm2b1/2rDDDF8Tw==";
+            var link = $"ss://{Uri.EscapeDataString($"2022-blake3-aes-256-gcm:{key}")}@example.com:8388#SS2022";
+
+            var s = NodeLinkParser.Parse(link);
+
+            Assert.NotNull(s);
+            Assert.Equal("2022-blake3-aes-256-gcm", s.Encryption);
+            Assert.Equal(key, s.Password);
+        }
+
+        [Fact]
+        public void Parse_SsWithSip003Plugin_ReturnsNull()
+        {
+            // xray-core has no SIP003 outbound; importing would save an unconnectable node.
+            var link = $"ss://{B64("aes-256-gcm:pw")}@example.com:8388?plugin=v2ray-plugin%3Btls#X";
+
+            Assert.Null(NodeLinkParser.Parse(link));
+        }
+
+        // ── VMess ─────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Parse_VmessWsTls_ExtractsAllFields()
+        {
+            var json = """
+                {"v":"2","ps":"VM Node","add":"vm.example.com","port":"443",
+                 "id":"b831381d-6324-4d53-ad4f-8cda48b30811","aid":"0","net":"ws","type":"none",
+                 "host":"cdn.example.com","path":"/ws","tls":"tls","sni":"sni.example.com","fp":"chrome"}
+                """;
+
+            var s = NodeLinkParser.Parse($"vmess://{B64(json)}");
+
+            Assert.NotNull(s);
+            Assert.Equal("vmess", s.Protocol);
+            Assert.Equal("VM Node", s.Name);
+            Assert.Equal("vm.example.com", s.Host);
+            Assert.Equal(443, s.Port);
+            Assert.Equal("b831381d-6324-4d53-ad4f-8cda48b30811", s.Uuid);
+            Assert.Equal(0, s.AlterId);
+            Assert.Equal("ws", s.Network);
+            Assert.Equal("/ws", s.Path);
+            Assert.Equal("cdn.example.com", s.WsHost);
+            Assert.Equal("tls", s.Security);
+            Assert.Equal("sni.example.com", s.Sni);
+            Assert.Equal("chrome", s.Fingerprint);
+            Assert.Equal("TLS", s.Encryption);
+        }
+
+        [Fact]
+        public void Parse_VmessNumericPortAndAid_AreAccepted()
+        {
+            // Some generators emit port/aid as JSON numbers instead of strings.
+            var json = """{"v":"2","ps":"n","add":"h.example.com","port":8443,"id":"u","aid":2,"net":"tcp","tls":""}""";
+
+            var s = NodeLinkParser.Parse($"vmess://{B64(json)}");
+
+            Assert.NotNull(s);
+            Assert.Equal(8443, s.Port);
+            Assert.Equal(2, s.AlterId);
+            Assert.Equal("none", s.Security);
+            Assert.Equal("None", s.Encryption);
+        }
+
+        // ── VLESS ─────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Parse_VlessRealityVision_ExtractsAllFields()
+        {
+            var link = "vless://b831381d-6324-4d53-ad4f-8cda48b30811@example.com:443" +
+                       "?type=tcp&security=reality&sni=www.apple.com&fp=chrome" +
+                       "&pbk=PBK123&sid=6ba85179&spx=%2F&flow=xtls-rprx-vision&encryption=none#Reality%20Node";
+
+            var s = NodeLinkParser.Parse(link);
+
+            Assert.NotNull(s);
+            Assert.Equal("vless", s.Protocol);
+            Assert.Equal("b831381d-6324-4d53-ad4f-8cda48b30811", s.Uuid);
+            Assert.Equal("example.com", s.Host);
+            Assert.Equal(443, s.Port);
+            Assert.Equal("reality", s.Security);
+            Assert.Equal("www.apple.com", s.Sni);
+            Assert.Equal("chrome", s.Fingerprint);
+            Assert.Equal("PBK123", s.PublicKey);
+            Assert.Equal("6ba85179", s.ShortId);
+            Assert.Equal("/", s.SpiderX);
+            Assert.Equal("xtls-rprx-vision", s.Flow);
+            // "encryption=none" maps to empty (the field stores only non-default values).
+            Assert.Equal(string.Empty, s.VlessEncryption);
+            Assert.Equal("Reality Node", s.Name);
+            Assert.Equal("Reality", s.Encryption);
+        }
+
+        [Fact]
+        public void Parse_VlessXhttp_KeepsModeAndExtra()
+        {
+            // Regression guard: dropping mode/extra produces a node that connects in
+            // v2rayN but times out here (stream-one + xPadding obfuscation needs both).
+            var extra = Uri.EscapeDataString("""{"xPaddingBytes":"100-1000"}""");
+            var link = "vless://u-u-i-d@example.com:8443" +
+                       $"?type=xhttp&security=tls&sni=x.example.com&path=%2Fxh&mode=stream-one&extra={extra}#XH";
+
+            var s = NodeLinkParser.Parse(link);
+
+            Assert.NotNull(s);
+            Assert.Equal("xhttp", s.Network);
+            Assert.Equal("stream-one", s.XhttpMode);
+            Assert.Contains("xPaddingBytes", s.XhttpExtra);
+            Assert.Equal("/xh", s.Path);
+        }
+
+        [Fact]
+        public void Parse_VlessGrpc_ModeParamIsNotMisreadAsXhttpMode()
+        {
+            // grpc links reuse "mode" for gun/multi — it must not leak into XhttpMode.
+            var link = "vless://u-u-i-d@example.com:443?type=grpc&security=tls&serviceName=svc&mode=gun#G";
+
+            var s = NodeLinkParser.Parse(link);
+
+            Assert.NotNull(s);
+            Assert.Equal("grpc", s.Network);
+            Assert.Equal(string.Empty, s.XhttpMode);
+            Assert.Equal("svc", s.Path);
+        }
+
+        // ── Hysteria2 ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Parse_Hysteria2WithSalamanderObfs_BuildsFinalmask()
+        {
+            var link = "hysteria2://pw123@hy2.example.com:443" +
+                       "?sni=hy2.example.com&insecure=1&obfs=salamander&obfs-password=ob123#H2";
+
+            var s = NodeLinkParser.Parse(link);
+
+            Assert.NotNull(s);
+            Assert.Equal("hysteria2", s.Protocol);
+            Assert.Equal("pw123", s.Password);
+            Assert.Equal("hy2.example.com", s.Sni);
+            Assert.True(s.AllowInsecure);
+            Assert.Equal("udp", s.Network);
+            Assert.Equal("tls", s.Security);
+            Assert.Contains("salamander", s.Finalmask);
+            Assert.Contains("ob123", s.Finalmask);
+        }
+
+        // ── Trojan ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Parse_TrojanWs_ExtractsAllFields()
+        {
+            var link = "trojan://trojanpw@t.example.com:8443" +
+                       "?sni=t.example.com&type=ws&path=%2Fws&host=cdn.t.example.com&fp=firefox#TJ";
+
+            var s = NodeLinkParser.Parse(link);
+
+            Assert.NotNull(s);
+            Assert.Equal("trojan", s.Protocol);
+            Assert.Equal("trojanpw", s.Password);
+            Assert.Equal("t.example.com", s.Host);
+            Assert.Equal(8443, s.Port);
+            Assert.Equal("ws", s.Network);
+            Assert.Equal("/ws", s.Path);
+            Assert.Equal("cdn.t.example.com", s.WsHost);
+            Assert.Equal("tls", s.Security);
+            Assert.Equal("firefox", s.Fingerprint);
+        }
+
+        [Fact]
+        public void Parse_TrojanWithoutPort_DefaultsTo443()
+        {
+            var s = NodeLinkParser.Parse("trojan://pw@t.example.com#T");
+
+            Assert.NotNull(s);
+            Assert.Equal(443, s.Port);
+        }
+
+        [Fact]
+        public void Parse_TrojanEmptyPassword_ReturnsNull()
+        {
+            Assert.Null(NodeLinkParser.Parse("trojan://@t.example.com:443#T"));
+        }
+    }
+}

--- a/XrayUI.Tests/NodeLinkRoundTripTests.cs
+++ b/XrayUI.Tests/NodeLinkRoundTripTests.cs
@@ -1,0 +1,150 @@
+using System.Reflection;
+using System.Text;
+using System.Text.Json.Serialization;
+using XrayUI.Models;
+using XrayUI.Services;
+
+namespace XrayUI.Tests
+{
+    /// <summary>
+    /// Parse → ToLink → Parse must be lossless for every persisted connection-config
+    /// field. NodeLinkSerializer documents itself as the exact inverse of
+    /// NodeLinkParser; these tests hold both to that contract.
+    /// </summary>
+    public class NodeLinkRoundTripTests
+    {
+        private static string B64(string s) => Convert.ToBase64String(Encoding.UTF8.GetBytes(s));
+
+        private static void RoundTrip(string link)
+        {
+            var first = NodeLinkParser.Parse(link);
+            Assert.NotNull(first);
+
+            var relink = NodeLinkSerializer.ToLink(first);
+            Assert.NotNull(relink);
+
+            var second = NodeLinkParser.Parse(relink);
+            Assert.NotNull(second);
+
+            AssertConfigEqual(first, second);
+        }
+
+        // Properties that are persisted but are identity/bookkeeping, not
+        // connection config carried by a share link. Anything listed here is a
+        // deliberate, visible exclusion from the round-trip invariant.
+        private static readonly string[] ExcludedProperties =
+        [
+            nameof(ServerEntry.Id) // regenerated per instance on parse
+        ];
+
+        // Compares every writable, non-[JsonIgnore] property, so a future
+        // persisted field is covered automatically the day it is added — if it
+        // must not round-trip, it has to be excluded loudly above. Reflection
+        // is fine here: the test project is not AOT-compiled.
+        private static void AssertConfigEqual(ServerEntry a, ServerEntry b)
+        {
+            var mismatches = new List<string>();
+            foreach (var p in typeof(ServerEntry).GetProperties())
+            {
+                if (!p.CanWrite || ExcludedProperties.Contains(p.Name)) continue;
+                if (p.GetCustomAttribute<JsonIgnoreAttribute>() is not null) continue;
+
+                var va = p.GetValue(a);
+                var vb = p.GetValue(b);
+                if (!Equals(va, vb))
+                    mismatches.Add($"{p.Name}: \"{va}\" != \"{vb}\"");
+            }
+
+            Assert.True(mismatches.Count == 0,
+                "Round-trip lost fields:\n" + string.Join("\n", mismatches));
+        }
+
+        [Fact]
+        public void RoundTrip_Ss()
+        {
+            RoundTrip($"ss://{B64("aes-256-gcm:p@ss:w0rd/=+")}@example.com:8388#SS%20%E8%8A%82%E7%82%B9");
+        }
+
+        [Fact]
+        public void RoundTrip_VmessWsTlsInsecure()
+        {
+            var json = """
+                {"v":"2","ps":"VM 节点","add":"vm.example.com","port":"443",
+                 "id":"b831381d-6324-4d53-ad4f-8cda48b30811","aid":"1","net":"ws","type":"none",
+                 "host":"cdn.example.com","path":"/ws?ed=2048","tls":"tls","sni":"sni.example.com",
+                 "fp":"chrome","allowInsecure":"1"}
+                """;
+            RoundTrip($"vmess://{B64(json)}");
+        }
+
+        [Fact]
+        public void RoundTrip_VlessRealityVision()
+        {
+            RoundTrip("vless://b831381d-6324-4d53-ad4f-8cda48b30811@example.com:443" +
+                      "?type=tcp&security=reality&sni=www.apple.com&fp=chrome" +
+                      "&pbk=PBK123&sid=6ba85179&spx=%2Fspider&flow=xtls-rprx-vision&encryption=none#Reality");
+        }
+
+        [Fact]
+        public void RoundTrip_VlessXhttpModeAndExtra()
+        {
+            // The dogegg-style stream-one + xPadding combo: losing mode/extra on
+            // round-trip is exactly the historical import-timeout bug.
+            var extra = Uri.EscapeDataString("""{"xPaddingBytes":"100-1000","xmux":{"maxConcurrency":16}}""");
+            RoundTrip("vless://u-u-i-d@example.com:8443" +
+                      $"?type=xhttp&security=tls&sni=x.example.com&path=%2Fxh&host=h.example.com&mode=stream-one&extra={extra}#XHTTP");
+        }
+
+        [Fact]
+        public void RoundTrip_VlessPostQuantumEncryption()
+        {
+            RoundTrip("vless://u-u-i-d@example.com:443" +
+                      "?type=tcp&security=tls&sni=example.com&encryption=mlkem768x25519plus.native.0rtt.abc#PQ");
+        }
+
+        [Fact]
+        public void RoundTrip_VlessTlsWithEch()
+        {
+            // Only fixture exercising EchConfigList/EchForceQuery — without it the
+            // round-trip guard compares default-vs-default and the serializer's
+            // ECH emit logic could be deleted without any test noticing.
+            var ech = Uri.EscapeDataString("AEX+DQBBzQAgACBSvVUkExampleConfigList=");
+            RoundTrip("vless://u-u-i-d@example.com:443" +
+                      $"?type=tcp&security=tls&sni=example.com&encryption=none&echConfigList={ech}&echForceQuery=half#ECH");
+        }
+
+        [Fact]
+        public void RoundTrip_Hysteria2WithSalamanderObfs()
+        {
+            RoundTrip("hysteria2://pw123@hy2.example.com:443" +
+                      "?sni=hy2.example.com&insecure=1&obfs=salamander&obfs-password=ob123#H2");
+        }
+
+        [Fact]
+        public void RoundTrip_TrojanGrpc()
+        {
+            RoundTrip("trojan://pw@t.example.com:443?type=grpc&sni=t.example.com&serviceName=svc#TG");
+        }
+
+        [Fact]
+        public void RoundTrip_TrojanWs()
+        {
+            RoundTrip("trojan://p%40w@t.example.com:8443" +
+                      "?type=ws&sni=t.example.com&path=%2Fws&host=cdn.t.example.com&allowInsecure=1#TW");
+        }
+
+        [Fact]
+        public void RoundTrip_Ipv6Host()
+        {
+            RoundTrip("vless://u-u-i-d@[2001:db8::1]:443?type=tcp&security=none&encryption=none#V6");
+        }
+
+        [Fact]
+        public void ToLink_UnsupportedProtocols_ReturnNull()
+        {
+            Assert.Null(NodeLinkSerializer.ToLink(new ServerEntry { Protocol = "wireguard", Host = "h", Port = 1 }));
+            Assert.Null(NodeLinkSerializer.ToLink(new ServerEntry { Protocol = "chain", Host = "h", Port = 1 }));
+            Assert.Null(NodeLinkSerializer.ToLink(new ServerEntry { Protocol = "socks", Host = "h", Port = 1 }));
+        }
+    }
+}

--- a/XrayUI.Tests/SerializerContextStub.cs
+++ b/XrayUI.Tests/SerializerContextStub.cs
@@ -1,0 +1,21 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace XrayUI.Services
+{
+    // Test-side stand-in for the app's source-generated AppJsonSerializerContext.
+    // Linked production sources (FinalmaskJson) only touch WriteReadable, and only
+    // for JsonNode.ToJsonString — which reads writer settings, never the type
+    // resolver. Options must stay byte-for-byte equivalent to the real ones
+    // (WriteIndented + relaxed escaping) or round-trip string assertions drift.
+    internal static class AppJsonSerializerContext
+    {
+        public static JsonSerializerOptions WriteReadable { get; } = new()
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
+    }
+}

--- a/XrayUI.Tests/XrayUI.Tests.csproj
+++ b/XrayUI.Tests/XrayUI.Tests.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Plain net10.0 (no -windows TFM, no WinUI): the tested sources are pure
+         parsing/serialization logic. Linking them here instead of referencing
+         the app project keeps the test build free of XAML compile, CsWinRT
+         projection, and the Windows App SDK runtime. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Keep versions in lockstep with XrayUI-dev.csproj so linked sources
+         compile against the same API surface the app ships with. -->
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="YamlDotNet" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Production sources under test, compiled in directly. If a linked file
+         gains a dependency on WinUI/WinAppSDK types, this project stops
+         building — that is the signal to either stub the dependency (see
+         LocalizationStubs.cs) or keep the new dependency out of parser-layer
+         code. -->
+    <Compile Include="..\Models\ServerEntry.cs" Link="Prod\Models\ServerEntry.cs" />
+    <Compile Include="..\Services\NodeLinkParser.cs" Link="Prod\Services\NodeLinkParser.cs" />
+    <Compile Include="..\Services\NodeLinkSerializer.cs" Link="Prod\Services\NodeLinkSerializer.cs" />
+    <Compile Include="..\Services\ClashConfigParser.cs" Link="Prod\Services\ClashConfigParser.cs" />
+    <Compile Include="..\Services\CustomRuleValueParser.cs" Link="Prod\Services\CustomRuleValueParser.cs" />
+    <Compile Include="..\Services\XhttpSettings.cs" Link="Prod\Services\XhttpSettings.cs" />
+    <Compile Include="..\Services\EchSettings.cs" Link="Prod\Services\EchSettings.cs" />
+    <Compile Include="..\Services\FinalmaskJson.cs" Link="Prod\Services\FinalmaskJson.cs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Adds `XrayUI.Tests`, a plain `net10.0` xunit project covering `NodeLinkParser`, `NodeLinkSerializer`, `ClashConfigParser`, and `CustomRuleValueParser` — the only parts of the codebase with zero test coverage despite carrying the most user-visible risk (a dropped field produces a config that looks valid but silently fails to connect; see the VLESS-XHTTP mode/extra bug).
- Source-links the pure-logic production files instead of referencing the WinUI app project, so the test build never touches XAML compile or CsWinRT. WinAppSDK-backed dependencies (`L`/`Loc`, `AppJsonSerializerContext.WriteReadable`) are stubbed test-side.
- 49 tests: per-protocol link parsing, Parse → ToLink → Parse round-trip equality (via reflection over `ServerEntry`'s public properties, so a newly persisted field is covered automatically without editing the test), Clash YAML import, and custom-rule value parsing.
- Wires a new `test` job into `build.yml`, running in parallel with the existing AOT publish job.

Scope is deliberately parser-layer only. Config-builder shape tests and `xray.exe run -test` smoke tests were prototyped and dropped as more complexity than wanted for this repo.

## Test plan
- [x] `dotnet test XrayUI.Tests/XrayUI.Tests.csproj -c Release` — 49/49 passing locally
- [x] `.\BuildAndRun.ps1 -SkipRun` — confirms the new `XrayUI.Tests\**` glob exclusion doesn't affect the main app build
- [x] `dotnet sln XrayUI-dev.slnx list` — confirms the test project is registered correctly
- [x] CI `test` job (will run on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)