### PR TITLE
Add hysteria2 port hopping and certificate pinning

### DIFF
--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -48,6 +48,7 @@ public static class L
     public static string EditServer_Security         => Loc.GetString("EditServer_Security");
     public static string EditServer_Fingerprint      => Loc.GetString("EditServer_Fingerprint");
     public static string EditServer_AllowInsecure    => Loc.GetString("EditServer_AllowInsecure");
+    public static string EditServer_CertFingerprint  => Loc.GetString("EditServer_CertFingerprint");
     public static string EditServer_FlowPlaceholder  => Loc.GetString("EditServer_FlowPlaceholder");
 
     // ── Edit port dialog ───────────────────────────────────────────────────

--- a/Models/ServerEntry.cs
+++ b/Models/ServerEntry.cs
@@ -27,6 +27,7 @@ namespace XrayUI.Models
             Security = string.Empty;
             Sni = string.Empty;
             Fingerprint = string.Empty;
+            PinnedPeerCertSha256 = string.Empty;
             EchConfigList = string.Empty;
             EchForceQuery = string.Empty;
             PublicKey = string.Empty;
@@ -128,6 +129,16 @@ namespace XrayUI.Models
 
         [ObservableProperty]
         public partial bool AllowInsecure { get; set; }
+
+        /// <summary>
+        /// Server certificate fingerprint (SHA-256 hex) to pin instead of validating the chain.
+        /// Maps to tlsSettings.pinnedPeerCertSha256, so it applies to every TLS outbound — but
+        /// not to REALITY, which authenticates by public key and has no tlsSettings.
+        /// Only hysteria2 links carry it (as "pinSHA256"); other protocols have no share-link
+        /// convention for a pin, so their entries are set by hand in the edit dialog.
+        /// </summary>
+        [ObservableProperty]
+        public partial string PinnedPeerCertSha256 { get; set; }
 
         /// <summary>Client-side TLS ECH config list. Empty = disabled.</summary>
         [ObservableProperty]
@@ -265,6 +276,7 @@ namespace XrayUI.Models
             Sni                = source.Sni;
             Fingerprint        = source.Fingerprint;
             AllowInsecure      = source.AllowInsecure;
+            PinnedPeerCertSha256 = source.PinnedPeerCertSha256;
             EchConfigList      = source.EchConfigList;
             EchForceQuery      = source.EchForceQuery;
             PublicKey          = source.PublicKey;

--- a/Services/ClashConfigParser.cs
+++ b/Services/ClashConfigParser.cs
@@ -178,6 +178,9 @@ namespace XrayUI.Services
             Security      = "tls",
             Sni           = Str(p, "sni", Str(p, "servername")),
             AllowInsecure = Bool(p, "skip-cert-verify"),
+            // Clash spells the pinned certificate digest `fingerprint` — unrelated to the
+            // uTLS `client-fingerprint` that maps to ServerEntry.Fingerprint elsewhere.
+            PinnedPeerCertSha256 = Str(p, "fingerprint"),
             Finalmask     = BuildHysteria2Finalmask(p),
             Encryption    = "TLS",
         };
@@ -186,14 +189,20 @@ namespace XrayUI.Services
         {
             var finalmask = FinalmaskJson.NormalizeForStorage(Str(p, "fm", Str(p, "finalmask")));
 
-            if (!string.Equals(Str(p, "obfs"), "salamander", StringComparison.OrdinalIgnoreCase))
-                return finalmask;
+            if (string.Equals(Str(p, "obfs"), "salamander", StringComparison.OrdinalIgnoreCase))
+            {
+                var obfsPassword = Str(p, "obfs-password", Str(p, "obfs_password", Str(p, "obfsPassword")));
+                if (!string.IsNullOrWhiteSpace(obfsPassword))
+                    finalmask = FinalmaskJson.AddHysteria2SalamanderMask(finalmask, obfsPassword);
+            }
 
-            var obfsPassword = Str(p, "obfs-password", Str(p, "obfs_password", Str(p, "obfsPassword")));
-            if (string.IsNullOrWhiteSpace(obfsPassword))
-                return finalmask;
+            // Port hopping. The v2rayN share-link spelling ("mport") is deliberately not accepted
+            // here — that vocabulary belongs to NodeLinkParser, no Clash config emits it.
+            var ports = Str(p, "ports");
+            if (!string.IsNullOrWhiteSpace(ports))
+                finalmask = FinalmaskJson.AddHysteria2UdpHop(finalmask, ports, Str(p, "hop-interval"));
 
-            return FinalmaskJson.AddHysteria2SalamanderMask(finalmask, obfsPassword);
+            return finalmask;
         }
 
         // WireGuard: single-peer form (top-level public-key / server / port). Returns null when a

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -163,6 +163,15 @@ namespace XrayUI.Services
             var txtFp = new TextBox { Header = L.EditServer_Fingerprint, Text = existing?.Fingerprint ?? string.Empty };
             var chkAllowInsecure = new CheckBox
                 { Content = L.EditServer_AllowInsecure, IsChecked = existing?.AllowInsecure ?? false };
