### PR TITLE
Add subscription usage and bulk refresh

### DIFF
--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -124,6 +124,7 @@ public static class L
     public static string Subscription_AddTooltip         => Loc.GetString("Subscription_AddTooltip");
     public static string Subscription_ManageTooltip      => Loc.GetString("Subscription_ManageTooltip");
     public static string Subscription_Refresh            => Loc.GetString("Subscription_Refresh");
+    public static string Subscription_UpdateAll          => Loc.GetString("Subscription_UpdateAll");
     public static string Subscription_DeleteTooltip      => Loc.GetString("Subscription_DeleteTooltip");
     public static string Subscription_EditTooltip        => Loc.GetString("Subscription_EditTooltip");
     public static string Subscription_NeverUpdated       => Loc.GetString("Subscription_NeverUpdated");

--- a/Models/SubscriptionEntry.cs
+++ b/Models/SubscriptionEntry.cs
@@ -6,6 +6,14 @@ using XrayUI.Helpers;
 
 namespace XrayUI.Models
 {
+    /// <summary>
+    /// Traffic + expiry as reported by a provider's <c>subscription-userinfo</c> response header.
+    /// Kept as one value so the fetch, the model and the edit-rollback path all move the whole set
+    /// instead of enumerating four fields each — the failure mode when they diverge is a figure that
+    /// silently stops persisting.
+    /// </summary>
+    public readonly record struct SubscriptionUserInfo(long? Up, long? Down, long? Total, DateTimeOffset? Expire);
+
     public class SubscriptionEntry : INotifyPropertyChanged
     {
         private string _id = Guid.NewGuid().ToString("N");
@@ -14,6 +22,10 @@ namespace XrayUI.Models
         private DateTimeOffset? _lastUpdated;
         private string? _lastError;
         private bool _isBusy;
+        private long? _upload;
+        private long? _download;
+        private long? _total;
+        private DateTimeOffset? _expire;
 
         public string Id
         {
@@ -75,6 +87,96 @@ namespace XrayUI.Models
 
         [JsonIgnore]
         public string LastErrorText => _lastError ?? string.Empty;
+
+        // Traffic + expiry parsed from the provider's `subscription-userinfo` response header
+        // (bytes / unix-seconds). Optional — many self-built or converter subscriptions omit it,
+        // in which case the card falls back to showing the URL. Persisted so the figures survive
+        // a restart without a re-fetch. The individual properties exist for the JSON round trip;
+        // code holding the whole set assigns Usage instead.
+        public long? Upload
+        {
+            get => _upload;
+            set => Usage = Usage with { Up = value };
+        }
+
+        public long? Download
+        {
+            get => _download;
+            set => Usage = Usage with { Down = value };
+        }
+
+        public long? Total
+        {
+            get => _total;
+            set => Usage = Usage with { Total = value };
+        }
+
+        public DateTimeOffset? Expire
+        {
+            get => _expire;
+            set => Usage = Usage with { Expire = value };
+        }
+
+        /// <summary>
+        /// All four userinfo figures as one value. Assigning writes them together and raises the
+        /// derived notifications once, so the common case — a refresh reporting an unchanged quota —
+        /// costs nothing instead of re-rendering the card four times.
+        /// </summary>
+        [JsonIgnore]
+        public SubscriptionUserInfo Usage
+        {
+            get => new(_upload, _download, _total, _expire);
+            set
+            {
+                if (value == Usage) return;
+
+                (_upload, _download, _total, _expire) = (value.Up, value.Down, value.Total, value.Expire);
+                OnPropertyChanged(nameof(Upload));
+                OnPropertyChanged(nameof(Download));
+                OnPropertyChanged(nameof(Total));
+                OnPropertyChanged(nameof(Expire));
+                OnPropertyChanged(nameof(HasTraffic));
+                OnPropertyChanged(nameof(TrafficText));
+                OnPropertyChanged(nameof(HasExpiry));
+                OnPropertyChanged(nameof(ExpiryText));
+                OnPropertyChanged(nameof(TrafficLineText));
+            }
+        }
+
+        // Traffic requires a known positive quota; total == 0 means "unlimited" and has no bar to show.
+        [JsonIgnore] public bool HasTraffic => _total.HasValue && _total.Value > 0;
+
+        [JsonIgnore]
+        public string TrafficText =>
+            HasTraffic ? $"{FormatBytes((_upload ?? 0) + (_download ?? 0))} / {FormatBytes(_total!.Value)}" : string.Empty;
+
+        [JsonIgnore] public bool HasExpiry => _expire.HasValue;
+
+        [JsonIgnore]
+        public string ExpiryText =>
+            _expire.HasValue ? Loc.Format("Subscription_Expires", _expire.Value.LocalDateTime.ToString("yyyy-MM-dd")) : string.Empty;
+
+        // The card's second line, e.g. "6.21GB / 100GB · Expires 2026-08-01". Composed here rather
+        // than from nested XAML panels because Run.Text is not a dependency property in WinUI, so
+        // the alternative is a StackPanel per fragment with its own visibility binding.
+        [JsonIgnore]
+        public string TrafficLineText => HasExpiry ? $"{TrafficText} · {ExpiryText}" : TrafficText;
+
+        private static readonly string[] ByteUnits = { "B", "KB", "MB", "GB", "TB", "PB" };
+
+        // Human-readable bytes matching the Clash Verge convention: base-1024 units with no space
+        // before the unit, ~3 significant figures (6.21GB, 60.0GB, 341MB, 580KB, 100GB).
+        private static string FormatBytes(long bytes)
+        {
+            if (bytes < 0) bytes = 0;
+            double value = bytes;
+            int unit = 0;
+            while (value >= 1024 && unit < ByteUnits.Length - 1) { value /= 1024; unit++; }
+            string number = value >= 100 ? value.ToString("0")
+                          : value >= 10  ? value.ToString("0.0")
+                          :                value.ToString("0.00");
+            return number + ByteUnits[unit];
+        }
 
         [JsonIgnore]
         public bool IsBusy

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -710,6 +710,18 @@
   <data name="Subscription_LastUpdated" xml:space="preserve">
     <value>Last updated: {0}</value>
   </data>
+  <data name="Subscription_Expires" xml:space="preserve">
+    <value>Expires {0}</value>
+  </data>
+  <data name="Subscription_UpdateAll" xml:space="preserve">
+    <value>Update all</value>
+  </data>
+  <data name="Subscription_UpdatingAll" xml:space="preserve">
+    <value>Updating {0}/{1}…</value>
+  </data>
+  <data name="Subscription_Count" xml:space="preserve">
+    <value>{0} subscriptions</value>
+  </data>
   <data name="ControlPanel_EditPortItem.Text" xml:space="preserve">
     <value>Edit Port</value>
   </data>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -710,6 +710,18 @@
   <data name="Subscription_LastUpdated" xml:space="preserve">
     <value>上次更新: {0}</value>
   </data>
+  <data name="Subscription_Expires" xml:space="preserve">
+    <value>到期 {0}</value>
+  </data>
+  <data name="Subscription_UpdateAll" xml:space="preserve">
+    <value>全部更新</value>
+  </data>
+  <data name="Subscription_UpdatingAll" xml:space="preserve">
+    <value>更新中 {0}/{1}…</value>
+  </data>
+  <data name="Subscription_Count" xml:space="preserve">
+    <value>{0} 个订阅</value>
+  </data>
   <data name="ControlPanel_EditPortItem.Text" xml:space="preserve">
     <value>编辑本地端口</value>
   </data>

--- a/ViewModels/ManageSubscriptionsViewModel.cs
+++ b/ViewModels/ManageSubscriptionsViewModel.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using XrayUI.Helpers;
 using XrayUI.Models;
@@ -10,6 +12,10 @@ namespace XrayUI.ViewModels
 {
     public partial class ManageSubscriptionsViewModel : ObservableObject
     {
+        // Bulk-refresh fan-out. Each subscription costs two requests plus a settings write and a list
+        // rebuild, so this stays low enough to avoid tripping provider rate limits.
+        private const int MaxConcurrentRefresh = 3;
+
         private readonly Func<SubscriptionEntry, Task> _onRefresh;
         private readonly Func<SubscriptionEntry, Task<bool>> _onDelete;
         private readonly Func<SubscriptionEntry, Task> _onEdit;
@@ -48,11 +54,20 @@ namespace XrayUI.ViewModels
         [ObservableProperty]
         public partial string SubscriptionName { get; set; }
 
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(RefreshAllText))]
+        public partial bool IsRefreshingAll { get; set; }
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(RefreshAllText))]
+        public partial int RefreshAllDone { get; set; }
+
         private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             OnPropertyChanged(nameof(HasSubscriptions));
             OnPropertyChanged(nameof(EmptyStateVisibility));
             OnPropertyChanged(nameof(ListVisibility));
+            OnPropertyChanged(nameof(SubscriptionCountText));
         }
 
         public bool HasSubscriptions => Subscriptions.Count > 0;
