### PR TITLE
support Xray log level and dnsLog setting

### DIFF
--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -197,7 +197,9 @@ public static class L
     public static string Log_PrivacySaved  => Loc.GetString("Log_PrivacySaved");
     public static string Log_IpMask        => Loc.GetString("Log_IpMask");
     public static string Log_MaskOff       => Loc.GetString("Log_MaskOff");
-    public static string Log_Verbose       => Loc.GetString("Log_Verbose");
+    public static string Log_Level         => Loc.GetString("Log_Level");
+    public static string Log_DnsLog        => Loc.GetString("Log_DnsLog");
+    public static string Log_DnsLogOn      => Loc.GetString("Log_DnsLogOn");
     public static string Log_AutoScroll    => Loc.GetString("Log_AutoScroll");
     public static string Log_CopyAll       => Loc.GetString("Log_CopyAll");
     public static string Log_Clear         => Loc.GetString("Log_Clear");

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -36,10 +36,18 @@ namespace XrayUI.Models
         public string? LastSelectedServerId { get; set; }
         /// <summary>"" | "quarter" | "half" | "full"; controls Xray log IP masking.</summary>
         public string LogMaskAddress { get; set; } = string.Empty;
-        /// <summary>Verbose xray error log: true = loglevel "info" (per-connection sniffing/routing/
-        /// transport detail), false (default) = "warning". Independent of the access log, which
-        /// always prints one [inbound -> outbound] verdict line per connection.</summary>
+        /// <summary>Legacy verbose toggle (true → "info", false → "warning"). SettingsService
+        /// migrates this into <see cref="XrayLogLevel"/> on load; not read anywhere else.</summary>
         public bool VerboseXrayLog { get; set; } = false;
+        /// <summary>"debug" | "info" | "warning". Populated from the legacy
+        /// <see cref="VerboseXrayLog"/> bool by SettingsService.LoadSettingsAsync if unset, so
+        /// other readers can treat null as "not yet migrated" rather than re-deriving the
+        /// fallback themselves. See <see cref="XrayUI.Services.XrayLogLevel"/>. Independent of
+        /// the access log, which always prints one [inbound -> outbound] verdict line per
+        /// connection.</summary>
+        public string? XrayLogLevel { get; set; }
+        /// <summary>Enable Xray's per-query DNS resolution log (log.dnsLog).</summary>
+        public bool DnsLog { get; set; } = false;
 
         // ── Internationalization ──────────────────────────────────────────────
         /// <summary>BCP-47 tag from <see cref="XrayUI.Helpers.LanguageHelper.SupportedLanguages"/>, or null to follow system.</summary>

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -68,6 +68,11 @@ namespace XrayUI.Services
 
                 var json = await File.ReadAllTextAsync(SettingsFile).ConfigureAwait(false);
                 _cachedSettings = JsonSerializer.Deserialize(json, AppJsonSerializerContext.Default.AppSettings) ?? new AppSettings();
+
+                // One-time migration: settings.json written before XrayLogLevel existed only has
+                // the legacy VerboseXrayLog bool. Populate the new field so every other reader
+                // can trust it's non-null instead of re-deriving the fallback on every read.
+                _cachedSettings.XrayLogLevel ??= _cachedSettings.VerboseXrayLog ? XrayLogLevel.Info : XrayLogLevel.Warning;
                 return _cachedSettings;
             }
             catch (Exception ex)

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -14,11 +14,6 @@ namespace XrayUI.Services
     /// </summary>
     public static class XrayConfigBuilder
     {
-        // Both must stay at debug/info/warning: XrayReadySignal detects core readiness via the
-        // Warning-level "core: Xray x.y.z started" log line, which "error"/"none" would
-        // suppress — degrading every connect/switch/reapply to the 3s timeout fallback.
-        private const string DefaultLogLevel = "warning";
-        private const string VerboseLogLevel = "info";
         private const string ProxyOutboundTag = "proxy";
         private const string DirectOutboundTag = "direct";
         private const string BlockOutboundTag = "block";
@@ -73,12 +68,17 @@ namespace XrayUI.Services
                 // loglevel governs the error log only. The access log ("access" unset = stdout)
                 // keeps printing one [inbound -> outbound] verdict line per connection either way,
                 // so proxy/direct visibility survives the quiet default.
-                ["loglevel"] = settings.VerboseXrayLog ? VerboseLogLevel : DefaultLogLevel
+                ["loglevel"] = XrayLogLevel.Normalize(settings.XrayLogLevel)
             };
 
             if (LogMaskAddress.IsEnabled(settings.LogMaskAddress))
             {
                 log["maskAddress"] = settings.LogMaskAddress;
+            }
+
+            if (settings.DnsLog)
+            {
+                log["dnsLog"] = true;
             }
 
             return log;