+            // Localized on purpose, unlike the PublicKey (Reality) / Flow (VLESS) rows below:
+            // it pairs with 指纹 (uTLS) above, of which 证书指纹 is the qualified form.
+            var txtPinnedCert = new TextBox
+            {
+                Header = L.EditServer_CertFingerprint,
+                PlaceholderText = "88b874b4cee4f3b6…",
+                Text = existing?.PinnedPeerCertSha256 ?? string.Empty,
+                TextWrapping = TextWrapping.Wrap
+            };
             var txtEchConfigList = new TextBox
             {
                 Header = "ECH ConfigList",
@@ -227,6 +236,7 @@ namespace XrayUI.Services
             var rowSni = Wrap(txtSni);
             var rowFp = Wrap(txtFp);
             var rowAllowInsecure = Wrap(chkAllowInsecure);
+            var rowPinnedCert = Wrap(txtPinnedCert);
             var rowEchConfigList = Wrap(txtEchConfigList);
             var rowEchForceQuery = Wrap(cmbEchForceQuery);
             var rowPk = Wrap(txtPk);
@@ -281,6 +291,11 @@ namespace XrayUI.Services
                 rowSni.Visibility = (hasTls || isHysteria2) ? Visibility.Visible : Visibility.Collapsed;
                 rowFp.Visibility = hasTls ? Visibility.Visible : Visibility.Collapsed;
                 rowAllowInsecure.Visibility = (hasTls || isHysteria2) ? Visibility.Visible : Visibility.Collapsed;
+                // Every TLS outbound can pin; REALITY cannot (it authenticates by public key and
+                // has no tlsSettings), so this tracks rowSni/rowAllowInsecure minus reality.
+                rowPinnedCert.Visibility = ((hasTls && !hasReality) || isHysteria2)
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
                 rowEchConfigList.Visibility = hasEch ? Visibility.Visible : Visibility.Collapsed;
                 rowEchForceQuery.Visibility = hasEch ? Visibility.Visible : Visibility.Collapsed;
                 rowPk.Visibility = hasReality ? Visibility.Visible : Visibility.Collapsed;
@@ -321,7 +336,7 @@ namespace XrayUI.Services
                     txtName, txtHost, numPort, cmbProtocol,
                     rowEncryption, rowUsername, rowPassword, rowUuid, rowAlterId,
                     cmbNetwork, rowPath, rowWsHost, rowXhttpMode, rowXhttpExtra,
-                    cmbSecurity, rowSni, rowFp, rowAllowInsecure, rowEchConfigList, rowEchForceQuery,
+                    cmbSecurity, rowSni, rowFp, rowAllowInsecure, rowPinnedCert, rowEchConfigList, rowEchForceQuery,
                     rowPk, rowSid, rowSpx, rowFlow, rowVlessEncryption,
                     rowWgPrivateKey, rowWgPublicKey, rowWgPreSharedKey, rowWgLocalAddress, rowWgMtu, rowWgReserved,
                     rowFinalmask
@@ -370,6 +385,13 @@ namespace XrayUI.Services
             entry.Sni = txtSni.Text.Trim();
             entry.Fingerprint = txtFp.Text.Trim();
             entry.AllowInsecure = chkAllowInsecure.IsChecked == true;
+            // Hand entry is the only path that needs cleaning: cert viewers copy digests with
+            // colons (openssl, Firefox) or spaces (Windows certmgr). Measured against the shipped
+            // core — it tolerates colons and either case itself, but rejects the spaced form with
+            // "incorrect pinnedPeerCertSha256 length". Links and Clash configs carry bare hex, so
+            // those paths store what they were given.
+            entry.PinnedPeerCertSha256 = txtPinnedCert.Text
+                .Trim().Replace(":", string.Empty).Replace(" ", string.Empty);
             entry.EchConfigList = txtEchConfigList.Text.Trim();
             entry.EchForceQuery = EchSettings.NormalizeForceQuery(cmbEchForceQuery.SelectedItem?.ToString());
             entry.PublicKey = txtPk.Text.Trim();
@@ -405,6 +427,7 @@ namespace XrayUI.Services
                 entry.Sni = string.Empty;
                 entry.Fingerprint = string.Empty;
                 entry.AllowInsecure = false;
+                entry.PinnedPeerCertSha256 = string.Empty;
                 entry.EchConfigList = string.Empty;
                 entry.EchForceQuery = string.Empty;
                 entry.PublicKey = string.Empty;
@@ -428,6 +451,7 @@ namespace XrayUI.Services
                 entry.Sni = string.Empty;
                 entry.Fingerprint = string.Empty;
                 entry.AllowInsecure = false;
+                entry.PinnedPeerCertSha256 = string.Empty;
                 entry.EchConfigList = string.Empty;
                 entry.EchForceQuery = string.Empty;
                 entry.PublicKey = string.Empty;
@@ -467,6 +491,16 @@ namespace XrayUI.Services
             {
                 entry.EchConfigList = string.Empty;
                 entry.EchForceQuery = string.Empty;
+            }
+
+            // Same rule for the certificate pin, the other TLS-only field: anything that cannot
+            // produce a tlsSettings block must not keep one. Covers REALITY (authenticates by
+            // public key), security=none, and the non-TLS protocols — hysteria2 passes because
+            // its branch above forces Security to "tls". Enforced here rather than only in the
+            // row's visibility, so a collapsed row cannot persist a value that revives on switch-back.
+            if (!string.Equals(entry.Security, "tls", StringComparison.OrdinalIgnoreCase))
+            {
+                entry.PinnedPeerCertSha256 = string.Empty;
             }
 
             if (entry.Protocol != "ss" && entry.Protocol != "socks" && entry.Protocol != "http" && entry.Protocol != "wireguard")

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -493,15 +493,8 @@ namespace XrayUI.Services
                 entry.EchForceQuery = string.Empty;
             }
 