@@ -67,6 +82,13 @@ namespace XrayUI.ViewModels
         public Visibility EmptyStateVisibility => HasSubscriptions ? Visibility.Collapsed : Visibility.Visible;
         public Visibility ListVisibility       => HasSubscriptions ? Visibility.Visible : Visibility.Collapsed;
 
+        public string SubscriptionCountText => Loc.Format("Subscription_Count", Subscriptions.Count);
+
+        /// <summary>Idle shows the action label; mid-run it doubles as the progress readout.</summary>
+        public string RefreshAllText => IsRefreshingAll
+            ? Loc.Format("Subscription_UpdatingAll", RefreshAllDone, Subscriptions.Count)
+            : L.Subscription_UpdateAll;
+
         public SubscriptionEntry? CreateSubscription()
         {
             var url = SubscriptionUrl.Trim();
@@ -78,16 +100,63 @@ namespace XrayUI.ViewModels
         [RelayCommand]
         private Task RefreshSubscription(SubscriptionEntry sub) => _onRefresh(sub);
 
+        /// <summary>
+        /// Refreshes every subscription, at most <see cref="MaxConcurrentRefresh"/> at a time. Capped
+        /// rather than fully parallel: each refresh issues two requests and ends in a settings/server
+        /// write plus a list rebuild, so an unbounded sweep would spike request count and pile up
+        /// concurrent rebuilds. Individual failures land in that entry's LastError (handled inside the
+        /// refresh callback), so the sweep never aborts early.
+        /// </summary>
+        [RelayCommand]
+        private async Task RefreshAll()
+        {
+            if (IsRefreshingAll || Subscriptions.Count == 0) return;
+
+            IsRefreshingAll = true;
+            RefreshAllDone  = 0;
+            try
+            {
+                using var gate = new SemaphoreSlim(MaxConcurrentRefresh);
+                var tasks = Subscriptions.ToList().Select(async sub =>
+                {
+                    await gate.WaitAsync();
+                    try
+                    {
+                        await _onRefresh(sub);
+                    }
+                    finally
+                    {
+                        gate.Release();
+                        // Continuations resume on the UI thread (no ConfigureAwait above), so the
+                        // tally needs no synchronization of its own.
+                        RefreshAllDone++;
+                    }
+                });
+
+                await Task.WhenAll(tasks);
+            }
+            finally
+            {
+                IsRefreshingAll = false;
+            }
+        }
+
         public async Task CommitEditAsync(SubscriptionEntry sub, string url, string name)
         {
-            var oldUrl  = sub.Url;
-            var oldName = sub.Name;
+            var oldUrl   = sub.Url;
+            var oldName  = sub.Name;
+            var oldUsage = sub.Usage;
             var urlChanged = !string.Equals(sub.Url, url, StringComparison.Ordinal);
             var editSaved = false;
 
             sub.Url  = url;
             sub.Name = ResolveName(name, url);
-            if (urlChanged) sub.LastError = null;
+            if (urlChanged)
+            {
+                // A different link is a different account, so the old quota/expiry no longer describes it.
+                sub.LastError = null;
+                sub.Usage     = default;
+            }
 
             try
             {
@@ -99,8 +168,9 @@ namespace XrayUI.ViewModels
             {
                 if (!editSaved)
                 {
-                    sub.Url  = oldUrl;
-                    sub.Name = oldName;
+                    sub.Url   = oldUrl;
+                    sub.Name  = oldName;
+                    sub.Usage = oldUsage;
                 }
 
                 // Fetch failures are handled inside the refresh callback and land in

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -29,6 +29,14 @@ namespace XrayUI.ViewModels
         private const string UngroupedChipKey      = "__ungrouped__";
         private const string FavoritesChipKey      = "__favorites__";
         private const string SubscriptionUserAgent = "v2rayN/7.22";
+        // Retry UA for providers that only emit a Clash/mihomo YAML config under a Clash-looking UA.
+        // Mimics Clash Verge Rev (a widely-used mihomo-based client); the "clash" substring is what
+        // most backends key on to serve their config — see the zero-hit retry in FetchSubscriptionNodesAsync.
+        private const string ClashUserAgent        = "clash-verge/v2.5.2";
+        // The traffic/expiry probe is best-effort and runs concurrently with the node fetch. Kept under
+        // the client timeout above so a stalled Clash-UA request can't hold an otherwise-finished
+        // refresh spinning — it is headers-only, so it has less to do anyway. See FetchSubscriptionNodesAsync.
+        private static readonly TimeSpan SubscriptionMetaTimeout = TimeSpan.FromSeconds(8);
 
         // Localized labels — looked up lazily so language changes apply at startup.
         private static string AllChipName     => L.ServerList_AllServers;
@@ -41,7 +49,11 @@ namespace XrayUI.ViewModels
 
         private static HttpClient CreateSubscriptionHttpClient()
         {
-            var client = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+            // Covers the whole operation (connect + TLS + body read), not just the response headers.
+            // A subscription body is small enough that anything which will succeed lands well inside
+            // this; past it we would only be delaying the same error, and Update all multiplies the
+            // wait by ceil(count / MaxConcurrentRefresh).
+            var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
             client.DefaultRequestHeaders.UserAgent.ParseAdd(SubscriptionUserAgent);
             return client;
         }
@@ -51,6 +63,7 @@ namespace XrayUI.ViewModels
         private readonly LatencyProbeService _latencyProbe;
         private readonly RealLatencyProbeService _realLatencyProbe;
         private readonly SemaphoreSlim      _settingsWriteLock = new(1, 1);
+        private readonly SemaphoreSlim      _serversWriteLock  = new(1, 1);
         private const int MaxConcurrentProbes = 16;
         private readonly List<ServerEntry> _selectedServers = new();
         private bool _disposed;
@@ -98,6 +111,7 @@ namespace XrayUI.ViewModels
                 server.PropertyChanged -= OnSelectedItemPropertyChanged;
             }
             _settingsWriteLock.Dispose();
+            _serversWriteLock.Dispose();
         }
 
         [ObservableProperty]
@@ -375,7 +389,24 @@ namespace XrayUI.ViewModels
             }
         }
 
