### PR TITLE
Improve log rendering

### DIFF
--- a/Services/LogLineParser.cs
+++ b/Services/LogLineParser.cs
@@ -1,0 +1,25 @@
+namespace XrayUI.Services
+{
+    /// <summary>
+    /// Length of the leading "yyyy/MM/dd HH:mm:ss[.ffffff]" timestamp on a raw
+    /// xray log line, or 0 if the line doesn't start with one. Pure string
+    /// logic (no WinUI types) so it stays source-linkable into the test
+    /// project; the log window uses this to dim the timestamp prefix.
+    /// </summary>
+    public static class LogLineParser
+    {
+        public static int TimestampLength(string line)
+        {
+            if (line.Length < 19 ||
+                !char.IsAsciiDigit(line[0]) ||
+                line[4] != '/' || line[7] != '/' || line[10] != ' ' ||
+                line[13] != ':' || line[16] != ':')
+            {
+                return 0;
+            }
+
+            var timeEnd = line.IndexOf(' ', 11);
+            return timeEnd < 0 ? line.Length : timeEnd;
+        }
+    }
+}

--- a/Views/LogWindow.xaml
+++ b/Views/LogWindow.xaml
@@ -22,19 +22,30 @@
             </TitleBar.IconSource>
         </TitleBar>
 
-        <!-- Log text area -->
+        <!-- Log text area — one Paragraph per buffer line, timestamp Run dimmed
+             (see LogLineParser); built in code-behind. -->
         <ScrollViewer x:Name="LogScrollViewer"
                       Grid.Row="1"
                       Padding="12,12,12,0"
                       VerticalScrollBarVisibility="Auto"
                       HorizontalScrollBarVisibility="Auto">
-            <TextBlock x:Name="LogTextBlock"
-                       FontFamily="Cascadia Code, Consolas, Courier New"
-                       FontSize="12"
-                       IsTextSelectionEnabled="True"
-                       TextWrapping="NoWrap"
-                       Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+            <RichTextBlock x:Name="LogRichText"
+                           FontFamily="Cascadia Code, Consolas, Courier New"
+                           FontSize="12"
+                           IsTextSelectionEnabled="True"
+                           TextWrapping="NoWrap"
+                           Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
         </ScrollViewer>
+
+        <!-- Code-created Runs can't reference {ThemeResource} directly, and
+             Application.Current.Resources[key] would resolve system brushes
+             against the (never-set) app-level theme instead of this window's
+             tracked theme — so this real, collapsed element carries the brush,
+             correctly inheriting WindowRoot's theme. Re-read on ActualThemeChanged. -->
+        <TextBlock x:Name="TimestampBrushSource"
+                   Grid.Row="1"
+                   Visibility="Collapsed"
+                   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
 
         <!-- Toolbar -->
         <Border Grid.Row="2"

--- a/Views/LogWindow.xaml.cs
+++ b/Views/LogWindow.xaml.cs
@@ -1,7 +1,9 @@
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
@@ -33,6 +35,10 @@ namespace XrayUI.Views
         private volatile bool _dirty;
         private int _linesReceivedSinceFlush; // Background-thread increments; UI thread reads + clears.
         private int _prevBufferCount;
+        private IReadOnlyList<string> _renderedLines = Array.Empty<string>();
+
+        // Timestamp brush, re-resolved (with a full re-render) when the theme changes.
+        private Brush _timestampBrush = null!;
 
         public LogWindow(
             XrayService xray,
@@ -66,7 +72,9 @@ namespace XrayUI.Views
 
             _xray.LogReceived     += OnLogReceived;
             _xray.RunningChanged  += OnRunningChanged;
+            WindowRoot.ActualThemeChanged += OnActualThemeChanged;
 
+            RefreshTimestampBrush();
             RenderLog();
             UpdateStatus();
             _ = InitializeLogSettingsMenuAsync();
@@ -87,6 +95,7 @@ namespace XrayUI.Views
             _flushTimer.Stop();
             _xray.LogReceived    -= OnLogReceived;
             _xray.RunningChanged -= OnRunningChanged;
+            WindowRoot.ActualThemeChanged -= OnActualThemeChanged;
         }
 
         private void OnLogReceived(object? sender, string line)
