### PR TITLE
Show subscription group and favorite marker in server detail pane

### DIFF
--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -253,6 +253,7 @@ public static class L
     public static string ServerDetail_Failed         => Loc.GetString("ServerDetail_Failed");
     public static string ServerDetail_RetestLatency  => Loc.GetString("ServerDetail_RetestLatency");
     public static string ServerDetail_CopyShareLink  => Loc.GetString("ServerDetail_CopyShareLink");
+    public static string ServerDetail_Favorited      => Loc.GetString("ServerDetail_Favorited");
 
     // ── Import link dialog ────────────────────────────────────────────────
     public static string Import_ParseFailed    => Loc.GetString("Import_ParseFailed");

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -65,6 +65,7 @@ namespace XrayUI.Models
         public string? ColorFallback  { get; set; }
         public bool ShowLatencyInDetails { get; set; } = true;
         public bool ShowAiUnlockInDetails { get; set; } = true;
+        public bool ShowGroupInDetails { get; set; } = true;
         /// <summary>Expand the server-list filter bar when the app starts.</summary>
         public bool OpenServerFilterPanelOnStartup { get; set; } = false;
 

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -836,8 +836,11 @@
   <data name="ServerDetail_HeaderText.Text" xml:space="preserve">
     <value>Server Details</value>
   </data>
-  <data name="ServerDetail_NameLabel.Text" xml:space="preserve">
-    <value>Name</value>
+  <data name="ServerDetail_GroupLabel.Text" xml:space="preserve">
+    <value>Group</value>
+  </data>
+  <data name="ServerDetail_Favorited" xml:space="preserve">
+    <value>In the favorites list</value>
   </data>
   <data name="ServerDetail_ProtocolLabel.Text" xml:space="preserve">
     <value>Protocol</value>
@@ -1009,6 +1012,12 @@
   </data>
   <data name="Personalize_DetailAiUnlockDesc.Text" xml:space="preserve">
     <value>Show AI unlock status on the node card</value>
+  </data>
+  <data name="Personalize_DetailGroup.Text" xml:space="preserve">
+    <value>Group</value>
+  </data>
+  <data name="Personalize_DetailGroupDesc.Text" xml:space="preserve">
+    <value>Show the subscription group on the node card</value>
   </data>
   <data name="Personalize_OpenFilterPanelOnStartup.Text" xml:space="preserve">
     <value>Expand filter bar on startup</value>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -836,8 +836,11 @@
   <data name="ServerDetail_HeaderText.Text" xml:space="preserve">
     <value>服务器详情</value>
   </data>
-  <data name="ServerDetail_NameLabel.Text" xml:space="preserve">
-    <value>名称</value>
+  <data name="ServerDetail_GroupLabel.Text" xml:space="preserve">
+    <value>分组</value>
+  </data>
+  <data name="ServerDetail_Favorited" xml:space="preserve">
+    <value>已加入收藏列表</value>
   </data>
   <data name="ServerDetail_ProtocolLabel.Text" xml:space="preserve">
     <value>协议</value>
@@ -1009,6 +1012,12 @@
   </data>
   <data name="Personalize_DetailAiUnlockDesc.Text" xml:space="preserve">
     <value>节点卡片上展示AI的解锁状态</value>
+  </data>
+  <data name="Personalize_DetailGroup.Text" xml:space="preserve">
+    <value>分组</value>
+  </data>
+  <data name="Personalize_DetailGroupDesc.Text" xml:space="preserve">
+    <value>节点卡片上展示所属订阅分组</value>
   </data>
   <data name="Personalize_OpenFilterPanelOnStartup.Text" xml:space="preserve">
     <value>启动时展开筛选栏</value>

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -92,6 +92,11 @@ namespace XrayUI.ViewModels
             ControlPanel.GetAllServers = () => ServerList.Servers;
             ControlPanel.CanStartSelectedServer = () => ServerList.CanRunSelectedServer;
             ServerDetail.GetAllServers = () => ServerList.Servers;
+            ServerDetail.ResolveGroupName = ServerList.GetGroupDisplayName;
+            ServerDetail.OpenSubscriptions = ServerList.OpenSubscriptionsOnManagePageAsync;
+            // A subscription rename/delete changes the detail pane's group label without touching
+            // the selected node, so property notifications on ServerEntry can't cover it.
+            ServerList.GroupNamesChanged += ServerDetail.RefreshGroupName;
             ServerList.RequestSwitchToSelectedServer = ControlPanel.SwitchToSelectedServerAsync;
             Personalize.IsProxyRunning = () => ControlPanel.IsRunning;
             // Live TUN state for the speed test's egress pin — settings.IsTunMode alone lags
