### PR TITLE
Add per-subscription scheduled auto-refresh

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -522,6 +522,7 @@ namespace XrayUI
 
         private void OnClosed(object sender, WindowEventArgs args)
         {
+            ViewModel.StopSubscriptionRefreshScheduler();
             ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
             _rootElement.ActualThemeChanged -= OnRootElementActualThemeChanged;
             _windowMessageMonitor.WindowMessageReceived -= OnWindowMessageReceived;
@@ -667,6 +668,7 @@ namespace XrayUI
 
         public void StopBackgroundServicesOnExit(bool fastShutdown = false)
         {
+            ViewModel.StopSubscriptionRefreshScheduler();
             ViewModel.ControlPanel.XrayService.StopForShutdown();
             ViewModel.ControlPanel.CleanupTunOnExit(fastShutdown);
         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -347,17 +347,15 @@ namespace XrayUI
                 // and WM_HOTKEY simply never arrives for an id Windows didn't actually register.
                 var (mods, vk) = GlobalHotkeyStore.GetCombo(id);
                 if (vk != 0)
-                    TryRegisterGlobalHotkey(hWnd, id, mods, vk);
+                    RegisterHotkeyOrLog(hWnd, id, mods, vk);
             }
         }
 
-        private static bool TryRegisterGlobalHotkey(IntPtr hWnd, int id, uint modifiers, uint virtualKey)
+        private static void RegisterHotkeyOrLog(IntPtr hWnd, int id, uint modifiers, uint virtualKey)
         {
-            if (HotkeyInterop.RegisterHotKey(hWnd, id, modifiers | GlobalHotkeyStore.ModNoRepeat, virtualKey))
-                return true;
+            if (HotkeyInterop.RegisterHotKey(hWnd, id, modifiers | GlobalHotkeyStore.ModNoRepeat, virtualKey)) return;
 
             Debug.WriteLine($"[Hotkey] Failed to register hotkey id={id} ({modifiers}:{virtualKey}). LastWin32Error={Marshal.GetLastWin32Error()}");
-            return false;
         }
 
         private void CenterOnPrimaryDisplay()

--- a/Models/PresetSettings.cs
+++ b/Models/PresetSettings.cs
@@ -5,7 +5,7 @@ namespace XrayUI.Models
 {
     public class PresetSettings
     {
-        public List<SubscriptionEntry>? Subscriptions { get; set; }
+        public List<SubscriptionPresetEntry>? Subscriptions { get; set; }
         public List<CustomRoutingRule>? CustomRules { get; set; }
         public JsonObject? AdvancedRouting { get; set; }
     }

--- a/Models/SubscriptionEntry.cs
+++ b/Models/SubscriptionEntry.cs
@@ -26,6 +26,8 @@ namespace XrayUI.Models
         private long? _download;
         private long? _total;
         private DateTimeOffset? _expire;
+        private int _autoRefreshIntervalMinutes;
+        private DateTimeOffset? _lastRefreshAttempt;
 
         public string Id
         {
@@ -53,6 +55,7 @@ namespace XrayUI.Models
                 _lastUpdated = value;
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(LastUpdatedText));
+                OnPropertyChanged(nameof(UpdateStatusText));
             }
         }
 
@@ -87,6 +90,67 @@ namespace XrayUI.Models
 
         [JsonIgnore]
         public string LastErrorText => _lastError ?? string.Empty;
+
+        /// <summary>
+        /// Per-subscription automatic refresh interval. Zero disables scheduling; all other values
+        /// are normalized to the fixed choices in <see cref="SubscriptionRefreshSchedule"/>.
+        /// </summary>
+        public int AutoRefreshIntervalMinutes
+        {
+            get => _autoRefreshIntervalMinutes;
+            set
+            {
+                var normalized = SubscriptionRefreshSchedule.NormalizeInterval(value);
+                if (_autoRefreshIntervalMinutes == normalized) return;
+
+                _autoRefreshIntervalMinutes = normalized;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsAutoRefreshEnabled));
+                OnPropertyChanged(nameof(AutoRefreshSummaryText));
+                OnPropertyChanged(nameof(UpdateStatusText));
+            }
+        }
+
+        /// <summary>
+        /// Most recent manual, bulk or scheduled refresh attempt. Failures count so an unavailable
+        /// provider is not hammered every scheduler tick.
+        /// </summary>
+        public DateTimeOffset? LastRefreshAttempt
+        {
+            get => _lastRefreshAttempt;
+            set
+            {
+                if (_lastRefreshAttempt == value) return;
+                _lastRefreshAttempt = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(UpdateStatusText));
+            }
+        }
+
+        [JsonIgnore]
+        public bool IsAutoRefreshEnabled => _autoRefreshIntervalMinutes > 0;
+
+        [JsonIgnore]
+        public string AutoRefreshSummaryText => IsAutoRefreshEnabled
+            ? Loc.Format("Subscription_AutoRefreshSummary", _autoRefreshIntervalMinutes / 60)
+            : string.Empty;
+
+        /// <summary>
+        /// The card's third line. A subscription that refreshes itself shows its cadence instead of
+        /// a "last updated" stamp: with a schedule running and no error, the last success is bounded
+        /// by the interval anyway, so the cadence is the more useful of the two — and it makes the
+        /// scheduled ones scannable down the list without costing a row. An overdue schedule falls
+        /// back to the stamp, which is the one case where the two disagree (app closed for longer
+        /// than the interval); there the honest answer is how old the data actually is.
+        /// Reads the clock, so it is not notification-driven past the three setters that raise it —
+        /// same as <see cref="LastUpdatedText"/>, and fine for a modal that is open briefly.
+        /// </summary>
+        [JsonIgnore]
+        public string UpdateStatusText =>
+            IsAutoRefreshEnabled &&
+            !SubscriptionRefreshSchedule.IsDue(_autoRefreshIntervalMinutes, _lastRefreshAttempt, DateTimeOffset.UtcNow)
+                ? AutoRefreshSummaryText
+                : LastUpdatedText;
 
         // Traffic + expiry parsed from the provider's `subscription-userinfo` response header
         // (bytes / unix-seconds). Optional — many self-built or converter subscriptions omit it,

--- a/Models/SubscriptionPresetEntry.cs
+++ b/Models/SubscriptionPresetEntry.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace XrayUI.Models
+{
+    /// <summary>
+    /// Portable subscription configuration stored in a preset. Runtime state deliberately stays
+    /// in the app's own settings.json: importing a preset must not restore stale update timestamps,
+    /// provider errors, quota figures or an automatic background-refresh policy.
+    /// </summary>
+    public sealed class SubscriptionPresetEntry
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString("N");
+        public string Name { get; set; } = string.Empty;
+        public string Url { get; set; } = string.Empty;
+
+        public static SubscriptionPresetEntry FromSubscription(SubscriptionEntry source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            return new SubscriptionPresetEntry
+            {
+                Id = source.Id,
+                Name = source.Name,
+                Url = source.Url,
+            };
+        }
+
+        public SubscriptionEntry ToSubscription() => new()
+        {
+            Id = Id,
+            Name = Name,
+            Url = Url,
+        };
+    }
+}

--- a/Models/SubscriptionRefreshSchedule.cs
+++ b/Models/SubscriptionRefreshSchedule.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+
+namespace XrayUI.Models
+{
+    /// <summary>
+    /// Pure scheduling policy for subscription refreshes. Keeping the supported intervals and
+    /// due-time calculation here gives the WinUI timer, the edit UI and unit tests one source of
+    /// truth without coupling the policy to a dispatcher or wall-clock service.
+    /// </summary>
+    public static class SubscriptionRefreshSchedule
+    {
+        private static readonly int[] Intervals = [0, 60, 360, 720, 1440];
+
+        public static IReadOnlyList<int> AllowedIntervalsMinutes => Intervals;
+
+        public static int NormalizeInterval(int minutes) =>
+            Array.IndexOf(Intervals, minutes) >= 0 ? minutes : 0;
+
+        // NormalizeInterval always lands on a member of Intervals, so the lookup cannot miss.
+        public static int GetIndex(int minutes) =>
+            Array.IndexOf(Intervals, NormalizeInterval(minutes));
+
+        public static int GetIntervalAt(int index) =>
+            (uint)index < (uint)Intervals.Length ? Intervals[index] : 0;
+
+        /// <summary>
+        /// Expressed through <see cref="GetNextRefreshAt"/> rather than recomputing the boundary,
+        /// so a later policy change (jitter, an exclusive comparison, ...) cannot leave the
+        /// predicate and the displayed time disagreeing.
+        /// </summary>
+        public static bool IsDue(
+            int intervalMinutes,
+            DateTimeOffset? lastRefreshAttempt,
+            DateTimeOffset now) =>
+            GetNextRefreshAt(intervalMinutes, lastRefreshAttempt) is { } next && next <= now;
+
+        /// <summary>The instant <see cref="IsDue"/> starts returning true; null when no schedule
+        /// is enabled or none has been anchored yet.</summary>
+        public static DateTimeOffset? GetNextRefreshAt(
+            int intervalMinutes,
+            DateTimeOffset? lastRefreshAttempt)
+        {
+            var normalized = NormalizeInterval(intervalMinutes);
+            return normalized > 0 && lastRefreshAttempt.HasValue
+                ? lastRefreshAttempt.Value.AddMinutes(normalized)
+                : null;
+        }
+    }
+}