--- a/Services/XrayLogLevel.cs
+++ b/Services/XrayLogLevel.cs
@@ -1,0 +1,19 @@
+namespace XrayUI.Services
+{
+    /// <summary>
+    /// Canonical names + validation for Xray's <c>log.loglevel</c> setting. Restricted to
+    /// debug/info/warning: XrayReadySignal detects core startup via a Warning-level log line,
+    /// which "error"/"none" would suppress, degrading every connect/switch/reapply to the
+    /// 3s timeout fallback.
+    /// </summary>
+    internal static class XrayLogLevel
+    {
+        public const string Debug   = "debug";
+        public const string Info    = "info";
+        public const string Warning = "warning";
+
+        /// <summary>Returns the value if recognized, otherwise the default (Warning).</summary>
+        public static string Normalize(string? value) =>
+            value is Debug or Info or Warning ? value : Warning;
+    }
+}

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -332,8 +332,14 @@
   <data name="Log_MaskOff" xml:space="preserve">
     <value>Off</value>
   </data>
-  <data name="Log_Verbose" xml:space="preserve">
-    <value>Verbose logging</value>
+  <data name="Log_Level" xml:space="preserve">
+    <value>Log Level</value>
+  </data>
+  <data name="Log_DnsLog" xml:space="preserve">
+    <value>DNS Query Log</value>
+  </data>
+  <data name="Log_DnsLogOn" xml:space="preserve">
+    <value>On</value>
   </data>
   <data name="Log_AutoScroll" xml:space="preserve">
     <value>Auto Scroll</value>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -332,8 +332,14 @@
   <data name="Log_MaskOff" xml:space="preserve">
     <value>关闭</value>
   </data>
-  <data name="Log_Verbose" xml:space="preserve">
-    <value>详细日志</value>
+  <data name="Log_Level" xml:space="preserve">
+    <value>日志级别</value>
+  </data>
+  <data name="Log_DnsLog" xml:space="preserve">
+    <value>DNS 查询日志</value>
+  </data>
+  <data name="Log_DnsLogOn" xml:space="preserve">
+    <value>开启</value>
   </data>
   <data name="Log_AutoScroll" xml:space="preserve">
     <value>自动滚动</value>

--- a/Views/LogWindow.xaml
+++ b/Views/LogWindow.xaml
@@ -67,7 +67,7 @@
                                     <RadioMenuFlyoutItem x:Name="MaskOffMenuItem"
                                                          Text="关闭"
                                                          GroupName="LogMaskAddressGroup"
-                                                         Tag=""
+                                                         Tag="off"
                                                          Click="MaskAddressMenuItem_Click" />
                                     <RadioMenuFlyoutItem x:Name="MaskQuarterMenuItem"
                                                          Text="quarter"
@@ -85,8 +85,35 @@
                                                          Tag="full"
                                                          Click="MaskAddressMenuItem_Click" />
                                 </MenuFlyoutSubItem>
