### PR TITLE
Fix invisible scroll thumb in log window

### DIFF
--- a/Views/LogWindow.xaml
+++ b/Views/LogWindow.xaml
@@ -23,19 +23,26 @@
         </TitleBar>
 
         <!-- Log text area — one Span per buffer line, timestamp Run dimmed
-             (see LogLineParser); built in code-behind. -->
-        <ScrollViewer x:Name="LogScrollViewer"
-                      Grid.Row="1"
-                      Padding="12,12,12,0"
-                      VerticalScrollBarVisibility="Auto"
-                      HorizontalScrollBarVisibility="Auto">
+             (see LogLineParser); built in code-behind. ScrollView (not the
+             legacy ScrollViewer): its scroll bars are driven by ScrollView's
+             own controller instead of the WUX visual-state storyboards whose
+             thumb kept wedging invisible on some machines. ContentOrientation
+             must stay "Both" or the NoWrap text gets clipped instead of
+             scrolling horizontally. Padding lives on the TextBlock as Margin
+             because ScrollView doesn't apply Padding to its content. -->
+        <ScrollView x:Name="LogScrollViewer"
+                    Grid.Row="1"
+                    ContentOrientation="Both"
+                    VerticalScrollBarVisibility="Auto"
+                    HorizontalScrollBarVisibility="Auto">
             <TextBlock x:Name="LogTextBlock"
+                       Margin="12,12,12,0"
                        FontFamily="Cascadia Code, Consolas, Courier New"
                        FontSize="12"
                        IsTextSelectionEnabled="True"
                        TextWrapping="NoWrap"
                        Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
-        </ScrollViewer>
+        </ScrollView>
 
         <!-- Code-created Runs can't reference {ThemeResource} directly, and
              Application.Current.Resources[key] would resolve system brushes

--- a/Views/LogWindow.xaml.cs
+++ b/Views/LogWindow.xaml.cs
@@ -40,8 +40,11 @@ namespace XrayUI.Views
         // Timestamp brush, re-resolved (with a full re-render) when the theme changes.
         private Brush _timestampBrush = null!;
 
-        // Last observed "can scroll horizontally" state; see OnLogLayoutChanged.
-        private bool _horizontallyScrollable;
+        // ScrollView.ScrollTo has no "keep current offset" sentinel like
+        // ChangeView's null — the current offset is passed explicitly, and
+        // jumps must disable animation to match the old instant behavior.
+        private static readonly ScrollingScrollOptions JumpOptions =
+            new(ScrollingAnimationMode.Disabled);
 
         public LogWindow(
             XrayService xray,
@@ -76,8 +79,6 @@ namespace XrayUI.Views
             _xray.LogReceived     += OnLogReceived;
             _xray.RunningChanged  += OnRunningChanged;
             WindowRoot.ActualThemeChanged += OnActualThemeChanged;
-            LogTextBlock.SizeChanged      += OnLogLayoutChanged;
-            LogScrollViewer.SizeChanged   += OnLogLayoutChanged;
 
             RefreshTimestampBrush();
             RenderLog();
@@ -101,8 +102,6 @@ namespace XrayUI.Views
             _xray.LogReceived    -= OnLogReceived;
             _xray.RunningChanged -= OnRunningChanged;
             WindowRoot.ActualThemeChanged -= OnActualThemeChanged;
-            LogTextBlock.SizeChanged      -= OnLogLayoutChanged;
-            LogScrollViewer.SizeChanged   -= OnLogLayoutChanged;
         }
 
         private void OnLogReceived(object? sender, string line)
@@ -123,43 +122,19 @@ namespace XrayUI.Views
                 RefreshTimestampBrush();
                 var offset = LogScrollViewer.VerticalOffset;
                 RenderLog(forceRebuild: true);