@@ -137,6 +142,7 @@ namespace XrayUI.ViewModels
             Personalize.LoadRegion(s);
             ServerDetail.ShowLatencyInDetails = s.ShowLatencyInDetails;
             ServerDetail.ShowAiUnlockInDetails = s.ShowAiUnlockInDetails;
+            ServerDetail.ShowGroupInDetails = s.ShowGroupInDetails;
             ServerList.IsFilterPanelOpen = s.OpenServerFilterPanelOnStartup;
 
             // Reconcile external state vs persisted setting (external is ground truth)
@@ -315,6 +321,10 @@ namespace XrayUI.ViewModels
             else if (e.PropertyName == nameof(PersonalizeViewModel.ShowAiUnlockInDetails))
             {
                 ServerDetail.ShowAiUnlockInDetails = Personalize.ShowAiUnlockInDetails;
+            }
+            else if (e.PropertyName == nameof(PersonalizeViewModel.ShowGroupInDetails))
+            {
+                ServerDetail.ShowGroupInDetails = Personalize.ShowGroupInDetails;
             }
             else if (e.PropertyName == nameof(PersonalizeViewModel.OpenServerFilterPanelOnStartup))
             {

--- a/ViewModels/ManageSubscriptionsViewModel.cs
+++ b/ViewModels/ManageSubscriptionsViewModel.cs
@@ -72,8 +72,18 @@ namespace XrayUI.ViewModels
 
         public bool HasSubscriptions => Subscriptions.Count > 0;
 
-        public bool IsAddPage => SelectedIndex == 0;
-        public bool IsManagePage => SelectedIndex == 1;
+        // Dialog page indices, in selector order.
+        private const int AddPageIndex    = 0;
+        private const int ManagePageIndex = 1;
+
+        /// <summary>
+        /// Opens the dialog straight on the manage page. For entry points that already name an
+        /// existing subscription (the detail pane's group link) instead of offering to add one.
+        /// </summary>
+        public void ShowManagePage() => SelectedIndex = ManagePageIndex;
+
+        public bool IsAddPage => SelectedIndex == AddPageIndex;
+        public bool IsManagePage => SelectedIndex == ManagePageIndex;
         public bool CanAddSubscription => IsAddPage && !string.IsNullOrWhiteSpace(SubscriptionUrl);
         public string DialogTitle => IsAddPage ? L.Subscription_DialogTitle_Add : L.Subscription_DialogTitle_Manage;
 

--- a/ViewModels/PersonalizeViewModel.cs
+++ b/ViewModels/PersonalizeViewModel.cs
@@ -38,6 +38,7 @@ namespace XrayUI.ViewModels
             _settings = settings;
             ShowLatencyInDetails = true;
             ShowAiUnlockInDetails = true;
+            ShowGroupInDetails = true;
         }
 
         // ── Colors ────────────────────────────────────────────────────────────
@@ -183,24 +184,29 @@ namespace XrayUI.ViewModels
         partial void OnShowAiUnlockInDetailsChanged(bool value) => UpdateDisplaySettingsUnsavedHint();
 
         [ObservableProperty]
+        public partial bool ShowGroupInDetails { get; set; }
+
+        partial void OnShowGroupInDetailsChanged(bool value) => UpdateDisplaySettingsUnsavedHint();
+
+        [ObservableProperty]
         public partial bool OpenServerFilterPanelOnStartup { get; set; }
 
         partial void OnOpenServerFilterPanelOnStartupChanged(bool value) => UpdateDisplaySettingsUnsavedHint();
 
-        /// <summary>True once any of the three display toggles above diverges from the
-        /// last-loaded/last-saved baseline. All three apply live immediately (see
+        /// <summary>True once any of the display toggles above diverges from the
+        /// last-loaded/last-saved baseline. They all apply live immediately (see
         /// MainViewModel's PropertyChanged wiring), but only persist to disk when "完成" is
         /// clicked — same live-now/persist-on-Done split as hotkeys — so this drives an InfoBar
         /// reminder instead of leaving a silent toggle as the only feedback.</summary>
         [ObservableProperty]
         public partial bool ShowDisplaySettingsUnsavedHint { get; set; }
 