-                                <ToggleMenuFlyoutItem x:Name="VerboseLogMenuItem"
-                                                      Click="VerboseLogMenuItem_Click" />
+                                <MenuFlyoutSubItem x:Name="LogLevelSubMenu" Text="日志级别">
+                                    <RadioMenuFlyoutItem x:Name="LogLevelDebugMenuItem"
+                                                         Text="Debug"
+                                                         GroupName="LogLevelGroup"
+                                                         Tag="debug"
+                                                         Click="LogLevelMenuItem_Click" />
+                                    <RadioMenuFlyoutItem x:Name="LogLevelInfoMenuItem"
+                                                         Text="Info"
+                                                         GroupName="LogLevelGroup"
+                                                         Tag="info"
+                                                         Click="LogLevelMenuItem_Click" />
+                                    <RadioMenuFlyoutItem x:Name="LogLevelWarningMenuItem"
+                                                         Text="Warning"
+                                                         GroupName="LogLevelGroup"
+                                                         Tag="warning"
+                                                         Click="LogLevelMenuItem_Click" />
+                                </MenuFlyoutSubItem>
+                                <MenuFlyoutSubItem x:Name="DnsLogSubMenu" Text="DNS 查询日志">
+                                    <RadioMenuFlyoutItem x:Name="DnsLogOffMenuItem"
+                                                         Text="关闭"
+                                                         GroupName="DnsLogGroup"
+                                                         Tag="off"
+                                                         Click="DnsLogMenuItem_Click" />
+                                    <RadioMenuFlyoutItem x:Name="DnsLogOnMenuItem"
+                                                         Text="开启"
+                                                         GroupName="DnsLogGroup"
+                                                         Tag="on"
+                                                         Click="DnsLogMenuItem_Click" />
+                                </MenuFlyoutSubItem>
                             </MenuFlyout>
                         </Button.Flyout>
                     </Button>

--- a/Views/LogWindow.xaml.cs
+++ b/Views/LogWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Dispatching;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Media;
 using System;
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 using WinUIEx;
 using XrayUI.Helpers;
+using XrayUI.Models;
 using XrayUI.Services;
 
 namespace XrayUI.Views
@@ -52,7 +53,10 @@ namespace XrayUI.Views
 			ToolTipService.SetToolTip(LogPrivacyButton, L.Log_PrivacyTooltip);
             MaskAddressSubMenu.Text = L.Log_IpMask;
             MaskOffMenuItem.Text    = L.Log_MaskOff;
-            VerboseLogMenuItem.Text = L.Log_Verbose;
+            LogLevelSubMenu.Text    = L.Log_Level;
+            DnsLogSubMenu.Text      = L.Log_DnsLog;
+            DnsLogOffMenuItem.Text  = L.Log_MaskOff;
+            DnsLogOnMenuItem.Text   = L.Log_DnsLogOn;
             AutoScrollToggle.Content = L.Log_AutoScroll;
             CopyButton.Content       = L.Log_CopyAll;
             ClearButton.Content      = L.Log_Clear;
@@ -144,12 +148,14 @@ namespace XrayUI.Views
             {
                 var settings = await _settings.LoadSettingsAsync();
                 SetMaskAddressSelection(LogMaskAddress.Normalize(settings.LogMaskAddress));
-                VerboseLogMenuItem.IsChecked = settings.VerboseXrayLog;
+                SetLogLevelSelection(XrayLogLevel.Normalize(settings.XrayLogLevel));
+                SetDnsLogSelection(settings.DnsLog);
             }
             catch
             {
                 SetMaskAddressSelection(LogMaskAddress.Off);
-                VerboseLogMenuItem.IsChecked = false;
+                SetLogLevelSelection(XrayLogLevel.Warning);
+                SetDnsLogSelection(false);
             }
         }
 
@@ -159,6 +165,19 @@ namespace XrayUI.Views
             MaskQuarterMenuItem.IsChecked = value == LogMaskAddress.Quarter;
             MaskHalfMenuItem.IsChecked    = value == LogMaskAddress.Half;
             MaskFullMenuItem.IsChecked    = value == LogMaskAddress.Full;
+        }
+
+        private void SetLogLevelSelection(string value)
+        {
+            LogLevelDebugMenuItem.IsChecked   = value == XrayLogLevel.Debug;
+            LogLevelInfoMenuItem.IsChecked    = value == XrayLogLevel.Info;
+            LogLevelWarningMenuItem.IsChecked = value == XrayLogLevel.Warning;
+        }
+
+        private void SetDnsLogSelection(bool value)
+        {
+            DnsLogOffMenuItem.IsChecked = !value;
+            DnsLogOnMenuItem.IsChecked  = value;
         }
 
         private void UpdateStatus()
@@ -191,53 +210,82 @@ namespace XrayUI.Views
                 return;
             }
 