-                LogScrollViewer.ChangeView(
-                    null,
-                    AutoScrollToggle.IsChecked == true ? double.MaxValue : offset,
-                    null,
-                    disableAnimation: true);
+                // Flush layout so ScrollableHeight reflects the rebuilt content
+                // before ScrollTo clamps against it.
+                LogScrollViewer.UpdateLayout();
+                LogScrollViewer.ScrollTo(
+                    LogScrollViewer.HorizontalOffset,
+                    AutoScrollToggle.IsChecked == true ? LogScrollViewer.ScrollableHeight : offset,
+                    JumpOptions);
             });
         }
 
         private void OnRunningChanged(object? sender, bool running)
         {
             _queue.TryEnqueue(UpdateStatus);
-        }
-
-        private void OnLogLayoutChanged(object sender, SizeChangedEventArgs e)
-        {
-            // Workaround for a WinUI ScrollBar state-machine bug: when horizontal
-            // scrollability flips on/off under frequent re-layout (long lines
-            // entering/leaving the ring buffer keep this window near the boundary),
-            // the bar can come back with its thumb stuck collapsed — arrows work,
-            // but track clicks jump to the far end. When scrollability returns,
-            // bounce the bar through Hidden (scrolling stays enabled, offset is
-            // preserved) so it re-materializes with a fresh thumb.
-            var scrollable = LogScrollViewer.ScrollableWidth > 0;
-            if (scrollable == _horizontallyScrollable)
-            {
-                return;
-            }
-
-            _horizontallyScrollable = scrollable;
-            if (!scrollable)
-            {
-                return;
-            }
-
-            LogScrollViewer.HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden;
-            _queue.TryEnqueue(() =>
-                LogScrollViewer.HorizontalScrollBarVisibility = ScrollBarVisibility.Auto);
         }
 
         private void OnFlushTick(DispatcherQueueTimer sender, object args)
@@ -178,7 +153,14 @@ namespace XrayUI.Views
 
             if (autoScroll)
             {
-                LogScrollViewer.ChangeView(null, double.MaxValue, null, disableAnimation: true);
+                // Flush layout first so ScrollableHeight already includes the
+                // lines just rendered — ScrollTo clamps at request time, unlike
+                // ChangeView's late clamping.
+                LogScrollViewer.UpdateLayout();
+                LogScrollViewer.ScrollTo(
+                    LogScrollViewer.HorizontalOffset,
+                    LogScrollViewer.ScrollableHeight,
+                    JumpOptions);
             }
             else
             {
@@ -189,7 +171,7 @@ namespace XrayUI.Views
                 {
                     var lineHeight = prevExtent / prevCount;
                     var target = Math.Max(0, prevOffset - evicted * lineHeight);
-                    LogScrollViewer.ChangeView(null, target, null, disableAnimation: true);
+                    LogScrollViewer.ScrollTo(LogScrollViewer.HorizontalOffset, target, JumpOptions);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- The log window's horizontal scroll bar (legacy `ScrollViewer`) could come back with its thumb permanently invisible under this window's constant text relayout — arrows still worked, but the thumb never rendered and track clicks jumped straight to the far end with no way back except spamming an arrow button.
- Root cause: WinUI's `ScrollBar` template ships its thumb transparent by default and relies on visual-state opacity storyboards to fade it in/out; under this window's ~10Hz relayout those transitions could wedge.
- Fix: replace `ScrollViewer` with the newer `ScrollView` control, whose scroll bars are driven by its own controller instead of those visual-state storyboards. `ChangeView` calls become `ScrollTo` (preceded by `UpdateLayout()`, since `ScrollTo` clamps against `ScrollableHeight` at request time rather than `ChangeView`'s late clamping).
- Verified on a machine that reliably reproduced the bug — confirmed fixed after switching to `ScrollView`.

## Test plan
- [x] Built and ran locally; opened the log window with a running connection and confirmed logging, auto-scroll, and horizontal scrolling of long lines all work
- [x] Verified fix on a second machine that previously reproduced the stuck-thumb bug reliably
- [x] `dotnet test XrayUI.Tests/XrayUI.Tests.csproj -c Release` passes (unaffected — no test-linked files touched)