-            // Same rule for the certificate pin, the other TLS-only field: anything that cannot
-            // produce a tlsSettings block must not keep one. Gated on protocol AND security, not
-            // Security alone: ss shows the same Security combobox as vmess/vless/trojan (it is
-            // "standard transport" for visibility purposes) but BuildSsOutbound never reads
-            // Security at all, so a "tls" selection left over from before switching to ss would
-            // otherwise survive untouched — and silently reapply itself, targeting the wrong
-            // server, if the entry is later switched to a real TLS protocol without the user
-            // re-entering the pin. hysteria2 always qualifies because its branch above forces
-            // Security to "tls"; REALITY is excluded because it has no tlsSettings at all.
+            // Same rule for the certificate pin: gated on protocol AND security, not Security
+            // alone, because ss shares the same combobox but BuildSsOutbound never reads it.
             bool pinApplies = entry.Protocol == "hysteria2"
                 || ((entry.Protocol == "vmess" || entry.Protocol == "vless" || entry.Protocol == "trojan")
                     && string.Equals(entry.Security, "tls", StringComparison.OrdinalIgnoreCase));

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -168,7 +168,6 @@ namespace XrayUI.Services
             var txtPinnedCert = new TextBox
             {
                 Header = L.EditServer_CertFingerprint,
-                PlaceholderText = "88b874b4cee4f3b6…",
                 Text = existing?.PinnedPeerCertSha256 ?? string.Empty,
                 TextWrapping = TextWrapping.Wrap
             };

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -494,11 +494,18 @@ namespace XrayUI.Services
             }
 
             // Same rule for the certificate pin, the other TLS-only field: anything that cannot
-            // produce a tlsSettings block must not keep one. Covers REALITY (authenticates by
-            // public key), security=none, and the non-TLS protocols — hysteria2 passes because
-            // its branch above forces Security to "tls". Enforced here rather than only in the
-            // row's visibility, so a collapsed row cannot persist a value that revives on switch-back.
-            if (!string.Equals(entry.Security, "tls", StringComparison.OrdinalIgnoreCase))
+            // produce a tlsSettings block must not keep one. Gated on protocol AND security, not
+            // Security alone: ss shows the same Security combobox as vmess/vless/trojan (it is
+            // "standard transport" for visibility purposes) but BuildSsOutbound never reads
+            // Security at all, so a "tls" selection left over from before switching to ss would
+            // otherwise survive untouched — and silently reapply itself, targeting the wrong
+            // server, if the entry is later switched to a real TLS protocol without the user
+            // re-entering the pin. hysteria2 always qualifies because its branch above forces
+            // Security to "tls"; REALITY is excluded because it has no tlsSettings at all.
+            bool pinApplies = entry.Protocol == "hysteria2"
+                || ((entry.Protocol == "vmess" || entry.Protocol == "vless" || entry.Protocol == "trojan")
+                    && string.Equals(entry.Security, "tls", StringComparison.OrdinalIgnoreCase));
+            if (!pinApplies)
             {
                 entry.PinnedPeerCertSha256 = string.Empty;
             }

--- a/Services/FinalmaskJson.cs
+++ b/Services/FinalmaskJson.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -61,16 +63,35 @@ namespace XrayUI.Services
             }
         }
 
-        public static string AddHysteria2SalamanderMask(string finalmask, string password)
+        /// <summary>
+        /// Opens a stored mask for mutation. Fails for anything that is not an object — a mask
+        /// we cannot understand must be handed back to the caller verbatim rather than silently
+        /// replaced by a fresh one, so every mutating helper starts here.
+        /// </summary>
+        private static bool TryOpenRoot(string finalmask, [NotNullWhen(true)] out JsonObject? root)
         {
             var parsed = Parse(finalmask);
-            if (parsed is not null and not JsonObject)
+            root = parsed as JsonObject;
+            if (root is not null)
+                return true;
+
+            if (parsed is null && string.IsNullOrWhiteSpace(finalmask))
+            {
+                root = [];
+                return true;
+            }
+
+            return false;
+        }
+
+        private static string Write(JsonObject root) =>
+            root.ToJsonString(AppJsonSerializerContext.WriteReadable);
+
+        public static string AddHysteria2SalamanderMask(string finalmask, string password)
+        {
+            if (!TryOpenRoot(finalmask, out var root))
                 return finalmask;
 
-            if (parsed is null && !string.IsNullOrWhiteSpace(finalmask))
-                return finalmask;
-
-            var root = parsed as JsonObject ?? [];
             var udp = root["udp"] as JsonArray;
             if (udp is null)
             {
@@ -83,7 +104,7 @@ namespace XrayUI.Services
                 if (item is JsonObject itemObject
                     && string.Equals(itemObject["type"]?.GetValue<string>(), "salamander", StringComparison.OrdinalIgnoreCase))
                 {
-                    return root.ToJsonString(AppJsonSerializerContext.WriteReadable);
+                    return Write(root);
                 }
             }
 
@@ -96,7 +117,130 @@ namespace XrayUI.Services
                 }
             });
 
-            return root.ToJsonString(AppJsonSerializerContext.WriteReadable);
+            return Write(root);
         }