-        private Task SaveAsync() => _settings.SaveServersAsync(Servers);
+        // Serializes servers.json writers the way _settingsWriteLock already does for settings.json.
+        // SaveServersAsync snapshots and serializes synchronously, then awaits a temp-write + atomic
+        // File.Replace; two overlapping saves therefore commit in whatever order their writes happen
+        // to finish, and an older snapshot landing last rolls the file back over the newer one. The
+        // wait resumes on the UI thread, so the snapshot is taken by whichever writer holds the lock —
+        // the last commit is always the newest list. Update all made this routine rather than rare.
+        private async Task SaveAsync()
+        {
+            await _serversWriteLock.WaitAsync();
+            try
+            {
+                await _settings.SaveServersAsync(Servers);
+            }
+            finally
+            {
+                _serversWriteLock.Release();
+            }
+        }
 
         public async Task SaveOrderAsync()
         {
@@ -873,16 +904,106 @@ namespace XrayUI.ViewModels
 
         private static async Task<(List<ServerEntry>? entries, string? error)> FetchSubscriptionNodesAsync(SubscriptionEntry sub)
         {
-            string raw;
+            // Kick off the traffic/expiry probe concurrently with the node fetch, headers-only so the
+            // clash config body is never downloaded. Deliberately not deferred until the node fetch
+            // shows no header: measured against real providers, ~95% emit `subscription-userinfo` only
+            // to a Clash-looking UA, which the v2rayN fetch below never sends. Probing lazily would
+            // therefore add a serial round trip to almost every refresh (a + b instead of max(a, b))
+            // to save a request on the rare provider that answers any UA.
+            var metaTask = FetchSubscriptionAsync(sub.Url, ClashUserAgent, headersOnly: true, timeout: SubscriptionMetaTimeout);
+
+            var (raw, mainUsage, error) = await FetchSubscriptionAsync(sub.Url, userAgent: null);
+
+            // Best-effort, and applied even if node parsing fails below. The probe wins when it lands;
+            // the node response is the fallback for the minority of providers that do answer a v2rayN
+            // UA, so a probe that timed out no longer leaves stale figures on the card. A miss on both
+            // keeps the previous figures. A response that *did* carry the header mirrors it exactly, so
+            // a dropped quota/expiry clears — leaving a stale date would keep re-saving it forever.
+            var usage = (await metaTask).usage ?? mainUsage;
+            if (usage is { } u)
+                sub.Usage = u;
+
+            if (raw == null)
+                return (null, error);
+
+            var entries = ParseSubscriptionText(raw);
+
+            if (entries.Count == 0)
+            {
+                // Nothing parsed as a v2rayN link list, and the first response wasn't YAML either.
+                // Many providers do UA-based content negotiation and only emit a Clash/mihomo config
+                // when the request *looks* like Clash, so the v2rayN fetch above never saw that YAML.
+                // Re-fetch once with a Clash UA before giving up. Only reached on a zero-hit first
+                // fetch, so normal link-list subscriptions never pay for this extra request. A network
+                // error on the retry is ignored: the first fetch succeeded, its content was just
+                // unparseable, so the NoParsed error below is the accurate outcome.
+                var (clashRaw, clashUsage, _) = await FetchSubscriptionAsync(sub.Url, ClashUserAgent);
+
+                // Same UA as the probe, so this response carries the header whenever the probe would
+                // have. Worth taking when the probe itself came back empty (typically a timeout).
+                if (usage == null && clashUsage is { } cu)
+                    sub.Usage = cu;
+
+                if (clashRaw != null)
+                    entries = ParseSubscriptionText(clashRaw);
+            }
+
+            if (entries.Count == 0)
+                return (null, L.Subscription_NoParsed);
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                var entry = entries[i];
+                if (string.IsNullOrEmpty(entry.Name))
+                    entry.Name = $"{sub.Name} #{i + 1}";
+                entry.SubscriptionId = sub.Id;
+            }
+
+            return (entries, null);
+        }
+
+        // One subscription request, shared by the node fetch, the Clash-UA retry and the traffic probe.
+        // A null userAgent leaves the request with no UA of its own, so it inherits the shared client's
+        // default v2rayN UA. headersOnly skips the body (raw comes back null) for probes that only want
+        // the `subscription-userinfo` header; timeout overrides the shared client's. Never throws —
+        // failures come back in error, and usage is simply null when the provider didn't send the header.
+        private static async Task<(string? raw, SubscriptionUserInfo? usage, string? error)> FetchSubscriptionAsync(
+            string url, string? userAgent, bool headersOnly = false, TimeSpan? timeout = null)
+        {
             try
             {
-                raw = await Http.GetStringAsync(sub.Url);
+                using var cts = timeout is { } t ? new CancellationTokenSource(t) : null;
+                using var req = new HttpRequestMessage(HttpMethod.Get, url);
+                if (userAgent != null)
+                    req.Headers.UserAgent.ParseAdd(userAgent);
+
+                using var resp = await Http.SendAsync(
+                    req,
+                    headersOnly ? HttpCompletionOption.ResponseHeadersRead : HttpCompletionOption.ResponseContentRead,
+                    cts?.Token ?? CancellationToken.None);
+                resp.EnsureSuccessStatusCode();
+
+                return (headersOnly ? null : await resp.Content.ReadAsStringAsync(), ReadUserInfo(resp), null);
             }
             catch (Exception ex)
             {
-                return (null, ex.Message);
+                return (null, null, ex.Message);
             }
+        }
 