--- a/Services/AppJsonSerializerContext.cs
+++ b/Services/AppJsonSerializerContext.cs
@@ -18,6 +18,8 @@ namespace XrayUI.Services;
 [JsonSerializable(typeof(CustomRoutingRule))]
 [JsonSerializable(typeof(List<SubscriptionEntry>))]
 [JsonSerializable(typeof(SubscriptionEntry))]
+[JsonSerializable(typeof(List<SubscriptionPresetEntry>))]
+[JsonSerializable(typeof(SubscriptionPresetEntry))]
 [JsonSerializable(typeof(PresetSettings))]
 [JsonSerializable(typeof(GhRelease))]
 [JsonSerializable(typeof(GhAsset))]

--- a/Services/InitialImportService.cs
+++ b/Services/InitialImportService.cs
@@ -77,7 +77,9 @@ namespace XrayUI.Services
 
             if (hasSubscriptions && (target.Subscriptions?.Count ?? 0) == 0)
             {
-                target.Subscriptions = preset.Subscriptions!.ToList();
+                target.Subscriptions = preset.Subscriptions!
+                    .Select(subscription => subscription.ToSubscription())
+                    .ToList();
                 changed = true;
             }
 

--- a/Services/PresetExportService.cs
+++ b/Services/PresetExportService.cs
@@ -27,7 +27,9 @@ namespace XrayUI.Services
             var preset = new PresetSettings
             {
                 Subscriptions = settings.Subscriptions is { Count: > 0 }
-                    ? settings.Subscriptions.ToList()
+                    ? settings.Subscriptions
+                        .Select(SubscriptionPresetEntry.FromSubscription)
+                        .ToList()
                     : null,
                 CustomRules = settings.CustomRules is { Count: > 0 }
                     ? settings.CustomRules.ToList()

--- a/Services/PresetImportService.cs
+++ b/Services/PresetImportService.cs
@@ -60,7 +60,9 @@ namespace XrayUI.Services
             var target = await _settings.LoadSettingsAsync().ConfigureAwait(false);
 
             target.Subscriptions = preset.Subscriptions is { Count: > 0 }
-                ? preset.Subscriptions.ToList()
+                ? preset.Subscriptions
+                    .Select(subscription => subscription.ToSubscription())
+                    .ToList()
                 : null;
 
             target.CustomRules = preset.CustomRules is { Count: > 0 }

--- a/Services/SubscriptionRefreshBatchRunner.cs
+++ b/Services/SubscriptionRefreshBatchRunner.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace XrayUI.Services
+{
+    /// <summary>
+    /// Runs subscription refresh callbacks with the same bounded fan-out for manual bulk updates
+    /// and scheduled updates. One item failing never prevents the remaining snapshot from running.
+    /// </summary>
+    public sealed class SubscriptionRefreshBatchRunner : IDisposable
+    {
+        public const int MaxConcurrency = 3;
+        private readonly SemaphoreSlim _gate = new(MaxConcurrency);
+        private bool _disposed;
+
+        /// <remarks>
+        /// <paramref name="progress"/> and <paramref name="onError"/> run on whatever context the
+        /// awaits below resume on — there is no ConfigureAwait here, so that is the caller's
+        /// context. Every current call site starts a batch from the UI thread, which is the only
+        /// reason the progress callback can assign bindable state (and so raise PropertyChanged)
+        /// directly. Call this from a background thread, or add ConfigureAwait(false) below, and
+        /// those callbacks land off-thread — where touching bound state throws
+        /// RPC_E_WRONG_THREAD in the ViewModel, far from the change that caused it. Marshal
+        /// yourself if you need that; this type stays plain net10.0 with no dispatcher dependency
+        /// so it can be source-linked into the test project.
+        /// </remarks>
+        public async Task RunAsync<T>(
+            IEnumerable<T> source,
+            Func<T, Task> refresh,
+            Action<int, int>? progress = null,
+            Func<T, Exception, Task>? onError = null)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(refresh);
+
+            var items = source.ToList();
+            if (items.Count == 0) return;
+
+            var completed = 0;
+            var tasks = items.Select(async item =>
+            {
+                await _gate.WaitAsync();
+                try
+                {
+                    await refresh(item);
+                }
+                catch (Exception ex)
+                {
+                    if (onError is not null)
+                    {
+                        try
+                        {
+                            await onError(item, ex);
+                        }
+                        catch
+                        {
+                            // Error reporting is best-effort. A failed settings write must not
+                            // prevent the rest of the batch from refreshing.
+                        }
+                    }
+                }
+                finally
+                {
+                    _gate.Release();
+                    progress?.Invoke(Interlocked.Increment(ref completed), items.Count);
+                }
+            });
+
+            await Task.WhenAll(tasks);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _gate.Dispose();
+        }
+    }
+}

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -722,6 +722,9 @@
   <data name="Subscription_Count" xml:space="preserve">
     <value>{0} subscriptions</value>
   </data>
+  <data name="Subscription_AutoRefreshSummary" xml:space="preserve">
+    <value>Auto update: every {0}h</value>
+  </data>
   <data name="ControlPanel_EditPortItem.Text" xml:space="preserve">
     <value>Edit Port</value>
   </data>
@@ -1207,6 +1210,24 @@
   </data>
   <data name="Subscription_NameBox.PlaceholderText" xml:space="preserve">
     <value>Leave empty to use link domain</value>
+  </data>
+  <data name="Subscription_AutoRefreshBox.Header" xml:space="preserve">
+    <value>Auto update</value>
+  </data>
+  <data name="Subscription_AutoRefreshOff.Content" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="Subscription_AutoRefresh1Hour.Content" xml:space="preserve">
+    <value>Every 1 hour</value>
+  </data>
+  <data name="Subscription_AutoRefresh6Hours.Content" xml:space="preserve">
+    <value>Every 6 hours</value>
+  </data>
+  <data name="Subscription_AutoRefresh12Hours.Content" xml:space="preserve">
+    <value>Every 12 hours</value>
+  </data>
+  <data name="Subscription_AutoRefresh24Hours.Content" xml:space="preserve">
+    <value>Every 24 hours</value>
   </data>
   <data name="Subscription_AutoImportHintText.Text" xml:space="preserve">
     <value>Auto-parsing and importing subscription nodes.</value>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -722,6 +722,9 @@
   <data name="Subscription_Count" xml:space="preserve">
     <value>{0} 个订阅</value>
   </data>
+  <data name="Subscription_AutoRefreshSummary" xml:space="preserve">
+    <value>自动更新：每 {0} 小时</value>
+  </data>
   <data name="ControlPanel_EditPortItem.Text" xml:space="preserve">
     <value>编辑本地端口</value>
   </data>
@@ -1210,6 +1213,24 @@
   </data>
   <data name="Subscription_NameBox.PlaceholderText" xml:space="preserve">
     <value>留空则使用链接域名</value>
+  </data>
+  <data name="Subscription_AutoRefreshBox.Header" xml:space="preserve">
+    <value>自动更新</value>
+  </data>
+  <data name="Subscription_AutoRefreshOff.Content" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Subscription_AutoRefresh1Hour.Content" xml:space="preserve">
+    <value>每 1 小时</value>
+  </data>
+  <data name="Subscription_AutoRefresh6Hours.Content" xml:space="preserve">
+    <value>每 6 小时</value>
+  </data>
+  <data name="Subscription_AutoRefresh12Hours.Content" xml:space="preserve">
+    <value>每 12 小时</value>
+  </data>
+  <data name="Subscription_AutoRefresh24Hours.Content" xml:space="preserve">
+    <value>每 24 小时</value>
   </data>
   <data name="Subscription_AutoImportHintText.Text" xml:space="preserve">
     <value>将自动解析并导入该订阅中的全部节点</value>

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -105,6 +105,11 @@ namespace XrayUI.ViewModels
             // Live TUN state for the speed test's egress pin — settings.IsTunMode alone lags
             // the UI toggle and can survive a crash as a stale true (see IDialogService remarks).
             realLatencyProbe.IsTunActive = () => ControlPanel.IsRunning && ControlPanel.IsTunMode;
+            // Subscription fetches ride the core's own SOCKS inbound whenever it is running:
+            // IsProxyRunning can't tell manual mode (system proxy untouched) from system-proxy
+            // mode, and a direct fetch on a proxy-only link burns the schedule's whole interval.
+            ServerListViewModel.GetLocalProxyPort =
+                () => ControlPanel.IsRunning ? ControlPanel.LocalPort : (int?)null;
 
             ServerList.PropertyChanged   += OnServerListPropertyChanged;
             ControlPanel.PropertyChanged += OnControlPanelPropertyChanged;

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,7 +1,9 @@
 ﻿using System.ComponentModel;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
 using XrayUI.Helpers;
 using XrayUI.Models;
 using XrayUI.Services;
@@ -13,7 +15,8 @@ namespace XrayUI.ViewModels
         private readonly SettingsService _settings;
         private readonly StartupService _startupService;
         private readonly IUpdateService _updateService;
-        private readonly Microsoft.UI.Dispatching.DispatcherQueue? _uiDispatcher;
+        private readonly DispatcherQueue? _uiDispatcher;
+        private DispatcherQueueTimer? _subscriptionRefreshTimer;
         private bool _updateCheckQueued;
         private ServerEntry? _activeServer;
         private string _activeLatencyText = string.Empty;