-        private (bool Latency, bool AiUnlock, bool FilterPanel)? _displaySettingsBaseline;
+        private (bool Latency, bool AiUnlock, bool Group, bool FilterPanel)? _displaySettingsBaseline;
 
         private void UpdateDisplaySettingsUnsavedHint()
         {
             ShowDisplaySettingsUnsavedHint = _displaySettingsBaseline is { } baseline &&
-                baseline != (ShowLatencyInDetails, ShowAiUnlockInDetails, OpenServerFilterPanelOnStartup);
+                baseline != (ShowLatencyInDetails, ShowAiUnlockInDetails, ShowGroupInDetails, OpenServerFilterPanelOnStartup);
         }
 
         // ── Global hotkeys ────────────────────────────────────────────────────
@@ -325,11 +331,12 @@ namespace XrayUI.ViewModels
             s.BackdropSetting = ThemeHelper.CurrentBackdrop;
             s.ShowLatencyInDetails = ShowLatencyInDetails;
             s.ShowAiUnlockInDetails = ShowAiUnlockInDetails;
+            s.ShowGroupInDetails = ShowGroupInDetails;
             s.OpenServerFilterPanelOnStartup = OpenServerFilterPanelOnStartup;
-            // Re-baseline so the unsaved-changes hint clears now that these three match disk —
+            // Re-baseline so the unsaved-changes hint clears now that these match disk —
             // otherwise reopening Personalize later would show a stale "unsaved" hint for
             // values that were, in fact, already saved here.
-            _displaySettingsBaseline = (ShowLatencyInDetails, ShowAiUnlockInDetails, OpenServerFilterPanelOnStartup);
+            _displaySettingsBaseline = (ShowLatencyInDetails, ShowAiUnlockInDetails, ShowGroupInDetails, OpenServerFilterPanelOnStartup);
             ShowDisplaySettingsUnsavedHint = false;
             // Language and region don't take effect until the next process start, but Done
             // still persists them — otherwise the user would have to click the restart hint
@@ -367,8 +374,9 @@ namespace XrayUI.ViewModels
         {
             ShowLatencyInDetails = settings.ShowLatencyInDetails;
             ShowAiUnlockInDetails = settings.ShowAiUnlockInDetails;
+            ShowGroupInDetails = settings.ShowGroupInDetails;
             OpenServerFilterPanelOnStartup = settings.OpenServerFilterPanelOnStartup;
-            _displaySettingsBaseline = (ShowLatencyInDetails, ShowAiUnlockInDetails, OpenServerFilterPanelOnStartup);
+            _displaySettingsBaseline = (ShowLatencyInDetails, ShowAiUnlockInDetails, ShowGroupInDetails, OpenServerFilterPanelOnStartup);
         }
 
         public void LoadLanguage(AppSettings settings)

--- a/ViewModels/ServerDetailViewModel.cs
+++ b/ViewModels/ServerDetailViewModel.cs
@@ -32,10 +32,17 @@ namespace XrayUI.ViewModels
             LatencyText = L.ServerDetail_NotTested;
             ShowLatencyInDetails = true;
             ShowAiUnlockInDetails = true;
+            ShowGroupInDetails = true;
             ResetAiUnlockDisplay();
         }
 
         public Func<IEnumerable<ServerEntry>> GetAllServers { get; set; } = () => Array.Empty<ServerEntry>();
+
+        /// <summary>
+        /// Resolves a node's group label. Set by MainViewModel so this VM can read the
+        /// subscription list that lives in ServerListViewModel without a back-reference.
+        /// </summary>
+        public Func<ServerEntry?, string> ResolveGroupName { get; set; } = _ => string.Empty;
 
         private ServerEntry? ResolveChainServer(string id)
             => string.IsNullOrEmpty(id) ? null : GetAllServers().FirstOrDefault(s => s.Id == id);
@@ -68,6 +75,60 @@ namespace XrayUI.ViewModels
                 : SelectedServer?.Port.ToString() ?? "-";
 
         public string SelectedProtocol => SelectedServer?.DisplayProtocol ?? "-";