+        // `subscription-userinfo` lands on the response or the content headers depending on the server.
+        // Null when absent, which the caller reads as "no news" rather than "quota cleared".
+        private static SubscriptionUserInfo? ReadUserInfo(HttpResponseMessage resp) =>
+            resp.Headers.TryGetValues("subscription-userinfo", out var values) ||
+            resp.Content.Headers.TryGetValues("subscription-userinfo", out values)
+                ? ParseSubscriptionUserInfo(values.FirstOrDefault())
+                : null;
+
+        // Decodes a subscription body (base64 or plain) and parses it as a v2rayN link list, falling
+        // back to a Clash/Clash.Meta YAML parse only when no line parsed as a share link — so a normal
+        // link-list subscription never pays for a YAML parse attempt.
+        private static List<ServerEntry> ParseSubscriptionText(string raw)
+        {
             var trimmed = raw.Trim();
             var decoded = new byte[trimmed.Length];
             var text = Convert.TryFromBase64String(trimmed, decoded, out var written)
@@ -899,31 +1020,42 @@ namespace XrayUI.ViewModels
 
             if (entries.Count == 0)
             {
-                // Some providers ("universal" subscriptions) serve a Clash/Clash.Meta YAML config
-                // instead of a plain link list. Only attempted when no line parsed as a share link,
-                // so a normal link-list subscription never pays for a YAML parse attempt.
                 try
                 {
                     entries.AddRange(ClashConfigParser.Parse(text).Nodes);
                 }
                 catch
                 {
-                    // Not valid YAML either - falls through to the NoParsed error below.
+                    // Not valid YAML either - caller treats an empty list as "nothing parsed".
                 }
             }
 
-            if (entries.Count == 0)
-                return (null, L.Subscription_NoParsed);
+            return entries;
+        }
 