+            // The off item carries the sentinel tag "off" (an empty-string Tag round-trips
+            // unreliably through XAML); Normalize maps it back to Off ("").
             var value = LogMaskAddress.Normalize(item.Tag as string);
             SetMaskAddressSelection(value);
 
-            try
+            await ApplyLogSettingAsync(L.Log_PrivacyTitle, s =>
             {
-                var settings = await _settings.LoadSettingsAsync();
-                if (LogMaskAddress.Normalize(settings.LogMaskAddress) == value)
+                if (LogMaskAddress.Normalize(s.LogMaskAddress) == value)
                 {
-                    return;
+                    return false;
                 }
 
-                settings.LogMaskAddress = value;
-                await _settings.SaveSettingsAsync(settings);
-
-                if (!_xray.IsRunning)
-                {
-                    return;
-                }
-
-                if (settings.IsTunMode)
-                {
-                    await ShowInfoAsync(L.Log_PrivacyTitle, L.Log_PrivacySaved);
-                    return;
-                }
-
-                await _reapplyConfigAsync();
-            }
-            catch (Exception ex)
-            {
-                await ShowInfoAsync(L.Log_PrivacyTitle, Loc.Format("Log_PrivacyFailed", ex.Message));
-            }
+                s.LogMaskAddress = value;
+                return true;
+            });
         }
 
-        private async void VerboseLogMenuItem_Click(object sender, RoutedEventArgs e)
+        private async void LogLevelMenuItem_Click(object sender, RoutedEventArgs e)
         {
-            // ToggleMenuFlyoutItem has already flipped IsChecked by the time Click fires.
-            var value = VerboseLogMenuItem.IsChecked;
+            if (sender is not RadioMenuFlyoutItem item)
+            {
+                return;
+            }
 
+            var value = XrayLogLevel.Normalize(item.Tag as string);
+            SetLogLevelSelection(value);
+
+            await ApplyLogSettingAsync(L.Log_Level, s =>
+            {
+                if (XrayLogLevel.Normalize(s.XrayLogLevel) == value)
+                {
+                    return false;
+                }
+
+                s.XrayLogLevel = value;
+                return true;
+            });
+        }
+
+        private async void DnsLogMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not RadioMenuFlyoutItem item)
+            {
+                return;
+            }
+
+            var value = (item.Tag as string) == "on";
+            SetDnsLogSelection(value);
+
+            await ApplyLogSettingAsync(L.Log_DnsLog, s =>
+            {
+                if (s.DnsLog == value)
+                {
+                    return false;
+                }
+
+                s.DnsLog = value;
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Shared save path for the log-settings flyout: persists the mutation, then hot-reapplies
+        /// the config (proxy mode) or tells the user it applies next session (TUN mode).
+        /// <paramref name="apply"/> returns false when the stored value already matches.
+        /// </summary>
+        private async Task ApplyLogSettingAsync(string title, Func<AppSettings, bool> apply)
+        {
             try
             {
                 var settings = await _settings.LoadSettingsAsync();
-                if (settings.VerboseXrayLog == value)
+                if (!apply(settings))
                 {
                     return;
                 }
 
-                settings.VerboseXrayLog = value;
                 await _settings.SaveSettingsAsync(settings);
 
                 if (!_xray.IsRunning)
@@ -247,7 +295,7 @@ namespace XrayUI.Views
 
                 if (settings.IsTunMode)
                 {
-                    await ShowInfoAsync(L.Log_Verbose, L.Log_PrivacySaved);
+                    await ShowInfoAsync(title, L.Log_PrivacySaved);
                     return;
                 }
 
@@ -255,7 +303,7 @@ namespace XrayUI.Views
             }
             catch (Exception ex)
             {
-                await ShowInfoAsync(L.Log_Verbose, Loc.Format("Log_PrivacyFailed", ex.Message));
+                await ShowInfoAsync(title, Loc.Format("Log_PrivacyFailed", ex.Message));
             }
         }
 


### PR DESCRIPTION
This PR refactors Xray log settings to support multiple log levels (Debug, Info, Warning) instead of a simple verbose toggle, and adds support for Xray's DNS query log (log.dnsLog).