@@ -95,6 +104,24 @@ namespace XrayUI.Views
             // just mark dirty; the timer will re-render on the UI thread.
             Interlocked.Increment(ref _linesReceivedSinceFlush);
             _dirty = true;
+        }
+
+        private void OnActualThemeChanged(FrameworkElement sender, object args)
+        {
+            // Enqueue so TimestampBrushSource's {ThemeResource} lookup has settled
+            // before the brush is re-read; existing Runs keep their old brush
+            // instance, so a full re-render is required.
+            _queue.TryEnqueue(() =>
+            {
+                RefreshTimestampBrush();
+                var offset = LogScrollViewer.VerticalOffset;
+                RenderLog(forceRebuild: true);
+                LogScrollViewer.ChangeView(
+                    null,
+                    AutoScrollToggle.IsChecked == true ? double.MaxValue : offset,
+                    null,
+                    disableAnimation: true);
+            });
         }
 
         private void OnRunningChanged(object? sender, bool running)
@@ -136,13 +163,82 @@ namespace XrayUI.Views
 
         // ── Rendering ──────────────────────────────────────────────────────────
 
-        private void RenderLog()
+        private void RenderLog(bool forceRebuild = false)
         {
             // XrayService owns the single source of truth; we just render a snapshot.
             var lines = _xray.GetLogBuffer();
-            LogTextBlock.Text = string.Join('\n', lines);
+            var overlap = forceRebuild ? 0 : FindSuffixPrefixOverlap(_renderedLines, lines);
+
+            if (forceRebuild)
+            {
+                LogRichText.Blocks.Clear();
+            }
+            else
+            {
+                for (var i = _renderedLines.Count; i > overlap; i--)
+                {
+                    LogRichText.Blocks.RemoveAt(0);
+                }
+            }
+
+            for (var i = overlap; i < lines.Count; i++)
+            {
+                LogRichText.Blocks.Add(BuildParagraph(lines[i]));
+            }
+
+            _renderedLines = lines;
             LineCountText.Text = Loc.Format("Log_Lines", lines.Count);
             _prevBufferCount = lines.Count;
+        }
+
+        private static int FindSuffixPrefixOverlap(
+            IReadOnlyList<string> previous,
+            IReadOnlyList<string> current)
+        {
+            for (var overlap = Math.Min(previous.Count, current.Count); overlap > 0; overlap--)
+            {
+                var previousStart = previous.Count - overlap;
+                var matches = true;
+
+                for (var i = 0; i < overlap; i++)
+                {
+                    if (!string.Equals(previous[previousStart + i], current[i], StringComparison.Ordinal))
+                    {
+                        matches = false;
+                        break;
+                    }
+                }
+
+                if (matches)
+                {
+                    return overlap;
+                }
+            }
+
+            return 0;
+        }
+
+        private Paragraph BuildParagraph(string line)
+        {
+            var paragraph = new Paragraph();
+            var timestampLength = LogLineParser.TimestampLength(line);
+
+            if (timestampLength > 0)
+            {
+                paragraph.Inlines.Add(new Run { Text = line[..timestampLength], Foreground = _timestampBrush });
+            }
+
+            if (timestampLength < line.Length)
+            {
+                paragraph.Inlines.Add(new Run { Text = line[timestampLength..] });
+            }
+
+            return paragraph;
+        }
+
+        private void RefreshTimestampBrush()
+        {
+            _timestampBrush = TimestampBrushSource.Foreground;
         }
 
         private async Task InitializeLogSettingsMenuAsync()
@@ -195,14 +291,13 @@ namespace XrayUI.Views
         private void CopyButton_Click(object sender, RoutedEventArgs e)
         {
             var dp = new DataPackage();
-            dp.SetText(LogTextBlock.Text);
+            dp.SetText(string.Join('\n', _xray.GetLogBuffer()));
             Clipboard.SetContent(dp);
         }
 
         private void ClearButton_Click(object sender, RoutedEventArgs e)
         {
             _xray.ClearLogBuffer();
-            Interlocked.Exchange(ref _linesReceivedSinceFlush, 0);
             RenderLog();
         }
 