@@ -172,10 +175,82 @@ namespace XrayUI.ViewModels
             if (isBootLaunch && s.IsStartupEnabled && s.IsAutoConnect)
                 await TryAutoConnectAsync(s);
 
+            await ServerList.InitializeSubscriptionRefreshSchedulesAsync(DateTimeOffset.UtcNow);
+            StartSubscriptionRefreshScheduler();
+
             // Fire-and-forget background tasks. Failures here must never block
             // startup or surface as dialogs (per the auto-update failure policy).
             _ = Task.Run(() => _updateService.CleanupOldStagingDirs());
             QueueUpdateCheck(CurrentProxyUrl());
+        }
+
+        private void StartSubscriptionRefreshScheduler()
+        {
+            if (_uiDispatcher is null || _subscriptionRefreshTimer is not null) return;
+
+            var timer = _uiDispatcher.CreateTimer();
+            timer.Interval = TimeSpan.FromMinutes(1);
+            timer.IsRepeating = true;
+            timer.Tick += OnSubscriptionRefreshTimerTick;
+            _subscriptionRefreshTimer = timer;
+            timer.Start();
+
+            // Check once at startup so a schedule missed while the app was closed is caught up.
+            // Lands immediately on the boot path, where auto-connect has already run above; on a
+            // manual launch the proxy is still down and the sweep declines (see
+            // RefreshDueSubscriptionsAsync) until the connect below wakes it.
+            _ = RunSubscriptionRefreshCheckAsync();
+        }
+
+        private async void OnSubscriptionRefreshTimerTick(DispatcherQueueTimer sender, object args)
+        {
+            await RunSubscriptionRefreshCheckAsync();
+        }
+
+        /// <summary>
+        /// Fired from three places (startup, the minute timer, and connecting), so calls can overlap;
+        /// re-entrancy is excluded by RefreshDueSubscriptionsAsync, which owns the sweep state. All
+        /// this layer adds is the catch — scheduled refreshes are silent background work, per-entry
+        /// failures are already handled inside the shared batch runner, and anything unexpected must
+        /// stay out of startup and off the UI.
+        /// </summary>
+        private async Task RunSubscriptionRefreshCheckAsync()
+        {
+            try
+            {
+                await ServerList.RefreshDueSubscriptionsAsync(DateTimeOffset.UtcNow);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[Subscriptions] Scheduled refresh check failed: {ex}");
+            }
+        }
+
+        public void StopSubscriptionRefreshScheduler()
+        {
+            var timer = _subscriptionRefreshTimer;
+            _subscriptionRefreshTimer = null;
+            if (timer is null) return;
+
+            void StopTimer()
+            {
+                try
+                {
+                    timer.Stop();
+                    timer.Tick -= OnSubscriptionRefreshTimerTick;
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine(
+                        $"[Subscriptions] Failed to stop refresh timer: {ex.Message}");
+                }
+            }
+
+            if (_uiDispatcher?.HasThreadAccess != false)
+                StopTimer();
+            else
+                _uiDispatcher.TryEnqueue(StopTimer);
         }
 
         private string? CurrentProxyUrl() =>
@@ -374,6 +449,12 @@ namespace XrayUI.ViewModels
 
             if (isRunning && !ControlPanel.IsUpdateAvailable)
                 QueueUpdateCheck(CurrentProxyUrl());
+
+            // Scheduled refreshes stand down while the proxy is down, so connecting is the moment
+            // an overdue subscription becomes fetchable. Without this it would sit until the next
+            // minute tick — a visible lag right after the user connects and opens the list.
+            if (isRunning)
+                _ = RunSubscriptionRefreshCheckAsync();
         }
 
         private void UpdateActiveServer(ServerEntry? server)

--- a/ViewModels/ManageSubscriptionsViewModel.cs
+++ b/ViewModels/ManageSubscriptionsViewModel.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using XrayUI.Helpers;
 using XrayUI.Models;
@@ -12,11 +11,7 @@ namespace XrayUI.ViewModels
 {
     public partial class ManageSubscriptionsViewModel : ObservableObject
     {
-        // Bulk-refresh fan-out. Each subscription costs two requests plus a settings write and a list
-        // rebuild, so this stays low enough to avoid tripping provider rate limits.
-        private const int MaxConcurrentRefresh = 3;
-
-        private readonly Func<SubscriptionEntry, Task> _onRefresh;
+        private readonly Func<IReadOnlyList<SubscriptionEntry>, Action<int, int>?, Task> _onRefreshMany;
         private readonly Func<SubscriptionEntry, Task<bool>> _onDelete;
         private readonly Func<SubscriptionEntry, Task> _onEdit;
 
@@ -24,13 +19,13 @@ namespace XrayUI.ViewModels
 
         public ManageSubscriptionsViewModel(
             IEnumerable<SubscriptionEntry> source,
-            Func<SubscriptionEntry, Task> onRefresh,
+            Func<IReadOnlyList<SubscriptionEntry>, Action<int, int>?, Task> onRefreshMany,
             Func<SubscriptionEntry, Task<bool>> onDelete,
             Func<SubscriptionEntry, Task> onEdit)
         {
-            _onRefresh = onRefresh;
-            _onDelete  = onDelete;
-            _onEdit    = onEdit;
+            _onRefreshMany = onRefreshMany;
+            _onDelete      = onDelete;
+            _onEdit        = onEdit;
 
             Subscriptions = new ObservableCollection<SubscriptionEntry>(source);
             Subscriptions.CollectionChanged += OnCollectionChanged;
@@ -108,14 +103,12 @@ namespace XrayUI.ViewModels
         }
 
         [RelayCommand]
-        private Task RefreshSubscription(SubscriptionEntry sub) => _onRefresh(sub);
+        private Task RefreshSubscription(SubscriptionEntry sub) =>
+            _onRefreshMany([sub], null);
 
         /// <summary>
-        /// Refreshes every subscription, at most <see cref="MaxConcurrentRefresh"/> at a time. Capped
-        /// rather than fully parallel: each refresh issues two requests and ends in a settings/server
-        /// write plus a list rebuild, so an unbounded sweep would spike request count and pile up
-        /// concurrent rebuilds. Individual failures land in that entry's LastError (handled inside the
-        /// refresh callback), so the sweep never aborts early.
+        /// Uses the same bounded batch runner as scheduled refreshes. Individual failures land in
+        /// that entry's LastError, so the sweep never aborts early.
         /// </summary>
         [RelayCommand]
         private async Task RefreshAll()
@@ -126,24 +119,9 @@ namespace XrayUI.ViewModels
             RefreshAllDone  = 0;
             try
             {
-                using var gate = new SemaphoreSlim(MaxConcurrentRefresh);
-                var tasks = Subscriptions.ToList().Select(async sub =>
-                {
-                    await gate.WaitAsync();
-                    try
-                    {
-                        await _onRefresh(sub);
-                    }
-                    finally
-                    {
-                        gate.Release();
-                        // Continuations resume on the UI thread (no ConfigureAwait above), so the
-                        // tally needs no synchronization of its own.
-                        RefreshAllDone++;
-                    }
-                });
-
-                await Task.WhenAll(tasks);
+                await _onRefreshMany(
+                    Subscriptions.ToList(),
+                    (completed, _) => RefreshAllDone = completed);
             }
             finally
             {
@@ -151,16 +129,34 @@ namespace XrayUI.ViewModels
             }
         }
 
-        public async Task CommitEditAsync(SubscriptionEntry sub, string url, string name)
+        public async Task CommitEditAsync(
+            SubscriptionEntry sub,
+            string url,
+            string name,
+            int autoRefreshIntervalMinutes)
         {
-            var oldUrl   = sub.Url;
-            var oldName  = sub.Name;
-            var oldUsage = sub.Usage;
+            var oldUrl                    = sub.Url;
+            var oldName                   = sub.Name;
+            var oldUsage                  = sub.Usage;
+            var oldAutoRefreshInterval    = sub.AutoRefreshIntervalMinutes;
+            var oldLastRefreshAttempt     = sub.LastRefreshAttempt;
+            var normalizedRefreshInterval =
+                SubscriptionRefreshSchedule.NormalizeInterval(autoRefreshIntervalMinutes);
             var urlChanged = !string.Equals(sub.Url, url, StringComparison.Ordinal);
+            var scheduleChanged = oldAutoRefreshInterval != normalizedRefreshInterval;
             var editSaved = false;
 
             sub.Url  = url;
             sub.Name = ResolveName(name, url);
+            if (scheduleChanged)
+            {
+                sub.AutoRefreshIntervalMinutes = normalizedRefreshInterval;
+                // Saving a new schedule starts a fresh interval instead of unexpectedly fetching
+                // immediately. Disabling clears the anchor because there is no next due time.
+                sub.LastRefreshAttempt = normalizedRefreshInterval > 0
+                    ? DateTimeOffset.UtcNow
+                    : null;
+            }
             if (urlChanged)
             {
                 // A different link is a different account, so the old quota/expiry no longer describes it.
@@ -172,7 +168,7 @@ namespace XrayUI.ViewModels
             {
                 await _onEdit(sub);
                 editSaved = true;
-                if (urlChanged) await _onRefresh(sub);
+                if (urlChanged) await _onRefreshMany([sub], null);
             }
             catch (Exception ex)
             {
@@ -181,6 +177,8 @@ namespace XrayUI.ViewModels
                     sub.Url   = oldUrl;
                     sub.Name  = oldName;
                     sub.Usage = oldUsage;
+                    sub.AutoRefreshIntervalMinutes = oldAutoRefreshInterval;
+                    sub.LastRefreshAttempt = oldLastRefreshAttempt;
                 }
 
                 // Fetch failures are handled inside the refresh callback and land in

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -58,9 +59,43 @@ namespace XrayUI.ViewModels
             // A subscription body is small enough that anything which will succeed lands well inside
             // this; past it we would only be delaying the same error, and Update all multiplies the
             // wait by ceil(count / MaxConcurrentRefresh).
-            var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+            var client = new HttpClient(new HttpClientHandler
+            {
+                Proxy = new RunningCoreOrSystemProxy(),
+                UseProxy = true,
+            })
+            { Timeout = TimeSpan.FromSeconds(10) };
             client.DefaultRequestHeaders.UserAgent.ParseAdd(SubscriptionUserAgent);
             return client;
+        }
+
+        /// <summary>Set by MainViewModel: the local SOCKS port while the core is running, null
+        /// otherwise. Static because the shared <see cref="Http"/> client is; wired once at
+        /// composition time.</summary>
+        internal static Func<int?>? GetLocalProxyPort { get; set; }
+
+        /// <summary>
+        /// Routes subscription fetches through the running core's local SOCKS inbound instead of
+        /// trusting the Windows proxy settings. IsProxyRunning only says the core is up: in manual
+        /// mode the system proxy stays untouched, so a default HttpClient would fetch DIRECT, fail
+        /// on proxy-only links, and — because a failed attempt advances the schedule anchor — burn
+        /// the whole interval silently. GetProxy is consulted per request, so start/stop and port
+        /// edits are picked up without rebuilding the client; with the core stopped this falls
+        /// back to the system default, which is what manual refresh always did. The SOCKS inbound
+        /// exists in every mode (TUN only adds its own inbound on top), so the port is always
+        /// live while the core is.
+        /// </summary>
+        private sealed class RunningCoreOrSystemProxy : IWebProxy
+        {
+            public ICredentials? Credentials { get; set; }
+
+            public Uri? GetProxy(Uri destination) =>
+                GetLocalProxyPort?.Invoke() is int port
+                    ? new Uri($"socks5://127.0.0.1:{port}")
+                    : HttpClient.DefaultProxy.GetProxy(destination);
+
+            public bool IsBypassed(Uri host) =>
+                GetLocalProxyPort?.Invoke() is not int && HttpClient.DefaultProxy.IsBypassed(host);
         }
 
         private readonly IDialogService     _dialogs;

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -918,7 +918,7 @@ namespace XrayUI.ViewModels
                     {
                         sub.LastError = Loc.Format("Subscription_UpdateFailed", ex.Message);
                         Debug.WriteLine($"[Subscriptions] Refresh failed for {sub.Id}: {ex}");
-                        if (!IsKnownSubscription(sub.Id)) return;
+                        if (!IsKnownSubscription(sub)) return;
                         try
                         {
                             await UpsertSubscriptionAsync(sub);
@@ -946,7 +946,7 @@ namespace XrayUI.ViewModels
                     // could exhaust them.
                     if (fetchedUrl is not null &&
                         !string.Equals(fetchedUrl, sub.Url, StringComparison.Ordinal) &&
-                        IsKnownSubscription(sub.Id))
+                        IsKnownSubscription(sub))
                         _ = CarryMissedUrlEditAsync(sub);
                 },
                 (completed, _) => progress?.Invoke(skipped + completed, subscriptions.Count));
@@ -970,8 +970,16 @@ namespace XrayUI.ViewModels
             }
         }
 