+
+        public string SelectedGroupName => ResolveGroupName(SelectedServer);
+
+        /// <summary>
+        /// Opens subscription management. Set by MainViewModel — same indirection as
+        /// <see cref="GetAllServers"/>, so this VM never references ServerListViewModel.
+        /// </summary>
+        public Func<Task> OpenSubscriptions { get; set; } = () => Task.CompletedTask;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(GroupVisibility))]
+        public partial bool ShowGroupInDetails { get; set; }
+
+        // Only for nodes that actually came from a subscription — the value is a link into
+        // subscription management, and a manually added node has nothing on the other end of it.
+        // Expressed via CanOpenGroup so the row and the link can never disagree.
+        public Visibility GroupVisibility
+            => ShowGroupInDetails && CanOpenGroup ? Visibility.Visible : Visibility.Collapsed;
+
+        public bool CanOpenGroup => !string.IsNullOrEmpty(SelectedServer?.SubscriptionId);
+
+        // Favourite marks the node, not its group, so the star trails the card title. It is an
+        // inline Run rather than a sibling element: a separate FontIcon would need either a fixed
+        // width on the name (killing its wrap) or right-alignment (detaching the star from the
+        // text it marks). Empty string when not favourited — the Run then occupies nothing.
+        // Segoe Fluent Icons FavoriteStarFill, with the separator space baked in so the two
+        // Runs need no significant whitespace between their XAML tags.
+        private const string FavoriteStarFill = " \uE735";
+
+        public string FavoriteGlyph => SelectedServer?.IsFavorite == true ? FavoriteStarFill : string.Empty;
+
+        /// <summary>
+        /// Title text for screen readers. The star is a private-use codepoint that reads as garbage,
+        /// so the favourite state has to be spelled out here instead of inferred from the glyph.
+        /// </summary>
+        public string SelectedNameAutomationText
+            => SelectedServer?.IsFavorite == true
+                ? $"{SelectedName} {L.ServerDetail_Favorited}"
+                : SelectedName;
+
+        [RelayCommand(CanExecute = nameof(CanOpenGroup))]
+        private Task OpenGroup() => OpenSubscriptions();
+
+        /// <summary>
+        /// Re-reads the group label. Needed for edits that change the label without touching the
+        /// selected <see cref="ServerEntry"/> itself — renaming or deleting a subscription.
+        /// </summary>
+        public void RefreshGroupName()
+        {
+            OnPropertyChanged(nameof(SelectedGroupName));
+            OnPropertyChanged(nameof(GroupVisibility));
+            OnPropertyChanged(nameof(CanOpenGroup));
+            OpenGroupCommand.NotifyCanExecuteChanged();
+        }
 
         public string SelectedSecurityLabel
             => (SelectedServer?.Protocol?.ToLowerInvariant()) switch
@@ -215,6 +276,7 @@ namespace XrayUI.ViewModels
             {
                 case nameof(ServerEntry.Name):
                     OnPropertyChanged(nameof(SelectedName));
+                    OnPropertyChanged(nameof(SelectedNameAutomationText));
                     break;
                 case nameof(ServerEntry.Host):
                     OnPropertyChanged(nameof(SelectedHostLabel));
@@ -254,6 +316,13 @@ namespace XrayUI.ViewModels
                 case nameof(ServerEntry.Network):
                     OnPropertyChanged(nameof(SelectedTransport));
                     break;
+                case nameof(ServerEntry.SubscriptionId):
+                    RefreshGroupName();
+                    break;
+                case nameof(ServerEntry.IsFavorite):
+                    OnPropertyChanged(nameof(FavoriteGlyph));
+                    OnPropertyChanged(nameof(SelectedNameAutomationText));
+                    break;
             }
 
             // Any persisted config field can feed NodeLinkSerializer, so refresh the share link
@@ -279,6 +348,9 @@ namespace XrayUI.ViewModels
             OnPropertyChanged(nameof(SelectedPortLabel));
             OnPropertyChanged(nameof(SelectedPort));
             OnPropertyChanged(nameof(SelectedProtocol));
+            OnPropertyChanged(nameof(FavoriteGlyph));
+            OnPropertyChanged(nameof(SelectedNameAutomationText));
+            RefreshGroupName();
             OnPropertyChanged(nameof(SelectedSecurityLabel));
             OnPropertyChanged(nameof(SelectedEncryption));
             OnPropertyChanged(nameof(SelectedTransport));

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -45,6 +45,11 @@ namespace XrayUI.ViewModels
         private static string UnnamedSubLabel => L.ServerList_UnnamedSub;
         private static string OrphanSubLabel  => L.ServerList_OrphanSub;
 