--- a/XrayUI.Tests/LogLineParserTests.cs
+++ b/XrayUI.Tests/LogLineParserTests.cs
@@ -1,0 +1,49 @@
+using XrayUI.Services;
+
+namespace XrayUI.Tests
+{
+    public class LogLineParserTests
+    {
+        [Fact]
+        public void TimestampedLine_ReturnsPrefixLength()
+        {
+            const string timestamp = "2026/07/21 16:55:06.567737";
+            const string rest = " from 127.0.0.1:50262 accepted //graph.microsoft.com:443 [mixed-in -> proxy]";
+            var line = timestamp + rest;
+
+            var length = LogLineParser.TimestampLength(line);
+
+            Assert.Equal(timestamp.Length, length);
+            Assert.Equal(timestamp, line[..length]);
+            Assert.Equal(rest, line[length..]);
+        }
+
+        [Fact]
+        public void Ipv6Source_NotMistakenForMissingTimestamp()
+        {
+            const string timestamp = "2026/07/21 16:54:50.770602";
+            var line = timestamp + " from [::1]:5000 accepted //example.com:443 [mixed-in -> direct]";
+
+            Assert.Equal(timestamp.Length, LogLineParser.TimestampLength(line));
+        }
+
+        [Fact]
+        public void NoTimestamp_ReturnsZero()
+        {
+            Assert.Equal(0, LogLineParser.TimestampLength("Xray 25.1.30 (Xray, Penetrates Everything.)"));
+        }
+
+        [Fact]
+        public void TimestampOnly_ReturnsFullLength()
+        {
+            const string line = "2026/07/21 16:54:50.770602";
+            Assert.Equal(line.Length, LogLineParser.TimestampLength(line));
+        }
+
+        [Fact]
+        public void EmptyLine_ReturnsZero()
+        {
+            Assert.Equal(0, LogLineParser.TimestampLength(""));
+        }
+    }
+}

--- a/XrayUI.Tests/XrayUI.Tests.csproj
+++ b/XrayUI.Tests/XrayUI.Tests.csproj
@@ -32,6 +32,7 @@
     <Compile Include="..\Services\NodeLinkSerializer.cs" Link="Prod\Services\NodeLinkSerializer.cs" />
     <Compile Include="..\Services\ClashConfigParser.cs" Link="Prod\Services\ClashConfigParser.cs" />
     <Compile Include="..\Services\CustomRuleValueParser.cs" Link="Prod\Services\CustomRuleValueParser.cs" />
+    <Compile Include="..\Services\LogLineParser.cs" Link="Prod\Services\LogLineParser.cs" />
     <Compile Include="..\Services\XhttpSettings.cs" Link="Prod\Services\XhttpSettings.cs" />
     <Compile Include="..\Services\EchSettings.cs" Link="Prod\Services\EchSettings.cs" />
     <Compile Include="..\Services\FinalmaskJson.cs" Link="Prod\Services\FinalmaskJson.cs" />


### PR DESCRIPTION
## Summary

- render Xray log timestamps with a theme-aware tertiary foreground
- update the log view incrementally by retaining unchanged paragraphs, removing evicted entries, and appending only new lines
- add focused timestamp parser tests and link the parser into the test project

## Why

Using one rich-text paragraph per log line enables timestamp styling, but rebuilding the entire 500-line visual tree every 100 ms would add avoidable UI-thread allocation and layout work during sustained traffic. The incremental reconciliation keeps the styling while avoiding repeated full rebuilds.

## Impact

Log timestamps are visually de-emphasized in both light and dark themes, and busy log streams should remain more responsive. Full rebuilding is reserved for theme changes.

## Validation

- `dotnet test XrayUI.Tests\XrayUI.Tests.csproj --no-restore` — 54 tests passed
- `dotnet build XrayUI-dev.csproj --no-restore` — succeeded with 0 warnings and 0 errors
- launched the unpackaged app and confirmed a responsive top-level “Proxy Pannel” window