-        private bool IsKnownSubscription(string id) =>
-            _knownSubscriptions.Any(s => string.Equals(s.Id, id, StringComparison.Ordinal));
+        /// <summary>
+        /// Liveness check for an in-flight refresh: by reference, not id. Every live path shares
+        /// one instance (the dialog binds the entries in <see cref="_knownSubscriptions"/>), so a
+        /// same-id different-instance means the list was rebuilt underneath us — a mid-session
+        /// preset import, whose entries keep their exported ids. The stale object's result must
+        /// be discarded there just like after a delete, or its final upsert would overwrite the
+        /// freshly imported name, URL and cleared refresh schedule.
+        /// </summary>
+        private bool IsKnownSubscription(SubscriptionEntry sub) =>
+            _knownSubscriptions.Any(s => ReferenceEquals(s, sub));
 
         /// <summary>
         /// An enabled schedule without an anchor came from an external/hand-edited settings file.
@@ -1282,10 +1290,11 @@ namespace XrayUI.ViewModels
                     (newEntries, error) = await FetchSubscriptionNodesAsync(sub);
                 }
 
-                // Deleted while the fetch was in flight: applying the result would re-add the
-                // nodes as an orphan group, and the finally's upsert would re-create the
-                // settings entry — the subscription would come back from the dead on restart.
-                if (!IsKnownSubscription(sub.Id)) return urlAtFetch;
+                // Deleted — or replaced wholesale by a mid-session preset import — while the
+                // fetch was in flight: applying the result would re-add the nodes as an orphan
+                // group, and the finally's upsert would re-create (or overwrite) the settings
+                // entry with pre-delete/pre-import state.
+                if (!IsKnownSubscription(sub)) return urlAtFetch;
 
                 if (newEntries == null)
                 {
@@ -1386,7 +1395,7 @@ namespace XrayUI.ViewModels
             {
                 try
                 {
-                    if (IsKnownSubscription(sub.Id))
+                    if (IsKnownSubscription(sub))
                         await UpsertSubscriptionAsync(sub);
                 }
                 finally

--- a/ViewModels/ServerListViewModel.cs
+++ b/ViewModels/ServerListViewModel.cs
@@ -69,6 +69,8 @@ namespace XrayUI.ViewModels
         private readonly RealLatencyProbeService _realLatencyProbe;
         private readonly SemaphoreSlim      _settingsWriteLock = new(1, 1);
         private readonly SemaphoreSlim      _serversWriteLock  = new(1, 1);
+        private readonly SubscriptionRefreshBatchRunner _subscriptionRefreshRunner = new();
+        private readonly HashSet<string> _refreshingSubscriptionIds = new(StringComparer.Ordinal);
         private const int MaxConcurrentProbes = 16;
         private readonly List<ServerEntry> _selectedServers = new();
         private bool _disposed;
@@ -82,6 +84,7 @@ namespace XrayUI.ViewModels
         // bounces SelectedServer, which cancels/restarts the detail pane's latency probe.
         private bool _rebuildAllInProgress;
         private List<SubscriptionEntry> _knownSubscriptions = new();
+        private bool _scheduledRefreshRunning;
 
         public ObservableCollection<ServerGroupChip> GroupChips { get; } = new();
         public ObservableCollection<ServerEntry>     VisibleServers { get; } = new();
@@ -117,6 +120,7 @@ namespace XrayUI.ViewModels
             }
             _settingsWriteLock.Dispose();
             _serversWriteLock.Dispose();
+            _subscriptionRefreshRunner.Dispose();
         }
 
         [ObservableProperty]
@@ -689,15 +693,6 @@ namespace XrayUI.ViewModels
         /// </summary>
         public event Action? GroupNamesChanged;
 
-        private async Task ReloadKnownSubscriptionsAsync()
-        {
-            var settings = await _settings.LoadSettingsAsync();
-            _knownSubscriptions = settings.Subscriptions != null
-                ? new List<SubscriptionEntry>(settings.Subscriptions)
-                : new List<SubscriptionEntry>();
-            GroupNamesChanged?.Invoke();
-        }
-
         private void OnSelectedItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName is nameof(ServerEntry.Protocol)
@@ -890,6 +885,163 @@ namespace XrayUI.ViewModels
 
         // ── Subscriptions ─────────────────────────────────────────────────────
 