+
+        /// <summary>Hop interval written for links that carry only a port range. Matches the hysteria2 default.</summary>
+        public const string DefaultUdpHopInterval = "30";
+
+        /// <summary>
+        /// Folds a hysteria2 port-hopping range ("35000-39000", or a comma-separated list) into
+        /// quicParams.udpHop. Idempotent: an existing udpHop wins, so a link carrying both an
+        /// explicit fm= mask and mport= does not get its hand-tuned hop settings overwritten.
+        /// </summary>
+        public static string AddHysteria2UdpHop(
+            string finalmask,
+            string ports,
+            string interval = DefaultUdpHopInterval)
+        {
+            ports = ports.Trim();
+            if (ports.Length == 0)
+                return finalmask;
+            interval = string.IsNullOrWhiteSpace(interval)
+                ? DefaultUdpHopInterval
+                : interval.Trim();
+
+            if (!TryOpenRoot(finalmask, out var root))
+                return finalmask;
+
+            JsonObject quicParams;
+            switch (root["quicParams"])
+            {
+                case JsonObject existing: quicParams = existing; break;
+                case null: root["quicParams"] = quicParams = []; break;
+                default: return finalmask; // non-object quicParams: leave the mask alone
+            }
+
+            quicParams["udpHop"] ??= new JsonObject
+            {
+                ["ports"] = ports,
+                ["interval"] = interval
+            };
+
+            return Write(root);
+        }
+
+        /// <summary>
+        /// Inverse of <see cref="AddHysteria2SalamanderMask"/>: pulls the obfs password out so a
+        /// share link can re-emit it as obfs= / obfs-password=, and returns what is left of the
+        /// mask for the fm= parameter.
+        /// </summary>
+        public static (bool has, string? password, string remaining) TakeHysteria2Salamander(string finalmask)
+        {
+            if (Parse(finalmask) is not JsonObject root || root["udp"] is not JsonArray udp)
+                return (false, null, finalmask);
+
+            string? password = null;
+            for (int i = 0; i < udp.Count; i++)
+            {
+                if (udp[i] is JsonObject itemObject
+                    && string.Equals(AsText(itemObject["type"]), "salamander", StringComparison.OrdinalIgnoreCase))
+                {
+                    password = AsText((itemObject["settings"] as JsonObject)?["password"]) ?? string.Empty;
+                    udp.RemoveAt(i);
+                    break;
+                }
+            }
+
+            if (password is null)
+                return (false, null, finalmask);
+
+            if (udp.Count == 0)
+                root.Remove("udp");
+
+            return (true, password, Remaining(root));
+        }
+
+        /// <summary>
+        /// Inverse of <see cref="AddHysteria2UdpHop"/>: returns the hop port range so a share link
+        /// can re-emit it as "mport". The entry is only removed when it carries this class's own
+        /// shape; a hand-tuned hop has settings no link parameter can express, so it is reported
+        /// *and* left in the returned mask — the caller then emits both, and re-importing does not
+        /// double-apply because <see cref="AddHysteria2UdpHop"/> leaves an existing hop alone.
+        /// </summary>
+        public static (string? ports, string remaining) TakeHysteria2UdpHop(string finalmask)
+        {
+            if (Parse(finalmask) is not JsonObject root
+                || root["quicParams"] is not JsonObject quicParams
+                || quicParams["udpHop"] is not JsonObject udpHop
+                || AsText(udpHop["ports"]) is not { Length: > 0 } ports)
+            {
+                return (null, finalmask);
+            }
+
+            // Remove only what AddHysteria2UdpHop itself writes: ports plus the default interval,
+            // nothing else. Everything else is reported but left in place, so fm= carries it back
+            // byte-exact. In particular a hand-written hop with no interval at all is NOT ours —
+            // dropping it would mean re-importing invents an interval the author never wrote, on
+            // the unverified assumption that omitting it is the same as writing "30".
+            bool isCanonical = udpHop.Count == 2
+                               && AsText(udpHop["interval"]) == DefaultUdpHopInterval;
+            if (!isCanonical)
+                return (ports, finalmask);
+
+            quicParams.Remove("udpHop");
+            if (quicParams.Count == 0)
+                root.Remove("quicParams");
+
+            return (ports, Remaining(root));
+        }
+
+        /// <summary>
+        /// Re-encodes a mask that just had an entry lifted out of it, for the fm= parameter.
+        /// A mask emptied by the removal shares as an absent parameter, not as "{}".
+        /// </summary>
+        private static string Remaining(JsonObject root) =>
+            root.Count == 0 ? string.Empty : root.ToJsonString();
+
+        /// <summary>
+        /// Reads a mask value as text whether it was written as a JSON string or a bare number
+        /// (hand-written masks use both for ports/interval). Returns null for anything else.
+        /// </summary>
+        private static string? AsText(JsonNode? node) => node switch
+        {
+            JsonValue value when value.TryGetValue<string>(out var s) => s,
+            JsonValue value when value.TryGetValue<long>(out var n) => n.ToString(CultureInfo.InvariantCulture),
+            _ => null
+        };
     }
 }

--- a/Services/NodeLinkParser.cs
+++ b/Services/NodeLinkParser.cs
@@ -289,7 +289,9 @@ namespace XrayUI.Services
         {
             try
             {
-                var uri      = new Uri(link);
+                var (normalizedLink, addressPortRange) = SplitHysteria2PortRange(link);
+
+                var uri      = new Uri(normalizedLink);
                 var password = Uri.UnescapeDataString(uri.UserInfo);
                 var host     = uri.Host;
                 var port     = uri.Port;
@@ -299,7 +301,7 @@ namespace XrayUI.Services
 
                 var query = ParseQuery(uri.Query);
                 var sni   = Q(query, "sni", string.Empty) ?? string.Empty;
-                var finalmask = BuildHysteria2Finalmask(query);
+                var finalmask = BuildHysteria2Finalmask(query, addressPortRange);
                 var allowInsecure = IsTruthy(Q(query, "allowInsecure")) || IsTruthy(Q(query, "insecure"));
 
                 return new ServerEntry
@@ -313,6 +315,8 @@ namespace XrayUI.Services
                     Security   = "tls",
                     Sni        = sni,
                     AllowInsecure = allowInsecure,
+                    PinnedPeerCertSha256 =
+                        (Q(query, "pinSHA256") ?? Q(query, "pinnedPeerCertSha256") ?? string.Empty).Trim(),
                     Finalmask  = finalmask,
                     Encryption = "TLS"
                 };
@@ -323,22 +327,73 @@ namespace XrayUI.Services
             }
         }
 