+        // What a subscription is called in the UI. Shared by the filter chips and the detail
+        // pane's group row so the two can't drift apart on the unnamed-subscription fallback.
+        private static string SubscriptionLabel(SubscriptionEntry sub)
+            => string.IsNullOrWhiteSpace(sub.Name) ? UnnamedSubLabel : sub.Name;
+
         private static readonly HttpClient Http = CreateSubscriptionHttpClient();
 
         private static HttpClient CreateSubscriptionHttpClient()
@@ -543,7 +548,7 @@ namespace XrayUI.ViewModels
                 GroupChips.Add(new ServerGroupChip
                 {
                     Kind           = ServerGroupChip.ChipKind.Subscription,
-                    DisplayName    = string.IsNullOrWhiteSpace(sub.Name) ? UnnamedSubLabel : sub.Name,
+                    DisplayName    = SubscriptionLabel(sub),
                     SubscriptionId = sub.Id,
                     Subscription   = sub,
                 });
@@ -584,6 +589,24 @@ namespace XrayUI.ViewModels
 
             OnPropertyChanged(nameof(IsChipBarVisible));
             OnPropertyChanged(nameof(IsFilterBarVisible));
+        }
+
+        /// <summary>
+        /// Display name of the group a node belongs to — the subscription it came from, or the
+        /// ungrouped label for manually added nodes. Shares <see cref="SubscriptionLabel"/> with the
+        /// chips built in <see cref="RebuildGroupChips"/>, and repeats the orphan case, so the detail
+        /// pane and the filter dropdown can't disagree on a node's group. Favorites is not a group:
+        /// it is a cross-cutting flag, so it never appears here.
+        /// </summary>
+        public string GetGroupDisplayName(ServerEntry? server)
+        {
+            if (server is null) return string.Empty;
+            if (string.IsNullOrEmpty(server.SubscriptionId)) return UngroupedName;
+
+            var sub = _knownSubscriptions.FirstOrDefault(s => s.Id == server.SubscriptionId);
+            if (sub is null) return OrphanSubLabel;
+
+            return SubscriptionLabel(sub);
         }
 
         private static string? ChipKey(ServerGroupChip? chip) => chip?.Kind switch
@@ -659,12 +682,20 @@ namespace XrayUI.ViewModels
             _      => 0,
         };
 
+        /// <summary>
+        /// Raised once whenever the known-subscription set changes — added, refreshed, renamed or
+        /// deleted. A rename changes what a node's group is called without touching the node, so
+        /// <see cref="ServerEntry"/> property notifications can't cover it; this is that signal.
+        /// </summary>
+        public event Action? GroupNamesChanged;
+
         private async Task ReloadKnownSubscriptionsAsync()
         {
             var settings = await _settings.LoadSettingsAsync();
             _knownSubscriptions = settings.Subscriptions != null
                 ? new List<SubscriptionEntry>(settings.Subscriptions)
                 : new List<SubscriptionEntry>();
+            GroupNamesChanged?.Invoke();
         }
 
         private void OnSelectedItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -857,7 +888,15 @@ namespace XrayUI.ViewModels
         // ── Subscriptions ─────────────────────────────────────────────────────
 
         [RelayCommand]