+        /// <summary>
+        /// Gives manually-triggered and scheduled batches one bounded fan-out and one error policy.
+        /// The entries are a snapshot so editing or deleting subscriptions while a batch is in
+        /// flight cannot invalidate its enumeration.
+        /// </summary>
+        private async Task RefreshSubscriptionsAsync(
+            IReadOnlyList<SubscriptionEntry> subscriptions,
+            Action<int, int>? progress = null)
+        {
+            var reserved = new List<SubscriptionEntry>(subscriptions.Count);
+            foreach (var sub in subscriptions)
+            {
+                if (_refreshingSubscriptionIds.Add(sub.Id))
+                    reserved.Add(sub);
+            }
+
+            var skipped = subscriptions.Count - reserved.Count;
+            if (skipped > 0)
+                progress?.Invoke(skipped, subscriptions.Count);
+
+            await _subscriptionRefreshRunner.RunAsync(
+                reserved,
+                async sub =>
+                {
+                    string? fetchedUrl = null;
+                    try
+                    {
+                        fetchedUrl = await RefreshSubscriptionAsync(sub);
+                    }
+                    catch (Exception ex)
+                    {
+                        sub.LastError = Loc.Format("Subscription_UpdateFailed", ex.Message);
+                        Debug.WriteLine($"[Subscriptions] Refresh failed for {sub.Id}: {ex}");
+                        if (!IsKnownSubscription(sub.Id)) return;
+                        try
+                        {
+                            await UpsertSubscriptionAsync(sub);
+                        }
+                        catch (Exception persistEx)
+                        {
+                            Debug.WriteLine(
+                                $"[Subscriptions] Failed to persist refresh error for {sub.Id}: {persistEx}");
+                        }
+                    }
+                    finally
+                    {
+                        // Released when THIS entry finishes, not when the whole batch does. A
+                        // batch-wide release would leave an early-finished entry's refresh button
+                        // silently dead until the slowest entry completes — and could strip a
+                        // reservation a newer batch legitimately took for the same id meanwhile.
+                        _refreshingSubscriptionIds.Remove(sub.Id);
+                    }
+
+                    // A URL edit saved after the refetch loop's last look had its own refetch
+                    // swallowed by the reservation just released. Everything from the release
+                    // above to the reserve inside the carry runs synchronously on the UI thread,
+                    // so nothing can steal the id in between. Fire-and-forget: this lambda still
+                    // holds one of the runner's slots, and awaiting a nested batch from here
+                    // could exhaust them.
+                    if (fetchedUrl is not null &&
+                        !string.Equals(fetchedUrl, sub.Url, StringComparison.Ordinal) &&
+                        IsKnownSubscription(sub.Id))
+                        _ = CarryMissedUrlEditAsync(sub);
+                },
+                (completed, _) => progress?.Invoke(skipped + completed, subscriptions.Count));
+        }
+
+        /// <summary>
+        /// Runs the refetch a tail-window URL edit was denied (see the carry comment above).
+        /// The old link's figures are dropped for the same reason CommitEditAsync drops them —
+        /// a different link is a different account.
+        /// </summary>
+        private async Task CarryMissedUrlEditAsync(SubscriptionEntry sub)
+        {
+            try
+            {
+                sub.Usage = default;
+                await RefreshSubscriptionsAsync([sub]);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[Subscriptions] Carry-over refresh failed for {sub.Id}: {ex}");
+            }
+        }
+
+        private bool IsKnownSubscription(string id) =>
+            _knownSubscriptions.Any(s => string.Equals(s.Id, id, StringComparison.Ordinal));
+
+        /// <summary>
+        /// An enabled schedule without an anchor came from an external/hand-edited settings file.
+        /// Anchor it at startup so enabling never causes an unexpected immediate network request.
+        /// </summary>
+        public async Task InitializeSubscriptionRefreshSchedulesAsync(DateTimeOffset now)
+        {
+            // Anchor everything first, then persist: the sweep only ever reads the in-memory
+            // entries, so it must never observe a half-anchored list across the awaits below.
+            var anchored = new List<SubscriptionEntry>();
+            foreach (var sub in _knownSubscriptions)
+            {
+                if (sub.IsAutoRefreshEnabled && !sub.LastRefreshAttempt.HasValue)
+                {
+                    sub.LastRefreshAttempt = now;
+                    anchored.Add(sub);
+                }
+            }
+
+            foreach (var sub in anchored)
+            {
+                try
+                {
+                    await UpsertSubscriptionAsync(sub);
+                }
+                catch (Exception ex)
+                {
+                    // Keep the in-memory anchors so this process still waits a full interval.
+                    Debug.WriteLine($"[Subscriptions] Failed to persist schedule anchor for {sub.Id}: {ex}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called from the UI dispatcher timer. Overlapping sweeps are excluded here; overlap
+        /// between a sweep and a manual refresh of the same entry is excluded one level down, by
+        /// the id reservation in <see cref="RefreshSubscriptionsAsync"/>.
+        /// </summary>
+        /// <remarks>
+        /// Sweeps are skipped while the proxy is down. The fetch goes out through the system proxy,
+        /// and subscription URLs are commonly unreachable without it, so an unproxied sweep mostly
+        /// buys a ten-second timeout — and because a failed attempt still moves the anchor, it would
+        /// spend a whole interval's retry budget on a request that was never going to land. Nothing
+        /// is lost by waiting: the timer keeps ticking, so a schedule that comes due while
+        /// disconnected runs within a minute of the proxy coming up. Manual refresh and Update all
+        /// are unaffected — those are the escape hatch for a subscription URL that resolves direct.
+        /// </remarks>
+        public async Task RefreshDueSubscriptionsAsync(DateTimeOffset now)
+        {
+            if (_disposed || _scheduledRefreshRunning || !IsProxyRunning) return;
+
+            var due = _knownSubscriptions
+                .Where(sub => SubscriptionRefreshSchedule.IsDue(
+                    sub.AutoRefreshIntervalMinutes,
+                    sub.LastRefreshAttempt,
+                    now))
+                .ToList();
+            if (due.Count == 0) return;
+
+            _scheduledRefreshRunning = true;
+            try
+            {
+                await RefreshSubscriptionsAsync(due);
+            }
+            finally
+            {
+                _scheduledRefreshRunning = false;
+            }
+        }
+
         [RelayCommand]
         private Task OpenSubscriptions() => ShowSubscriptionsDialogAsync(startOnManagePage: false);
 
@@ -901,10 +1053,9 @@ namespace XrayUI.ViewModels
 
         private async Task ShowSubscriptionsDialogAsync(bool startOnManagePage)
         {
-            var settings = await _settings.LoadSettingsAsync();
             var vm = new ManageSubscriptionsViewModel(
-                settings.Subscriptions ?? new List<SubscriptionEntry>(),
-                RefreshSubscriptionAsync,
+                _knownSubscriptions,
+                RefreshSubscriptionsAsync,
                 DeleteSubscriptionAsync,
                 EditSubscriptionAsync);
 
@@ -915,6 +1066,7 @@ namespace XrayUI.ViewModels
             if (sub == null) return;
 
             sub.Id = Guid.NewGuid().ToString("N");
+            sub.LastRefreshAttempt = DateTimeOffset.UtcNow;
 
             var (entries, error) = await FetchSubscriptionNodesAsync(sub);
 
@@ -933,7 +1085,8 @@ namespace XrayUI.ViewModels
             }
 
             await UpsertSubscriptionAsync(sub);
-            await ReloadKnownSubscriptionsAsync();
+            TrackKnownSubscription(sub);
+            GroupNamesChanged?.Invoke();
             RebuildAll();
 
             if (entries != null && SelectedServer == null && Servers.Count > 0)
@@ -1103,16 +1256,41 @@ namespace XrayUI.ViewModels
             return new SubscriptionUserInfo(up, down, total, expire);
         }
 
-        private async Task RefreshSubscriptionAsync(SubscriptionEntry sub)
+        /// <summary>Returns the URL whose fetch result this refresh recorded, so the caller can
+        /// detect an edit that landed after the refetch loop's last look — during the apply /
+        /// save / handover / upsert awaits — and schedule the fetch that edit was denied.</summary>
+        private async Task<string> RefreshSubscriptionAsync(SubscriptionEntry sub)
         {
             sub.IsBusy = true;
+            sub.LastRefreshAttempt = DateTimeOffset.UtcNow;
             try
             {
+                var urlAtFetch = sub.Url;
                 var (newEntries, error) = await FetchSubscriptionNodesAsync(sub);
+
+                // An edit can change the URL while the fetch is in flight — the edit's own
+                // refetch is skipped by the id reservation, so this refresh carries it:
+                // refetch until the result matches the URL the entry currently has, instead
+                // of recording the old link's nodes and quota as a fresh fetch of the new one.
+                while (!string.Equals(urlAtFetch, sub.Url, StringComparison.Ordinal))
+                {
+                    urlAtFetch = sub.Url;
+                    // Same policy as CommitEditAsync: a different link is a different account.
+                    // The superseded fetch may have written the old link's userinfo after the
+                    // edit cleared it, and a provider that omits the header must not inherit it.
+                    sub.Usage = default;
+                    (newEntries, error) = await FetchSubscriptionNodesAsync(sub);
+                }
+
+                // Deleted while the fetch was in flight: applying the result would re-add the
+                // nodes as an orphan group, and the finally's upsert would re-create the
+                // settings entry — the subscription would come back from the dead on restart.
+                if (!IsKnownSubscription(sub.Id)) return urlAtFetch;
+
                 if (newEntries == null)
                 {
                     sub.LastError = Loc.Format("Subscription_UpdateFailed", error);
-                    return;
+                    return urlAtFetch;
                 }
 
                 var removed = Servers.Where(s => s.SubscriptionId == sub.Id).ToList();
@@ -1201,11 +1379,23 @@ namespace XrayUI.ViewModels
                         await RequestSwitchToSelectedServer();
                     }
                 }
+
+                return urlAtFetch;
             }
             finally
             {
-                sub.IsBusy = false;
-                await UpsertSubscriptionAsync(sub);
+                try
+                {
+                    if (IsKnownSubscription(sub.Id))
+                        await UpsertSubscriptionAsync(sub);
+                }
+                finally
+                {
+                    // Cleared only after the upsert: the caller releases the id reservation
+                    // synchronously right after this method returns, so the refresh button
+                    // never shows enabled while a click on it would still hit the reservation.
+                    sub.IsBusy = false;
+                }
             }
         }
 
@@ -1238,7 +1428,8 @@ namespace XrayUI.ViewModels
         private async Task EditSubscriptionAsync(SubscriptionEntry sub)
         {
             await UpsertSubscriptionAsync(sub);
-            await ReloadKnownSubscriptionsAsync();
+            TrackKnownSubscription(sub);
+            GroupNamesChanged?.Invoke();
             RebuildAll();
         }
 
@@ -1257,7 +1448,9 @@ namespace XrayUI.ViewModels
             }, rebuild: false);
 
             await RemoveSubscriptionAsync(sub.Id);