-        private static string BuildHysteria2Finalmask(Dictionary<string, string> query)
+        /// <summary>
+        /// hysteria2's own URI form expresses port hopping as a range or list in the address
+        /// ("host:35000-39000", "host:35000,36000"). System.Uri rejects a non-numeric port
+        /// outright, so parsing the raw link threw and the node vanished at import. Rewrite the
+        /// address down to its first port and hand the range back for the finalmask fold-in.
+        /// </summary>
+        private static (string link, string? portRange) SplitHysteria2PortRange(string link)
+        {
+            var schemeEnd = link.IndexOf("://", StringComparison.Ordinal);
+            if (schemeEnd < 0) return (link, null);
+            schemeEnd += 3;
+
+            var authorityEnd = link.IndexOfAny(['/', '?', '#'], schemeEnd);
+            if (authorityEnd < 0) authorityEnd = link.Length;
+
+            // Auth may itself contain ':' and '@', so the host starts after the LAST '@'.
+            var authority = link.Substring(schemeEnd, authorityEnd - schemeEnd);
+            var hostStart = schemeEnd + authority.LastIndexOf('@') + 1;
+            var hostPort  = link.Substring(hostStart, authorityEnd - hostStart);
+
+            int colon;
+            if (hostPort.StartsWith('['))
+            {
+                var close = hostPort.IndexOf(']');
+                if (close < 0) return (link, null);
+                colon = hostPort.IndexOf(':', close);
+            }
+            else
+            {
+                colon = hostPort.LastIndexOf(':');
+            }
+            if (colon < 0) return (link, null);
+
+            var portPart = hostPort[(colon + 1)..];
+            var separator = portPart.IndexOfAny(['-', ',']);
+            if (separator < 0) return (link, null);
+
+            var firstPort = portPart[..separator];
+            if (!int.TryParse(firstPort, out _)) return (link, null);
+
+            // The port runs to the end of the authority by construction, so the tail resumes at
+            // authorityEnd — no need to re-derive it from the port length.
+            var portStart = hostStart + colon + 1;
+            return (string.Concat(link.AsSpan(0, portStart), firstPort, link.AsSpan(authorityEnd)), portPart);
+        }
+
+        private static string BuildHysteria2Finalmask(Dictionary<string, string> query, string? addressPortRange)
         {
             var finalmask = FinalmaskJson.NormalizeForStorage(
                 Q(query, "fm") ?? Q(query, "finalmask"));
 
             var obfs = Q(query, "obfs");
-            if (!string.Equals(obfs, "salamander", StringComparison.OrdinalIgnoreCase))
-                return finalmask;
+            if (string.Equals(obfs, "salamander", StringComparison.OrdinalIgnoreCase))
+            {
+                var obfsPassword = Q(query, "obfs-password")
+                                   ?? Q(query, "obfs_password")
+                                   ?? Q(query, "obfsPassword");
+                if (obfsPassword is not null)
+                    finalmask = FinalmaskJson.AddHysteria2SalamanderMask(finalmask, obfsPassword);
+            }
 
-            var obfsPassword = Q(query, "obfs-password")
-                               ?? Q(query, "obfs_password")
-                               ?? Q(query, "obfsPassword");
-            if (obfsPassword is null)
-                return finalmask;
+            // Query param wins over the address form — a client that emits both meant the param.
+            var ports = Q(query, "mport") ?? Q(query, "ports") ?? addressPortRange;
+            if (!string.IsNullOrWhiteSpace(ports))
+                finalmask = FinalmaskJson.AddHysteria2UdpHop(finalmask, ports);
 
-            return FinalmaskJson.AddHysteria2SalamanderMask(finalmask, obfsPassword);
+            return finalmask;
         }
 
         // Trojan

--- a/Services/NodeLinkSerializer.cs
+++ b/Services/NodeLinkSerializer.cs
@@ -174,11 +174,18 @@ namespace XrayUI.Services
             sb.Append(':');
             sb.Append(s.Port);
 
-            var (hasSalamanderObfs, obfsPassword, finalmask) =
-                ExtractHysteria2SalamanderObfs(FinalmaskJson.NormalizeForShare(s.Finalmask));
+            // Everything the mask can express as a dedicated link parameter is lifted out by
+            // FinalmaskJson; whatever is left rides along in fm=. This method only maps the
+            // results onto query keys.
+            var (hasSalamanderObfs, obfsPassword, mask) =
+                FinalmaskJson.TakeHysteria2Salamander(FinalmaskJson.NormalizeForShare(s.Finalmask));
+            var (hopPorts, finalmask) = FinalmaskJson.TakeHysteria2UdpHop(mask);
+
             bool hasQuery = !string.IsNullOrEmpty(s.Sni)
                             || s.AllowInsecure
+                            || !string.IsNullOrEmpty(s.PinnedPeerCertSha256)
                             || hasSalamanderObfs