-        private async Task OpenSubscriptions()
+        private Task OpenSubscriptions() => ShowSubscriptionsDialogAsync(startOnManagePage: false);
+
+        /// <summary>
+        /// Same dialog, opened straight on the manage page. Used by entry points that name an
+        /// existing subscription (the detail pane's group link) rather than offering to add one.
+        /// </summary>
+        public Task OpenSubscriptionsOnManagePageAsync() => ShowSubscriptionsDialogAsync(startOnManagePage: true);
+
+        private async Task ShowSubscriptionsDialogAsync(bool startOnManagePage)
         {
             var settings = await _settings.LoadSettingsAsync();
             var vm = new ManageSubscriptionsViewModel(
@@ -865,6 +904,9 @@ namespace XrayUI.ViewModels
                 RefreshSubscriptionAsync,
                 DeleteSubscriptionAsync,
                 EditSubscriptionAsync);
+
+            if (startOnManagePage)
+                vm.ShowManagePage();
 
             var sub = await _dialogs.ShowSubscriptionsDialogAsync(vm);
             if (sub == null) return;

--- a/Views/ControlPanelControl.xaml
+++ b/Views/ControlPanelControl.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <UserControl x:Class="XrayUI.Views.ControlPanelControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -9,7 +9,7 @@
              Loaded="UserControl_Loaded"
              Unloaded="UserControl_Unloaded">
 
-    <Grid RowSpacing="10"
+    <Grid RowSpacing="6"
           Margin="8,0,12,0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/Views/PersonalizeControl.xaml
+++ b/Views/PersonalizeControl.xaml
@@ -633,6 +633,27 @@
                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                 </StackPanel>
                             </CheckBox>
+
+                            <Rectangle Height="1"
+                                       Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
+
+                            <!-- Group Display -->
+                            <CheckBox IsChecked="{x:Bind ViewModel.ShowGroupInDetails, Mode=TwoWay}"
+                                      HorizontalAlignment="Stretch"
+                                      HorizontalContentAlignment="Stretch"
+                                      Margin="42,10,16,10">
+                                <StackPanel VerticalAlignment="Center"
+                                            Spacing="2">
+                                    <TextBlock x:Uid="Personalize_DetailGroup"
+                                               Text="分组"
+                                               FontSize="14" />
+                                    <TextBlock x:Uid="Personalize_DetailGroupDesc"
+                                               Text="节点卡片上展示所属订阅分组"
+                                               FontSize="12"
+                                               TextWrapping="Wrap"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                </StackPanel>
+                            </CheckBox>
                         </StackPanel>
                     </Expander>
                 </StackPanel>

--- a/Views/ServerDetailControl.xaml
+++ b/Views/ServerDetailControl.xaml
@@ -6,6 +6,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:controls="using:XrayUI.Controls"
+             xmlns:views="using:XrayUI.Views"
              mc:Ignorable="d"
              d:DesignWidth="500"
              d:DesignHeight="600">
@@ -23,12 +24,14 @@
                    Text="服务器详情"
                    FontSize="20"
                    FontWeight="SemiBold"
-                   Margin="0,0,0,16" />
+                   Margin="0,0,0,12" />
 
-        <StackPanel Orientation="Vertical"
-                    Grid.Row="1"
-                    Padding="0,0,12,40">
-
+        <!-- ScrollView, not StackPanel: a StackPanel measures its child with infinite height, so
+             the card was silently clipped from the bottom whenever it outgrew the row instead of
+             becoming scrollable. No bottom padding — the control panel below brings its own
+             breathing room, and every pixel here is one the card can't use. -->
+        <ScrollView Grid.Row="1"
+                    Padding="0,0,12,0">
 
             <Border
                 Background="{ThemeResource LayerFillColorDefaultBrush}"
@@ -41,6 +44,51 @@
                 <Grid>
                     <StackPanel Orientation="Vertical"
                                 Spacing="12">
+
+                        <!-- Card header. The node name is the card's title, not a labelled field —
+                             a 16px SemiBold string at the top of the card needs no "名称" telling
+                             you what it is, and dropping that label is what lets the group sit
+                             underneath as a subtitle without adding a row to the table below.
+                             Right margin keeps long names clear of the copy button. -->
+                        <StackPanel Spacing="4"
+                                    Margin="0,0,40,0">
+                            <TextBlock FontSize="16"
+                                       FontWeight="SemiBold"
+                                       TextWrapping="WrapWholeWords"
+                                       AutomationProperties.Name="{x:Bind ViewModel.SelectedNameAutomationText, Mode=OneWay}">
+                                <Run Text="{x:Bind ViewModel.SelectedName, Mode=OneWay}" />
+                                <Run Text="{x:Bind ViewModel.FavoriteGlyph, Mode=OneWay}"
+                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                     FontSize="14"
+                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </TextBlock>
+                            <!-- Grid, not a horizontal StackPanel: a StackPanel measures children
+                                 with unbounded width, so the link's TextTrimming would never fire
+                                 and a long subscription name would just run off the card. -->
+                            <Grid ColumnSpacing="6"
+                                  ColumnDefinitions="Auto,*"
+                                  Visibility="{x:Bind ViewModel.GroupVisibility, Mode=OneWay}">
+                                <TextBlock x:Uid="ServerDetail_GroupLabel"
+                                           Text="分组"
+                                           FontSize="12"
+                                           VerticalAlignment="Center"
+                                           Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+                                <HyperlinkButton x:Name="OpenGroupLink"
+                                                 AutomationProperties.AutomationId="OpenGroupLink"
+                                                 Grid.Column="1"
+                                                 Padding="0"
+                                                 MinHeight="0"
+                                                 HorizontalAlignment="Left"
+                                                 HorizontalContentAlignment="Left"
+                                                 VerticalAlignment="Center"
+                                                 Command="{x:Bind ViewModel.OpenGroupCommand}">
+                                    <TextBlock Text="{x:Bind ViewModel.SelectedGroupName, Mode=OneWay}"
+                                               FontSize="12"
+                                               TextWrapping="NoWrap"
+                                               TextTrimming="CharacterEllipsis" />
+                                </HyperlinkButton>
+                            </Grid>
+                        </StackPanel>
 
                         <Grid
                             ColumnSpacing="12"
@@ -55,77 +103,62 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
 
-                            <!-- Row 0: name -->
-                            <TextBlock x:Uid="ServerDetail_NameLabel"
-                                       Text="名称"
+                            <!-- Row 0: protocol -->
+                            <TextBlock x:Uid="ServerDetail_ProtocolLabel"
+                                       Text="协议"
                                        Grid.Row="0"
                                        Grid.Column="0"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        VerticalAlignment="Center" />
                             <TextBlock Grid.Row="0"
                                        Grid.Column="1"
-                                       Text="{x:Bind ViewModel.SelectedName, Mode=OneWay}"
+                                       Text="{x:Bind ViewModel.SelectedProtocol, Mode=OneWay}"
                                        FontSize="16"
-                                       FontWeight="SemiBold"
                                        TextWrapping="WrapWholeWords" />
 
-                            <!-- Row 1: protocol (new) -->
-                            <TextBlock x:Uid="ServerDetail_ProtocolLabel"
-                                       Text="协议"
+                            <!-- Row 1: address -->
+                            <TextBlock Text="{x:Bind ViewModel.SelectedHostLabel, Mode=OneWay}"
                                        Grid.Row="1"
                                        Grid.Column="0"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        VerticalAlignment="Center" />
                             <TextBlock Grid.Row="1"
                                        Grid.Column="1"
-                                       Text="{x:Bind ViewModel.SelectedProtocol, Mode=OneWay}"
+                                       Text="{x:Bind ViewModel.SelectedHost, Mode=OneWay}"
                                        FontSize="16"
                                        TextWrapping="WrapWholeWords" />
 
-                            <!-- Row 2: address -->
-                            <TextBlock Text="{x:Bind ViewModel.SelectedHostLabel, Mode=OneWay}"
+                            <!-- Row 2: port -->
+                            <TextBlock Text="{x:Bind ViewModel.SelectedPortLabel, Mode=OneWay}"
                                        Grid.Row="2"
                                        Grid.Column="0"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        VerticalAlignment="Center" />
                             <TextBlock Grid.Row="2"
                                        Grid.Column="1"
-                                       Text="{x:Bind ViewModel.SelectedHost, Mode=OneWay}"
-                                       FontSize="16"
-                                       TextWrapping="WrapWholeWords" />
+                                       Text="{x:Bind ViewModel.SelectedPort, Mode=OneWay}"
+                                       FontSize="16" />
 
-                            <!-- Row 3: port -->
-                            <TextBlock Text="{x:Bind ViewModel.SelectedPortLabel, Mode=OneWay}"
+                            <!-- Row 3: encryption / security -->
+                            <TextBlock Text="{x:Bind ViewModel.SelectedSecurityLabel, Mode=OneWay}"
                                        Grid.Row="3"
                                        Grid.Column="0"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        VerticalAlignment="Center" />
                             <TextBlock Grid.Row="3"
                                        Grid.Column="1"
-                                       Text="{x:Bind ViewModel.SelectedPort, Mode=OneWay}"
-                                       FontSize="16" />
-
-                            <!-- Row 4: encryption / security -->
-                            <TextBlock Text="{x:Bind ViewModel.SelectedSecurityLabel, Mode=OneWay}"
-                                       Grid.Row="4"
-                                       Grid.Column="0"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                       VerticalAlignment="Center" />
-                            <TextBlock Grid.Row="4"
-                                       Grid.Column="1"
                                        Text="{x:Bind ViewModel.SelectedEncryption, Mode=OneWay}"
                                        FontSize="16" />
                             <TextBlock x:Uid="ServerDetail_TransportLabel"
-                                       Grid.Row="5"
+                                       Grid.Row="4"
                                        Grid.Column="0"
                                        Text="传输"
                                        Visibility="{x:Bind ViewModel.SelectedTransportVisibility, Mode=OneWay}"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        VerticalAlignment="Center" />
-                            <TextBlock Grid.Row="5"
+                            <TextBlock Grid.Row="4"
                                        Grid.Column="1"
                                        Text="{x:Bind ViewModel.SelectedTransport, Mode=OneWay}"
                                        Visibility="{x:Bind ViewModel.SelectedTransportVisibility, Mode=OneWay}"
@@ -134,15 +167,17 @@
 
                         </Grid>
 
-                        <!-- AI service check area -->
-                        <StackPanel Spacing="12"
-                                    Margin="0,2,0,0"
+                        <!-- AI service check area. Spacing is 0 with the gap carried on the label
+                             instead: AIShadowCastGrid is a zero-height shadow receiver, and under
+                             a uniform Spacing it still claimed a full gap for nothing. -->
+                        <StackPanel Margin="{x:Bind views:ServerDetailControl.AiSectionMargin(ViewModel.GroupVisibility), Mode=OneWay}"
                                     Visibility="{x:Bind ViewModel.AiUnlockVisibility, Mode=OneWay}">
                             <Grid x:Name="AIShadowCastGrid" />
                             <TextBlock x:Uid="ServerDetail_AiUnlockLabel"
                                        Text="AI 访问解锁"
                                        FontSize="13"
                                        CharacterSpacing="80"
+                                       Margin="0,0,0,12"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        VerticalAlignment="Center" />
 
@@ -424,6 +459,6 @@
                 </Grid>
             </Border>
 
-        </StackPanel>
+        </ScrollView>
     </Grid>
 </UserControl>

--- a/Views/ServerDetailControl.xaml.cs
+++ b/Views/ServerDetailControl.xaml.cs
@@ -35,6 +35,15 @@ namespace XrayUI.Views
             SetTooltipAndName(CopyShareLinkButton, L.ServerDetail_CopyShareLink);
         }
 