-            await ReloadKnownSubscriptionsAsync();
+            _knownSubscriptions.RemoveAll(item =>
+                string.Equals(item.Id, sub.Id, StringComparison.Ordinal));
+            GroupNamesChanged?.Invoke();
             RebuildAll();
 
             if (SelectedServer != null && !Servers.Contains(SelectedServer))
@@ -1312,6 +1505,16 @@ namespace XrayUI.ViewModels
             }
         }
 
+        private void TrackKnownSubscription(SubscriptionEntry sub)
+        {
+            var index = _knownSubscriptions.FindIndex(item =>
+                string.Equals(item.Id, sub.Id, StringComparison.Ordinal));
+            if (index >= 0)
+                _knownSubscriptions[index] = sub;
+            else
+                _knownSubscriptions.Add(sub);
+        }
+
         private static SubscriptionEntry CloneForPersistence(SubscriptionEntry sub) => new()
         {
             Id          = sub.Id,
@@ -1320,6 +1523,8 @@ namespace XrayUI.ViewModels
             LastUpdated = sub.LastUpdated,
             LastError   = sub.LastError,
             Usage       = sub.Usage,
+            AutoRefreshIntervalMinutes = sub.AutoRefreshIntervalMinutes,
+            LastRefreshAttempt = sub.LastRefreshAttempt,
         };
 
         // ── Add manual ────────────────────────────────────────────────────────

--- a/Views/ManageSubscriptionsDialog.xaml
+++ b/Views/ManageSubscriptionsDialog.xaml
@@ -135,7 +135,7 @@
                                     BorderThickness="1"
                                     Padding="12,10"
                                     Margin="0,0,0,8">
-                                <Grid ColumnDefinitions="*,Auto,Auto,Auto"
+                                <Grid ColumnDefinitions="*,Auto,Auto"
                                       ColumnSpacing="4">
                                     <StackPanel Grid.Column="0"
                                                 Spacing="2"
@@ -159,12 +159,54 @@
                                                    TextTrimming="CharacterEllipsis"
                                                    Visibility="{x:Bind HasTraffic, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
 
-                                        <TextBlock Text="{x:Bind LastUpdatedText, Mode=OneWay}"
-                                                   FontSize="12"
-                                                   Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                                                   Visibility="{x:Bind HasError, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
-                                        <!-- Wraps rather than ellipsizes: a truncated error ("...status
-                                             code does n") tells the user nothing about what broke. -->
+                                        <!-- Third line: update status, with this subscription's own
+                                             refresh next to it — the action belongs to the freshness
+                                             it changes, unlike edit/delete which are card-scoped.
+                                             The status line stays put when a refresh fails, with the
+                                             error underneath rather than replacing it: retry has to
+                                             stay reachable exactly then, the button needs the text
+                                             beside it to sit against, and "the copy you have is 20
+                                             minutes old" is the other half of what a failure means. -->
+                                        <StackPanel Orientation="Horizontal"
+                                                    Spacing="4">
+                                            <TextBlock Text="{x:Bind UpdateStatusText, Mode=OneWay}"
+                                                       FontSize="12"
+                                                       VerticalAlignment="Center"
+                                                       Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+
+                                            <!-- The glyph keeps the inherited (primary) foreground the
+                                                 other card buttons use — graying it down to tertiary is
+                                                 what made an earlier attempt read as washed out. -->
+                                            <Button Padding="4"
+                                                    VerticalAlignment="Center"
+                                                    Background="Transparent"
+                                                    BorderThickness="0"
+                                                    IsEnabled="{x:Bind IsNotBusy, Mode=OneWay}"
+                                                    Loaded="RefreshButton_Loaded"
+                                                    Click="RefreshButton_Click">
+                                                <Grid>
+                                                    <FontIcon Glyph="&#xEDAB;"
+                                                              FontSize="12"
+                                                              Visibility="{x:Bind IsNotBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                                    <!-- MinWidth/MinHeight beat the default style's 16x16
+                                                         minimums, which would otherwise clamp the ring and
+                                                         make the button grow while busy. -->
+                                                    <ProgressRing Width="12"
+                                                                  Height="12"
+                                                                  MinWidth="12"
+                                                                  MinHeight="12"
+                                                                  IsActive="{x:Bind IsBusy, Mode=OneWay}"
+                                                                  Visibility="{x:Bind IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                                </Grid>
+                                            </Button>
+                                        </StackPanel>
+
+                                        <!-- A sibling of the status line rather than a cell beside it:
+                                             the enclosing vertical StackPanel hands its children the
+                                             real available width, which is what lets this wrap at all.
+                                             Wraps rather than ellipsizes because a truncated error
+                                             ("...status code does n") tells the user nothing about what
+                                             broke. -->
                                         <TextBlock Text="{x:Bind LastErrorText, Mode=OneWay}"
                                                    FontSize="12"
                                                    Foreground="{ThemeResource SystemFillColorCriticalBrush}"
@@ -192,6 +234,21 @@
                                                     <TextBox x:Uid="Subscription_NameBox"
                                                              Header="备注名称（可选）"
                                                              PlaceholderText="留空则使用链接域名" />
+                                                    <ComboBox x:Uid="Subscription_AutoRefreshBox"
+                                                              Header="自动更新"
+                                                              SelectedIndex="0"
+                                                              HorizontalAlignment="Stretch">
+                                                        <ComboBoxItem x:Uid="Subscription_AutoRefreshOff"
+                                                                      Content="关闭" />
+                                                        <ComboBoxItem x:Uid="Subscription_AutoRefresh1Hour"
+                                                                      Content="每 1 小时" />
+                                                        <ComboBoxItem x:Uid="Subscription_AutoRefresh6Hours"
+                                                                      Content="每 6 小时" />
+                                                        <ComboBoxItem x:Uid="Subscription_AutoRefresh12Hours"
+                                                                      Content="每 12 小时" />
+                                                        <ComboBoxItem x:Uid="Subscription_AutoRefresh24Hours"
+                                                                      Content="每 24 小时" />
+                                                    </ComboBox>
                                                     <Button x:Uid="Subscription_SaveBtn"
                                                             Click="ConfirmEdit_Click"
                                                             Style="{StaticResource AccentButtonStyle}"
@@ -207,23 +264,6 @@
                                             Background="Transparent"
                                             BorderThickness="0"
                                             IsEnabled="{x:Bind IsNotBusy, Mode=OneWay}"
-                                            Loaded="RefreshButton_Loaded"
-                                            Click="RefreshButton_Click">
-                                        <Grid Width="16" Height="16">
-                                            <FontIcon Glyph="&#xE895;"
-                                                      FontSize="14"
-                                                      Visibility="{x:Bind IsNotBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                            <ProgressRing Width="16"
-                                                          Height="16"
-                                                          IsActive="{x:Bind IsBusy, Mode=OneWay}"
-                                                          Visibility="{x:Bind IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                        </Grid>
-                                    </Button>
-
-                                    <Button Grid.Column="3"
-                                            Padding="6"
-                                            Background="Transparent"
-                                            BorderThickness="0"
                                             Loaded="DeleteButton_Loaded">
                                         <FontIcon Glyph="&#xE74D;" FontSize="14" />
                                         <Button.Flyout>

--- a/Views/ManageSubscriptionsDialog.xaml.cs
+++ b/Views/ManageSubscriptionsDialog.xaml.cs
@@ -1,11 +1,11 @@
-using Microsoft.UI.Xaml.Controls.Primitives;
+﻿using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using XrayUI.Helpers;
 using XrayUI.Models;
 
 namespace XrayUI.Views
 {
-    public sealed partial class ManageSubscriptionsDialog : UserControl
+    public sealed partial class ManageSubscriptionsDialog
     {
         public ManageSubscriptionsViewModel ViewModel { get; }
 

--- a/Views/ManageSubscriptionsDialog.xaml.cs
+++ b/Views/ManageSubscriptionsDialog.xaml.cs
@@ -33,13 +33,18 @@ namespace XrayUI.Views
         // The edit flyout lives inside a DataTemplate, so x:Name would not generate
         // code-behind fields; the controls are located by position instead. This is the
         // single place that knows the StackPanel layout: [0] URL box, [1] name box,
-        // last child = save button.
-        private static (TextBox? UrlBox, TextBox? NameBox, Button? SaveButton) GetEditControls(StackPanel panel)
+        // [2] refresh schedule, last child = save button.
+        private static (
+            TextBox? UrlBox,
+            TextBox? NameBox,
+            ComboBox? ScheduleBox,
+            Button? SaveButton) GetEditControls(StackPanel panel)
         {
             var children = panel.Children;
             return (
                 children.Count > 0 ? children[0] as TextBox : null,
                 children.Count > 1 ? children[1] as TextBox : null,
+                children.Count > 2 ? children[2] as ComboBox : null,
                 children.Count > 0 ? children[children.Count - 1] as Button : null);
         }
 
@@ -51,16 +56,19 @@ namespace XrayUI.Views
 
             panel.Tag = flyout;
 
-            var (urlBox, nameBox, _) = GetEditControls(panel);
+            var (urlBox, nameBox, scheduleBox, _) = GetEditControls(panel);
             if (urlBox != null) urlBox.Text = sub.Url;
             if (nameBox != null) nameBox.Text = sub.Name;
+            if (scheduleBox != null)
+                scheduleBox.SelectedIndex =
+                    SubscriptionRefreshSchedule.GetIndex(sub.AutoRefreshIntervalMinutes);
         }
 
         private void EditUrlBox_TextChanged(object sender, TextChangedEventArgs e)
         {
             if (sender is not TextBox { Parent: StackPanel panel } box) return;
 
-            var (_, _, saveBtn) = GetEditControls(panel);
+            var (_, _, _, saveBtn) = GetEditControls(panel);
             if (saveBtn != null)
                 saveBtn.IsEnabled = !string.IsNullOrWhiteSpace(box.Text);
         }
@@ -70,14 +78,18 @@ namespace XrayUI.Views
             if (sender is not Button { DataContext: SubscriptionEntry sub, Parent: StackPanel panel } btn)
                 return;
 
-            var (urlBox, nameBox, _) = GetEditControls(panel);
-            if (urlBox == null || nameBox == null) return;
+            var (urlBox, nameBox, scheduleBox, _) = GetEditControls(panel);
+            if (urlBox == null || nameBox == null || scheduleBox == null) return;
 
             var url = urlBox.Text.Trim();
             if (url.Length == 0) return;
 
             HideAncestorFlyout(btn);
-            await ViewModel.CommitEditAsync(sub, url, nameBox.Text);
+            await ViewModel.CommitEditAsync(
+                sub,
+                url,
+                nameBox.Text,
+                SubscriptionRefreshSchedule.GetIntervalAt(scheduleBox.SelectedIndex));
         }
 
         private void DeleteButton_Loaded(object sender, RoutedEventArgs e)

--- a/XrayUI.Tests/LocalizationStubs.cs
+++ b/XrayUI.Tests/LocalizationStubs.cs
@@ -7,6 +7,8 @@ namespace XrayUI.Helpers
     public static class L
     {
         public static string ServerDetail_Timeout => "Timeout";
+        public static string Subscription_NeverUpdated => "Never updated";
+        public static string Subscription_JustNow => "Just now";
     }
 
     public static class Loc

--- a/XrayUI.Tests/SubscriptionPresetEntryTests.cs
+++ b/XrayUI.Tests/SubscriptionPresetEntryTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using XrayUI.Models;
+
+namespace XrayUI.Tests
+{
+    public class SubscriptionPresetEntryTests
+    {
+        [Fact]
+        public void ExportCopy_ContainsOnlyPortableSubscriptionConfiguration()
+        {
+            var source = new SubscriptionEntry
+            {
+                Id = "subscription-id",
+                Name = "Provider",
+                Url = "https://example.com/sub",
+                LastUpdated = new DateTimeOffset(2026, 7, 26, 10, 0, 0, TimeSpan.Zero),
+                LastError = "stale provider error",
+                Usage = new SubscriptionUserInfo(
+                    Up: 1,
+                    Down: 2,
+                    Total: 3,
+                    Expire: new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero)),
+                AutoRefreshIntervalMinutes = 360,
+                LastRefreshAttempt = new DateTimeOffset(2026, 7, 26, 11, 0, 0, TimeSpan.Zero),
+            };
+
+            var presetEntry = SubscriptionPresetEntry.FromSubscription(source);
+            var json = JsonSerializer.Serialize(presetEntry);
+
+            Assert.Equal("subscription-id", presetEntry.Id);
+            Assert.Equal("Provider", presetEntry.Name);
+            Assert.Equal("https://example.com/sub", presetEntry.Url);
+            Assert.DoesNotContain(nameof(SubscriptionEntry.LastUpdated), json);
+            Assert.DoesNotContain(nameof(SubscriptionEntry.LastError), json);
+            Assert.DoesNotContain(nameof(SubscriptionEntry.Upload), json);
+            Assert.DoesNotContain(nameof(SubscriptionEntry.Download), json);
+            Assert.DoesNotContain(nameof(SubscriptionEntry.Total), json);
+            Assert.DoesNotContain(nameof(SubscriptionEntry.Expire), json);
+            Assert.DoesNotContain(nameof(SubscriptionEntry.AutoRefreshIntervalMinutes), json);
+            Assert.DoesNotContain(nameof(SubscriptionEntry.LastRefreshAttempt), json);
+        }
+
+        [Fact]
+        public void Import_IgnoresRuntimeFieldsFromOlderPreset()
+        {
+            var presetEntry = JsonSerializer.Deserialize<SubscriptionPresetEntry>(
+                """
+                {
+                  "Id": "legacy-id",
+                  "Name": "Legacy provider",
+                  "Url": "https://example.com/legacy",
+                  "LastUpdated": "2026-07-26T10:00:00+00:00",
+                  "LastError": "old error",
+                  "Upload": 10,
+                  "Download": 20,
+                  "Total": 30,
+                  "Expire": "2026-08-01T00:00:00+00:00",
+                  "AutoRefreshIntervalMinutes": 60,
+                  "LastRefreshAttempt": "2026-07-26T11:00:00+00:00"
+                }
+                """);
+
+            Assert.NotNull(presetEntry);
+
+            var imported = presetEntry.ToSubscription();
+
+            Assert.Equal("legacy-id", imported.Id);
+            Assert.Equal("Legacy provider", imported.Name);
+            Assert.Equal("https://example.com/legacy", imported.Url);
+            Assert.Null(imported.LastUpdated);
+            Assert.Null(imported.LastError);
+            Assert.Equal(default, imported.Usage);
+            Assert.Equal(0, imported.AutoRefreshIntervalMinutes);
+            Assert.Null(imported.LastRefreshAttempt);
+        }
+    }
+}