-            for (int i = 0; i < entries.Count; i++)
+        // Parses `upload=..; download=..; total=..; expire=..` (bytes; expire in unix seconds).
+        private static SubscriptionUserInfo ParseSubscriptionUserInfo(string? value)
+        {
+            long? up = null, down = null, total = null;
+            DateTimeOffset? expire = null;
+            if (string.IsNullOrWhiteSpace(value))
+                return default;
+
+            foreach (var part in value.Split(';'))
             {
-                var entry = entries[i];
-                if (string.IsNullOrEmpty(entry.Name))
-                    entry.Name = $"{sub.Name} #{i + 1}";
-                entry.SubscriptionId = sub.Id;
+                var kv = part.Split('=', 2);
+                if (kv.Length != 2) continue;
+                var key = kv[0].Trim();
+                var val = kv[1].Trim();
+                switch (key)
+                {
+                    case "upload":   if (long.TryParse(val, out var u)) up = u; break;
+                    case "download": if (long.TryParse(val, out var d)) down = d; break;
+                    case "total":    if (long.TryParse(val, out var t)) total = t; break;
+                    case "expire":   if (long.TryParse(val, out var e) && e > 0) expire = DateTimeOffset.FromUnixTimeSeconds(e); break;
+                }
             }
-
-            return (entries, null);
+            return new SubscriptionUserInfo(up, down, total, expire);
         }
 
         private async Task RefreshSubscriptionAsync(SubscriptionEntry sub)
