### PR TITLE
Fix mini window restoring to full size when moved after maximize

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -35,6 +35,9 @@ namespace XrayUI
         private bool _allowClose;
         private bool _initialized;
         private bool _isHiddenToTray;
+        // Set when mini mode was entered from a maximized window, so expanding
+        // returns to maximized instead of the plain windowed size.
+        private bool _restoreMaximizedOnExpand;
         private bool _personalizeRealized;
         private readonly bool _startMinimized;
         // Set when we parked the window off-screen at startup; cleared after
@@ -441,8 +444,12 @@ namespace XrayUI
 
             // Un-maximize first: resizing alone keeps the zoomed flag set, and
             // dragging a zoomed window restores it back to full-mode size.
-            if (isMini && presenter.State == OverlappedPresenterState.Maximized)
-                presenter.Restore();
+            if (isMini)
+            {
+                _restoreMaximizedOnExpand = presenter.State == OverlappedPresenterState.Maximized;
+                if (_restoreMaximizedOnExpand)
+                    presenter.Restore();
+            }
 
             var width  = isMini ? MiniWindowWidth  : FullWindowWidth;
             var height = isMini ? MiniWindowHeight : FullWindowHeight;
@@ -458,6 +465,14 @@ namespace XrayUI
             presenter.IsMaximizable = !isMini;
             AppTitleBar.Visibility = isMini ? Visibility.Collapsed : Visibility.Visible;
             this.SetWindowSize(width, height);
+
+            // Maximize only after the normal rect above is in place, so the restore
+            // rect the system captures is the windowed size, not the mini rect.
+            if (!isMini && _restoreMaximizedOnExpand)
+            {
+                _restoreMaximizedOnExpand = false;
+                presenter.Maximize();
+            }
         }
 
         private void MiniExpandButton_Click(object sender, RoutedEventArgs e)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -439,6 +439,11 @@ namespace XrayUI
         {
             var presenter = (OverlappedPresenter)AppWindow.Presenter;
 
+            // Un-maximize first: resizing alone keeps the zoomed flag set, and
+            // dragging a zoomed window restores it back to full-mode size.
+            if (isMini && presenter.State == OverlappedPresenterState.Maximized)
+                presenter.Restore();
+
             var width  = isMini ? MiniWindowWidth  : FullWindowWidth;
             var height = isMini ? MiniWindowHeight : FullWindowHeight;
 


### PR DESCRIPTION
## Problem

Toggling mini mode while the window is maximized only shrinks the HWND with `SetWindowSize` — the internal zoomed (maximized) flag stays set. When the user then drags the mini window (`WM_NCLBUTTONDOWN`/`HTCAPTION`), Windows performs its standard restore-on-drag for maximized windows and snaps the window back to the saved restore rect (full-mode 950x600).

This also explains the reported symptoms: stable repro within one session (the restore rect keeps the pre-maximize size), gone after an app restart (fresh process has no maximize record).

## Fix

- **Entering mini** (`ApplyWindowMode`): if the presenter is `Maximized`, call `presenter.Restore()` before resizing. The zoomed flag is cleared, so dragging the mini window is a plain move.
- **Expanding back**: entering mini from a maximized window sets `_restoreMaximizedOnExpand`; expanding then re-maximizes after the 950x600 windowed rect is applied. Mode round-trip is symmetric (maximized -> mini -> maximized), and because `Maximize()` runs after the windowed rect is set, the system-captured restore rect stays the windowed size — manually un-maximizing later yields a normal 950x600 window, not a mini-sized one.

## Verification

Debug build passes (only pre-existing WMC1510 warnings in `AppSettingsExpander.xaml`). UIA runtime round-trip:

1. maximize -> `IsZoomed=True`
2. Toggle Mini -> `IsZoomed=False`, 330x136 DIP (drag can no longer trigger restore-on-drag)
3. Expand -> `IsZoomed=True` (returns to maximized)
4. manual un-maximize -> `IsZoomed=False`, 950x600 DIP (sane restore rect)

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)