--- a/XrayUI.Tests/SubscriptionRefreshBatchRunnerTests.cs
+++ b/XrayUI.Tests/SubscriptionRefreshBatchRunnerTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Concurrent;
+using XrayUI.Services;
+
+namespace XrayUI.Tests
+{
+    public class SubscriptionRefreshBatchRunnerTests
+    {
+        [Fact]
+        public async Task RunAsync_CapsConcurrentRefreshesAtThree()
+        {
+            using var runner = new SubscriptionRefreshBatchRunner();
+            var active = 0;
+            var maxActive = 0;
+            var stateLock = new object();
+
+            Task RunRange(int start) =>
+                runner.RunAsync(
+                    Enumerable.Range(start, 6),
+                    async _ =>
+                    {
+                        lock (stateLock)
+                        {
+                            active++;
+                            maxActive = Math.Max(maxActive, active);
+                        }
+
+                        await Task.Delay(20);
+
+                        lock (stateLock)
+                        {
+                            active--;
+                        }
+                    });
+
+            await Task.WhenAll(RunRange(0), RunRange(100));
+
+            Assert.Equal(SubscriptionRefreshBatchRunner.MaxConcurrency, maxActive);
+            Assert.Equal(0, active);
+        }
+
+        [Fact]
+        public async Task RunAsync_IsolatesFailuresAndCompletesProgress()
+        {
+            using var runner = new SubscriptionRefreshBatchRunner();
+            var attempted = new ConcurrentBag<int>();
+            var failed = new ConcurrentBag<int>();
+            var progress = new ConcurrentBag<(int Completed, int Total)>();
+
+            await runner.RunAsync(
+                Enumerable.Range(0, 5),
+                item =>
+                {
+                    attempted.Add(item);
+                    return item == 2
+                        ? Task.FromException(new InvalidOperationException("provider failed"))
+                        : Task.CompletedTask;
+                },
+                (completed, total) => progress.Add((completed, total)),
+                (item, _) =>
+                {
+                    failed.Add(item);
+                    return Task.CompletedTask;
+                });
+
+            Assert.Equal(Enumerable.Range(0, 5), attempted.Order());
+            Assert.Equal(new[] { 2 }, failed.Order());
+            Assert.Equal(5, progress.Count);
+            Assert.Contains((5, 5), progress);
+        }
+
+        [Fact]
+        public async Task RunAsync_EmptyBatchDoesNothing()
+        {
+            using var runner = new SubscriptionRefreshBatchRunner();
+            var refreshCalled = false;
+            var progressCalled = false;
+
+            await runner.RunAsync(
+                Array.Empty<int>(),
+                _ =>
+                {
+                    refreshCalled = true;
+                    return Task.CompletedTask;
+                },
+                (_, _) => progressCalled = true);
+
+            Assert.False(refreshCalled);
+            Assert.False(progressCalled);
+        }
+    }
+}