@@ -1142,6 +1274,7 @@ namespace XrayUI.ViewModels
             Url         = sub.Url,
             LastUpdated = sub.LastUpdated,
             LastError   = sub.LastError,
+            Usage       = sub.Usage,
         };
 
         // ── Add manual ────────────────────────────────────────────────────────

--- a/Views/ManageSubscriptionsDialog.xaml
+++ b/Views/ManageSubscriptionsDialog.xaml
@@ -70,9 +70,21 @@
                        Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
         </StackPanel>
 
+        <!-- MaxHeight caps the whole page rather than the list: the Auto/star rows below then
+             subtract the bulk-action row and the spacing themselves, instead of the ScrollView
+             carrying a hand-computed number that goes stale the moment that row changes size. -->
         <Grid Grid.Row="1"
+              RowSpacing="8"
+              MaxHeight="440"
+              VerticalAlignment="Top"
               Visibility="{x:Bind ViewModel.ManagePageVisibility, Mode=OneWay}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
             <TextBlock x:Uid="Subscription_EmptyText"
+                       Grid.Row="1"
                        Text="暂无订阅"
                        HorizontalAlignment="Center"
                        Margin="0,48,0,48"
@@ -80,7 +92,37 @@
                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                        Visibility="{x:Bind ViewModel.EmptyStateVisibility, Mode=OneWay}" />
 