+                            || hopPorts is not null
                             || !string.IsNullOrEmpty(finalmask);
             if (hasQuery)
             {
@@ -197,10 +204,18 @@ namespace XrayUI.Services
                 {
                     AddParam("insecure", "1");
                 }
+                if (!string.IsNullOrEmpty(s.PinnedPeerCertSha256))
+                {
+                    AddParam("pinSHA256", s.PinnedPeerCertSha256);
+                }
                 if (hasSalamanderObfs)
                 {
                     AddParam("obfs", "salamander");
                     AddParam("obfs-password", obfsPassword ?? string.Empty);
+                }
+                if (hopPorts is not null)
+                {
+                    AddParam("mport", hopPorts);
                 }
                 if (!string.IsNullOrEmpty(finalmask))
                 {
@@ -218,42 +233,6 @@ namespace XrayUI.Services
         }
 
         // ── Trojan ───────────────────────────────────────────────────────────
-
-        private static (bool hasObfs, string? password, string finalmask) ExtractHysteria2SalamanderObfs(string finalmask)
-        {
-            // FinalmaskJson.Parse returns a freshly-parsed node owned by this call, so we
-            // mutate `root` and `udp` in place rather than cloning.
-            var parsed = FinalmaskJson.Parse(finalmask);
-            if (parsed is not JsonObject root)
-                return (false, null, finalmask);
-
-            if (root["udp"] is not JsonArray udp)
-                return (false, null, finalmask);
-
-            string? password = null;
-            for (int i = 0; i < udp.Count; i++)
-            {
-                if (udp[i] is JsonObject itemObject
-                    && string.Equals(itemObject["type"]?.GetValue<string>(), "salamander", StringComparison.OrdinalIgnoreCase))
-                {
-                    password = (itemObject["settings"] as JsonObject)?["password"]?.GetValue<string>() ?? string.Empty;
-                    udp.RemoveAt(i);
-                    break;
-                }
-            }
-
-            if (password is null)
-                return (false, null, finalmask);
-
-            if (udp.Count == 0)
-                root.Remove("udp");
-
-            var cleanedFinalmask = root.Count == 0
-                ? string.Empty
-                : FinalmaskJson.NormalizeForShare(root.ToJsonString());
-
-            return (true, password, cleanedFinalmask);
-        }
 
         private static string? ToTrojanLink(ServerEntry s)
         {

--- a/Services/XrayConfigBuilder.cs
+++ b/Services/XrayConfigBuilder.cs
@@ -416,15 +416,15 @@ namespace XrayUI.Services
         {
             var sni = string.IsNullOrWhiteSpace(server.Sni) ? server.Host : server.Sni;
 
+            // hysteria2 forks the *stream* shape, not the TLS block underneath — no uTLS
+            // fingerprint because it is QUIC, everything else identical to the shared path.
+            var tlsSettings = BuildTlsSettings(server, sni);
+
             var streamSettings = new JsonObject
             {
                 ["network"] = "hysteria",
                 ["security"] = "tls",
-                ["tlsSettings"] = new JsonObject
-                {
-                    ["serverName"] = sni,
-                    ["allowInsecure"] = server.AllowInsecure
-                },
+                ["tlsSettings"] = tlsSettings,
                 ["hysteriaSettings"] = new JsonObject
                 {
                     ["version"] = 2,
@@ -638,6 +638,32 @@ namespace XrayUI.Services
             return array;
         }
 
+        /// <summary>
+        /// The tlsSettings keys that are the same for every TLS outbound. hysteria2 builds its own
+        /// streamSettings because its stream shape differs, but the TLS block underneath is the
+        /// same contract — routing both through here is what stops each new TLS field from having
+        /// to be written twice and drifting. Transport-specific keys (uTLS fingerprint, ECH) are
+        /// added by the caller.
+        /// </summary>
+        private static JsonObject BuildTlsSettings(ServerEntry server, string sni)
+        {
+            var tlsSettings = new JsonObject
+            {
+                ["serverName"] = sni,
+                ["allowInsecure"] = server.AllowInsecure
+            };
+
+            // A node masquerading behind someone else's serverName authenticates by certificate
+            // fingerprint instead of by chain. Protocol-agnostic; REALITY is unaffected because it
+            // authenticates with the x25519 public key and has no tlsSettings at all.
+            if (!string.IsNullOrWhiteSpace(server.PinnedPeerCertSha256))
+            {
+                tlsSettings["pinnedPeerCertSha256"] = server.PinnedPeerCertSha256;
+            }
+
+            return tlsSettings;
+        }
+
         private static JsonObject BuildStreamSettings(ServerEntry server)
         {
             var network = string.IsNullOrWhiteSpace(server.Network)
@@ -662,13 +688,11 @@ namespace XrayUI.Services
                 var sni = !string.IsNullOrWhiteSpace(server.Sni) ? server.Sni
                     : !string.IsNullOrWhiteSpace(hostHeader) ? hostHeader
                     : server.Host;
-                var fingerprint = string.IsNullOrWhiteSpace(server.Fingerprint) ? "chrome" : server.Fingerprint;
-                var tlsSettings = new JsonObject
-                {
-                    ["serverName"] = sni,
-                    ["fingerprint"] = fingerprint,
-                    ["allowInsecure"] = server.AllowInsecure
-                };
+                var tlsSettings = BuildTlsSettings(server, sni);
+                // uTLS fingerprint applies to the TCP-based transports only, so it stays here
+                // rather than in the shared builder that hysteria2 also goes through.
+                tlsSettings["fingerprint"] =
+                    string.IsNullOrWhiteSpace(server.Fingerprint) ? "chrome" : server.Fingerprint;
 
                 if (string.Equals(server.Protocol, "vless", StringComparison.OrdinalIgnoreCase)
                     && !string.IsNullOrWhiteSpace(server.EchConfigList))

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -449,6 +449,9 @@
   <data name="EditServer_AllowInsecure" xml:space="preserve">
     <value>Allow insecure connection (skip certificate verification)</value>
   </data>
+  <data name="EditServer_CertFingerprint" xml:space="preserve">
+    <value>Certificate fingerprint (SHA-256)</value>
+  </data>
   <data name="EditServer_FlowPlaceholder" xml:space="preserve">
     <value>xtls-rprx-vision or leave empty</value>
   </data>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -449,6 +449,9 @@
   <data name="EditServer_AllowInsecure" xml:space="preserve">
     <value>允许不安全连接（跳过证书校验）</value>
   </data>
+  <data name="EditServer_CertFingerprint" xml:space="preserve">
+    <value>证书指纹 (SHA-256)</value>
+  </data>
   <data name="EditServer_FlowPlaceholder" xml:space="preserve">
     <value>xtls-rprx-vision 或留空</value>
   </data>

--- a/XrayUI.Tests/ClashConfigParserTests.cs
+++ b/XrayUI.Tests/ClashConfigParserTests.cs
@@ -160,6 +160,33 @@ namespace XrayUI.Tests
         }
 
         [Fact]
+        public void Parse_Hysteria2PortsAndFingerprint_BuildsUdpHopAndPin()
+        {
+            var yaml = """
+                proxies:
+                  - name: hy2hop
+                    type: hysteria2
+                    server: hy2.example.com
+                    port: 35000
+                    password: pw
+                    ports: 35000-39000
+                    hop-interval: 15-30
+                    fingerprint: 88b874b4
+                    sni: www.apple.com
+                """;
+
+            var node = Assert.Single(ClashConfigParser.Parse(yaml).Nodes);
+
+            Assert.Equal("hysteria2", node.Protocol);
+            // Clash's `fingerprint` is the cert pin, not the uTLS `client-fingerprint`; stored
+            // as given, like the link parser does.
+            Assert.Equal("88b874b4", node.PinnedPeerCertSha256);
+            Assert.Contains("udpHop", node.Finalmask);
+            Assert.Contains("35000-39000", node.Finalmask);
+            Assert.Contains("15-30", node.Finalmask);
+        }
+
+        [Fact]
         public void Parse_Hysteria2Salamander_BuildsFinalmask()
         {
             var yaml = """

--- a/XrayUI.Tests/NodeLinkParserTests.cs
+++ b/XrayUI.Tests/NodeLinkParserTests.cs
@@ -206,6 +206,65 @@ namespace XrayUI.Tests
             Assert.Contains("ob123", s.Finalmask);
         }
 
+        [Fact]
+        public void Parse_Hysteria2WithMportAndPin_BuildsUdpHopAndPin()
+        {
+            // Shape emitted by v2rayN for a port-hopping node behind a masquerading serverName.
+            var link = "hysteria2://87ae2e88-068e-48bc-a785-b98047a308e7@167.234.251.78:35000" +
+                       "?sni=www.apple.com&insecure=0&allowInsecure=0" +
+                       "&pinSHA256=88b874b4cee4f3b6ca00a629b71447c9b8dc9a12056ce6f8cba772fff80b3d02" +
+                       "&mport=35000-39000#hy2";
+
+            var s = NodeLinkParser.Parse(link);
+
+            Assert.NotNull(s);
+            Assert.Equal(35000, s.Port);
+            Assert.False(s.AllowInsecure);
+            Assert.Equal("88b874b4cee4f3b6ca00a629b71447c9b8dc9a12056ce6f8cba772fff80b3d02", s.PinnedPeerCertSha256);
+            Assert.Contains("udpHop", s.Finalmask);
+            Assert.Contains("35000-39000", s.Finalmask);
+        }
+
+        [Fact]
+        public void Parse_Hysteria2PortRangeInAddress_DoesNotDropTheNode()
+        {
+            // hysteria2's native URI puts the hop range in the address. System.Uri rejects that
+            // port outright, which used to make the whole node disappear at import.
+            var s = NodeLinkParser.Parse("hysteria2://pw@hy2.example.com:35000-39000?sni=hy2.example.com#H2");
+
+            Assert.NotNull(s);
+            Assert.Equal("hy2.example.com", s.Host);
+            Assert.Equal(35000, s.Port);
+            Assert.Contains("35000-39000", s.Finalmask);
+        }
+
+        [Theory]
+        // Stored as given. The shipped core accepts hex in either case and strips colons itself,
+        // so rewriting what a link sent would only risk mangling it — separator cleanup belongs
+        // on the hand-entry path in the edit dialog, which is where dirty pastes actually arrive.
+        [InlineData("88b874b4cee4f3b6")]
+        [InlineData("88B874B4CEE4F3B6")]
+        [InlineData("88:b8:74:b4:ce:e4:f3:b6")]
+        public void Parse_Hysteria2Pin_StoredVerbatim(string param)
+        {
+            var s = NodeLinkParser.Parse($"hysteria2://pw@hy2.example.com:443?pinSHA256={param}#H2");
+
+            Assert.NotNull(s);
+            Assert.Equal(param, s.PinnedPeerCertSha256);
+        }
+
+        [Fact]
+        public void Parse_Hysteria2ExplicitFinalmaskHop_WinsOverMport()
+        {
+            // A hand-tuned udpHop in fm= must not be clobbered by the compact mport= form.
+            var fm = Uri.EscapeDataString("""{"quicParams":{"udpHop":{"ports":"40000-41000","interval":"5"}}}""");
+            var s = NodeLinkParser.Parse($"hysteria2://pw@hy2.example.com:443?fm={fm}&mport=35000-39000#H2");
+
+            Assert.NotNull(s);
+            Assert.Contains("40000-41000", s.Finalmask);
+            Assert.DoesNotContain("35000-39000", s.Finalmask);
+        }
+
         // ── Trojan ────────────────────────────────────────────────────────────
 
         [Fact]

--- a/XrayUI.Tests/NodeLinkRoundTripTests.cs
+++ b/XrayUI.Tests/NodeLinkRoundTripTests.cs
@@ -121,6 +121,51 @@ namespace XrayUI.Tests
         }
 
         [Fact]
+        public void RoundTrip_Hysteria2PortHoppingAndPin()
+        {
+            RoundTrip("hysteria2://87ae2e88-068e-48bc-a785-b98047a308e7@167.234.251.78:35000" +
+                      "?sni=www.apple.com" +
+                      "&pinSHA256=88b874b4cee4f3b6ca00a629b71447c9b8dc9a12056ce6f8cba772fff80b3d02" +
+                      "&mport=35000-39000#hy2");
+        }
+
+        [Fact]
+        public void Share_Hysteria2PortHopping_EmitsMportNotFmBlob()
+        {
+            // Folding mport into finalmask is only worth it if it comes back out as mport= —
+            // a v2rayN user pasting our link has to get port hopping, not an opaque fm= blob.
+            var s = NodeLinkParser.Parse("hysteria2://pw@hy2.example.com:35000" +
+                                         "?sni=x.example.com&pinSHA256=88b874b4&mport=35000-39000#H2");
+            Assert.NotNull(s);
+
+            var link = NodeLinkSerializer.ToLink(s);
+
+            Assert.NotNull(link);
+            Assert.Contains("mport=35000-39000", link);
+            Assert.Contains("pinSHA256=88b874b4", link);
+            Assert.DoesNotContain("fm=", link);
+        }
+
+        [Fact]
+        public void RoundTrip_Hysteria2UdpHopWithoutInterval()
+        {
+            // A hand-written hop carrying only ports is NOT what the writer emits, so it must
+            // survive in fm= rather than being collapsed into mport= — collapsing it would make
+            // the re-import invent interval:"30" that the author never wrote.
+            var fm = Uri.EscapeDataString("""{"quicParams":{"udpHop":{"ports":"35000-39000"}}}""");
+            RoundTrip($"hysteria2://pw@hy2.example.com:443?sni=hy2.example.com&fm={fm}#H2");
+        }
+
+        [Fact]
+        public void RoundTrip_Hysteria2NonCanonicalUdpHop()
+        {
+            // A hop interval the parser would never write must survive the share hop: the
+            // serializer has to leave it in fm= instead of collapsing it into mport=.
+            var fm = Uri.EscapeDataString("""{"quicParams":{"congestion":"brutal","udpHop":{"ports":"35000-39000","interval":"5"}}}""");
+            RoundTrip($"hysteria2://pw@hy2.example.com:443?sni=hy2.example.com&fm={fm}#H2");
+        }
+
+        [Fact]
         public void RoundTrip_TrojanGrpc()
         {
             RoundTrip("trojan://pw@t.example.com:443?type=grpc&sni=t.example.com&serviceName=svc#TG");


### PR DESCRIPTION
## Summary

- Port hopping: `mport=` (share links) and Clash's `ports:` fold into `finalmask.quicParams.udpHop`, following the same fold-in/lift-out pattern already used for salamander obfs. Share links round-trip the range back out as `mport=`; a hand-tuned hop the writer wouldn't have produced itself is preserved verbatim in `fm=` instead of being silently rewritten (a `Count == 2 && interval == "30"` shape check, not a loose key-count guess — a looser check would have invented an `interval` value on re-import that the original author never wrote).
- Certificate pinning: new `ServerEntry.PinnedPeerCertSha256` → `tlsSettings.pinnedPeerCertSha256`, wired into the shared `BuildTlsSettings` helper so it applies to every TLS outbound (trojan/vless/vmess), not just hysteria2. Verified against the shipped xray core (`xray.exe run -test`) that the pin validates identically regardless of protocol — a short/malformed pin is rejected by the core's own length check on every protocol tested. Not applicable to REALITY (no `tlsSettings`); the edit dialog clears the field whenever the current config can't produce one, mirroring the existing ECH cleanup rule.
- Fixed a bug where hysteria2's own URI form (`host:35000-39000` port range in the address) threw inside `new Uri()` and silently dropped the whole node on import — no error, the node just never showed up.

## Test plan

- [x] `dotnet test XrayUI.Tests/XrayUI.Tests.csproj -c Release` — 65/65 passing, including round-trip coverage for: mport + pin together, a non-canonical hand-tuned udpHop (interval != "30"), and a hand-written udpHop missing `interval` entirely (regression guard for the fold/lift shape check — confirmed this test fails against a looser `Count`-based check before the fix).
- [x] `dotnet build` (BuildAndRun.ps1) — clean, x64 Debug.
- [x] Manually validated generated config shapes against the shipped `Assets/engine/xray.exe` via `run -test`: hysteria2 with pin + udpHop + brutal congestion, vless+ws+tls with pin, and trojan with pin — all `Configuration OK`; negative controls (truncated pin, short pin) correctly rejected with `incorrect pinnedPeerCertSha256 length`.
- [x] Real-world hysteria2 node with port hopping + pin (reporter's own node) — not verified live, only via `xray -test` config validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)