+        // The group subtitle is ~19px tall, so hiding it would leave the card that much shorter and
+        // strand dead space at the bottom of the pane. The gap above the AI section absorbs it:
+        // 16px here restores the pre-group spacing exactly (the 12 + 2 + 12 this section used to
+        // carry before it was tightened to make room for the subtitle).
+        public static Thickness AiSectionMargin(Visibility groupVisibility)
+            => groupVisibility == Visibility.Visible
+                ? new Thickness(0)
+                : new Thickness(0, 16, 0, 0);
+
         private void ShadowRect_Loaded(object sender, RoutedEventArgs e)
         {
             if (_shadowsWired) return;


### PR DESCRIPTION
## Summary
- Detail pane's name row is now a card header (name + inline favorite star), with a "Group" subtitle underneath showing which subscription a node came from — a `HyperlinkButton` for subscription-backed nodes that opens subscription management straight on the manage page.
- New Personalize toggle (`ShowGroupInDetails` / "分组") to hide the group subtitle, alongside the existing latency/AI-unlock toggles.
- `ServerDetailControl`'s root panel changed from `StackPanel` to `ScrollView` so a taller card no longer clips at the bottom of the pane.
- `ManageSubscriptionsViewModel` gained `ShowManagePage()` so the dialog can open directly on the manage page instead of the add page.

## Test plan
- [x] `.\BuildAndRun.ps1` — open a server's detail pane, verify group subtitle shows correct subscription name and links to Manage Subscriptions
- [x] Verify manually-added (non-subscription) nodes show no group row
- [x] Verify favorite star appears/disappears when toggling favorite on a node
- [x] Rename/delete a subscription while its node is selected — confirm the detail pane's group label updates without re-selecting
- [x] Toggle "Group" off/on in Personalize and confirm live effect + persistence after "完成"
- [x] Resize/shrink the window with a long detail card to confirm scrolling instead of clipping
- [x] `dotnet test XrayUI.Tests/XrayUI.Tests.csproj -c Release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)