-            <ScrollView MaxHeight="440"
+            <!-- Bulk action row: only meaningful once at least one subscription exists. -->
+            <Grid Grid.Row="0"
+                  ColumnDefinitions="*,Auto"
+                  Padding="2,0"
+                  Visibility="{x:Bind ViewModel.ListVisibility, Mode=OneWay}">
+                <TextBlock Grid.Column="0"
+                           Text="{x:Bind ViewModel.SubscriptionCountText, Mode=OneWay}"
+                           FontSize="13"
+                           VerticalAlignment="Center"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                <Button Grid.Column="1"
+                        AutomationProperties.AutomationId="RefreshAllSubscriptionsButton"
+                        Padding="10,4"
+                        Command="{x:Bind ViewModel.RefreshAllCommand}">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <Grid Width="14" Height="14">
+                            <FontIcon Glyph="&#xE895;"
+                                      FontSize="14"
+                                      Visibility="{x:Bind ViewModel.IsRefreshingAll, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                            <ProgressRing Width="14"
+                                          Height="14"
+                                          IsActive="{x:Bind ViewModel.IsRefreshingAll, Mode=OneWay}"
+                                          Visibility="{x:Bind ViewModel.IsRefreshingAll, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        </Grid>
+                        <TextBlock Text="{x:Bind ViewModel.RefreshAllText, Mode=OneWay}"
+                                   FontSize="13" />
+                    </StackPanel>
+                </Button>
+            </Grid>
+
+            <ScrollView Grid.Row="1"
                         VerticalScrollBarVisibility="Auto"
                         HorizontalScrollBarVisibility="Hidden"
                         Visibility="{x:Bind ViewModel.ListVisibility, Mode=OneWay}">
@@ -102,18 +144,31 @@
                                                    FontSize="14"
                                                    FontWeight="SemiBold"
                                                    TextTrimming="CharacterEllipsis" />
+
+                                        <!-- Second line: traffic, plus expiry after a bullet, when the
+                                             provider returned subscription-userinfo; otherwise falls
+                                             back to the URL below. -->
+                                        <TextBlock Text="{x:Bind TrafficLineText, Mode=OneWay}"
+                                                   FontSize="12"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                   Visibility="{x:Bind HasTraffic, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
                                         <TextBlock Text="{x:Bind Url, Mode=OneWay}"
                                                    FontSize="12"
                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                   TextTrimming="CharacterEllipsis" />
+                                                   TextTrimming="CharacterEllipsis"
+                                                   Visibility="{x:Bind HasTraffic, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+
                                         <TextBlock Text="{x:Bind LastUpdatedText, Mode=OneWay}"
                                                    FontSize="12"
                                                    Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                                                    Visibility="{x:Bind HasError, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                                        <!-- Wraps rather than ellipsizes: a truncated error ("...status
+                                             code does n") tells the user nothing about what broke. -->
                                         <TextBlock Text="{x:Bind LastErrorText, Mode=OneWay}"
                                                    FontSize="12"
                                                    Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                                   TextTrimming="CharacterEllipsis"
+                                                   TextWrapping="Wrap"
                                                    Visibility="{x:Bind HasError, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                     </StackPanel>
 
@@ -160,7 +215,7 @@
                                                       Visibility="{x:Bind IsNotBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                             <ProgressRing Width="16"
                                                           Height="16"
-                                                          IsActive="True"
+                                                          IsActive="{x:Bind IsBusy, Mode=OneWay}"
                                                           Visibility="{x:Bind IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                         </Grid>
                                     </Button>


### PR DESCRIPTION
## Summary

- Parse and persist provider `subscription-userinfo` traffic and expiry metadata.
- Display available usage and expiry in subscription cards, with localized bulk-refresh progress.
- Refresh all subscriptions with bounded concurrency, serialize server saves, and retry zero-result subscriptions with a Clash-compatible user agent.

## Why

Providers often expose quota and expiry only through response headers or require a Clash-compatible user agent. Updating several subscriptions one at a time also made keeping subscription data current unnecessarily tedious.

## User impact

Subscription cards now show traffic usage and expiry when the provider exposes them, and the management dialog offers an Update all action with progress feedback.

## Validation

- `dotnet test XrayUI.Tests\XrayUI.Tests.csproj --no-restore --verbosity minimal` — 65 passed
- `dotnet build XrayUI-dev.csproj --no-restore --configuration Debug --verbosity minimal` — succeeded with 0 warnings and 0 errors