--- a/XrayUI.Tests/SubscriptionRefreshScheduleTests.cs
+++ b/XrayUI.Tests/SubscriptionRefreshScheduleTests.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using XrayUI.Models;
+
+namespace XrayUI.Tests
+{
+    public class SubscriptionRefreshScheduleTests
+    {
+        public static TheoryData<int> EnabledIntervals => new()
+        {
+            60,
+            360,
+            720,
+            1440,
+        };
+
+        [Fact]
+        public void AllowedIntervals_AreExactlyTheSupportedChoices()
+        {
+            Assert.Equal(
+                new[] { 0, 60, 360, 720, 1440 },
+                SubscriptionRefreshSchedule.AllowedIntervalsMinutes);
+            Assert.Equal(0, SubscriptionRefreshSchedule.NormalizeInterval(30));
+            Assert.Equal(0, SubscriptionRefreshSchedule.GetIntervalAt(-1));
+            Assert.Equal(0, SubscriptionRefreshSchedule.GetIntervalAt(99));
+        }
+
+        [Theory]
+        [MemberData(nameof(EnabledIntervals))]
+        public void IsDue_UsesTheConfiguredBoundary(int intervalMinutes)
+        {
+            var lastAttempt = new DateTimeOffset(2026, 7, 26, 0, 0, 0, TimeSpan.Zero);
+            var dueAt = lastAttempt.AddMinutes(intervalMinutes);
+
+            Assert.False(SubscriptionRefreshSchedule.IsDue(
+                intervalMinutes, lastAttempt, dueAt.AddTicks(-1)));
+            Assert.True(SubscriptionRefreshSchedule.IsDue(
+                intervalMinutes, lastAttempt, dueAt));
+            Assert.Equal(
+                dueAt,
+                SubscriptionRefreshSchedule.GetNextRefreshAt(intervalMinutes, lastAttempt));
+        }
+
+        [Fact]
+        public void DisabledOrUnanchoredSchedule_IsNotDue()
+        {
+            var now = DateTimeOffset.UtcNow;
+
+            Assert.False(SubscriptionRefreshSchedule.IsDue(0, now.AddDays(-2), now));
+            Assert.False(SubscriptionRefreshSchedule.IsDue(60, null, now));
+            Assert.Null(SubscriptionRefreshSchedule.GetNextRefreshAt(0, now));
+            Assert.Null(SubscriptionRefreshSchedule.GetNextRefreshAt(60, null));
+        }
+
+        [Fact]
+        public void NewAttemptAnchor_DefersTheNextRunAfterManualRefreshOrFailure()
+        {
+            var priorAttempt = new DateTimeOffset(2026, 7, 26, 0, 0, 0, TimeSpan.Zero);
+            var now = priorAttempt.AddHours(7);
+
+            Assert.True(SubscriptionRefreshSchedule.IsDue(360, priorAttempt, now));
+            Assert.False(SubscriptionRefreshSchedule.IsDue(360, now, now));
+            Assert.True(SubscriptionRefreshSchedule.IsDue(360, now, now.AddHours(6)));
+        }
+
+        [Fact]
+        public void MissingFieldsFromOldJson_DefaultToDisabled()
+        {
+            var entry = JsonSerializer.Deserialize<SubscriptionEntry>(
+                """{"Name":"Legacy","Url":"https://example.com/sub"}""");
+
+            Assert.NotNull(entry);
+            Assert.Equal(0, entry.AutoRefreshIntervalMinutes);
+            Assert.Null(entry.LastRefreshAttempt);
+            Assert.False(entry.IsAutoRefreshEnabled);
+        }
+
+        [Fact]
+        public void ScheduleFields_RoundTripThroughJson()
+        {
+            var attemptedAt = new DateTimeOffset(2026, 7, 26, 12, 34, 56, TimeSpan.Zero);
+            var original = new SubscriptionEntry
+            {
+                Name = "Scheduled",
+                Url = "https://example.com/sub",
+                AutoRefreshIntervalMinutes = 720,
+                LastRefreshAttempt = attemptedAt,
+            };
+
+            var json = JsonSerializer.Serialize(original);
+            var restored = JsonSerializer.Deserialize<SubscriptionEntry>(json);
+
+            Assert.NotNull(restored);
+            Assert.Equal(720, restored.AutoRefreshIntervalMinutes);
+            Assert.Equal(attemptedAt, restored.LastRefreshAttempt);
+            Assert.True(restored.IsAutoRefreshEnabled);
+        }
+    }
+}

--- a/XrayUI.Tests/XrayUI.Tests.csproj
+++ b/XrayUI.Tests/XrayUI.Tests.csproj
@@ -28,6 +28,9 @@
          LocalizationStubs.cs) or keep the new dependency out of parser-layer
          code. -->
     <Compile Include="..\Models\ServerEntry.cs" Link="Prod\Models\ServerEntry.cs" />
+    <Compile Include="..\Models\SubscriptionEntry.cs" Link="Prod\Models\SubscriptionEntry.cs" />
+    <Compile Include="..\Models\SubscriptionPresetEntry.cs" Link="Prod\Models\SubscriptionPresetEntry.cs" />
+    <Compile Include="..\Models\SubscriptionRefreshSchedule.cs" Link="Prod\Models\SubscriptionRefreshSchedule.cs" />
     <Compile Include="..\Services\NodeLinkParser.cs" Link="Prod\Services\NodeLinkParser.cs" />
     <Compile Include="..\Services\NodeLinkSerializer.cs" Link="Prod\Services\NodeLinkSerializer.cs" />
     <Compile Include="..\Services\ClashConfigParser.cs" Link="Prod\Services\ClashConfigParser.cs" />
@@ -36,6 +39,7 @@
     <Compile Include="..\Services\XhttpSettings.cs" Link="Prod\Services\XhttpSettings.cs" />
     <Compile Include="..\Services\EchSettings.cs" Link="Prod\Services\EchSettings.cs" />
     <Compile Include="..\Services\FinalmaskJson.cs" Link="Prod\Services\FinalmaskJson.cs" />
+    <Compile Include="..\Services\SubscriptionRefreshBatchRunner.cs" Link="Prod\Services\SubscriptionRefreshBatchRunner.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What

Each subscription can now refresh itself on a fixed cadence — off / every 1 / 6 / 12 / 24 hours, configured per subscription in the edit flyout. A 1-minute `DispatcherQueueTimer` sweeps for due schedules; the card's third line shows the cadence ("Auto update: every 6h") while a schedule is on track and falls back to the last-updated stamp when overdue.

## How it works

- **`SubscriptionRefreshSchedule`** — pure scheduling policy (allowed intervals, normalization, due calculation). No dispatcher, no I/O, source-linked into the test project.
- **`SubscriptionRefreshBatchRunner`** — one bounded 3-wide fan-out shared by manual *Update all* and scheduled sweeps, with a single error policy. Also source-linked and unit-tested.
- **Anchor semantics** — `LastRefreshAttempt` moves on every attempt (manual, bulk, scheduled, failed), so an unavailable provider is retried once per interval, not every tick. Saving a new cadence starts a fresh interval instead of fetching immediately; an enabled-but-unanchored entry from a hand-edited settings file is anchored at startup.
- **Proxy-down policy** — sweeps stand down while the proxy is down (subscription URLs are usually unreachable direct, and a doomed attempt would burn the interval's retry) and run the moment it connects. Manual refresh stays available as the escape hatch.
- **Presets** — subscriptions in presets are now a trimmed `SubscriptionPresetEntry` (id/name/url only): importing a preset can no longer restore stale timestamps, provider errors, quota figures, or a background-refresh policy.

## Hardening (two adversarial review passes)

Background refreshes can now overlap user actions in the manage dialog, so the following races were found and closed:

- **Delete vs in-flight refresh** — a refresh completing after its subscription was deleted used to re-add the nodes as an orphan group and resurrect the settings entry on restart. Liveness checks before node-apply and before every upsert now discard the result instead.
- **URL edit vs in-flight refresh** — an edit landing mid-fetch is refetched in place (dropping the old account's userinfo so a header-less provider cannot inherit it); an edit landing in the apply/persist tail is detected after the id reservation is released and carried by a follow-up refresh. The new URL is never silently skipped.
- **Reservation lifetime** — refresh reservations release per entry, not per batch, and `IsBusy` clears only after the final upsert — an enabled refresh button can never hit a still-held reservation.
- **Busy-state layout** — the inline ProgressRing pins `MinWidth/MinHeight` so the default style's 16×16 minimums cannot grow the button (and shift the card) while refreshing.

Follow-ups from the Codex review comments:

- **Preset import vs in-flight refresh** — the liveness check is by reference, not id: a mid-session preset import rebuilds the subscription list with new instances that keep their exported ids, and an id-only check let a stale in-flight refresh overwrite the freshly imported entry.
- **Fetch routing** — subscription fetches go through the running core's own SOCKS inbound (`socks5://127.0.0.1:<port>`, consulted per request) instead of trusting the Windows proxy settings, falling back to the system default when the core is stopped. In manual mode (core running, system proxy untouched) the scheduled path used to fetch direct, fail on proxy-only links, and silently burn the schedule's interval.

## Reviewer notes

- Tests: 79/79 (schedule policy, batch runner, preset DTO round-trips, legacy-JSON defaults).
- Existing `settings.json` files without the new fields deserialize with auto-refresh off — no migration needed.
- Known cosmetic non-issues left as-is: the *Update all* ring's ~1px default-style clamp (pre-existing), and a transient "5/4" progress label if a subscription is deleted mid-*Update all*.

