### PR TITLE
Extract shared file helpers and stop settings loss on a failed load

### DIFF
--- a/Helpers/AtomicFile.cs
+++ b/Helpers/AtomicFile.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace XrayUI.Helpers
+{
+    /// <summary>
+    /// Write-to-temp + atomic swap. A crash or power cut mid-save can never leave a truncated
+    /// file — the previous complete one survives until the replace commits. The temp name is
+    /// per-call (Guid-suffixed) so concurrent saves of the same path never write over each
+    /// other's temp file or race on the replace.
+    /// </summary>
+    public static class AtomicFile
+    {
+        public static async Task WriteAllTextAsync(string path, string contents)
+        {
+            var tmp = $"{path}.{Guid.NewGuid():N}.tmp";
+            try
+            {
+                await File.WriteAllTextAsync(tmp, contents).ConfigureAwait(false);
+
+                if (File.Exists(path))
+                    File.Replace(tmp, path, destinationBackupFileName: null, ignoreMetadataErrors: true);
+                else
+                    File.Move(tmp, path);
+            }
+            catch
+            {
+                try { File.Delete(tmp); } catch { }
+                throw;
+            }
+        }
+    }
+}

--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -105,6 +105,10 @@ public static class L
     public static string Error_UpdateFailed        => Loc.GetString("Error_UpdateFailed");
     public static string Error_UpdaterLaunchFailed => Loc.GetString("Error_UpdaterLaunchFailed");
 
+    // settings.json failed to parse. Not profile-specific: Personalize shows it too.
+    public static string Settings_InvalidTitle => Loc.GetString("Settings_InvalidTitle");
+    public static string Settings_InvalidMsg   => Loc.GetString("Settings_InvalidMsg");
+
     // ── Startup / Update / TUN ─────────────────────────────────────────────
     public static string Startup_SetFailed => Loc.GetString("Startup_SetFailed");
     public static string Update_Updating   => Loc.GetString("Update_Updating");

--- a/Helpers/ModalWindowHelper.cs
+++ b/Helpers/ModalWindowHelper.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.UI;
+using Microsoft.UI.Windowing;
+
+namespace XrayUI.Helpers
+{
+    /// <summary>
+    /// Turns a secondary <see cref="Window"/> into a modal dialog owned by another window.
+    ///
+    /// Extracted because the sequence is order-dependent in ways nothing in the API signals, and
+    /// getting it wrong fails silently — the window opens, just not modal. Every tool window in
+    /// the app needs the identical dance, so it lives here rather than being copied with its
+    /// explanatory comments into each one.
+    /// </summary>
+    public static class ModalWindowHelper
+    {
+        private const int GWLP_HWNDPARENT = -8;
+
+        [DllImport("User32.dll", CharSet = CharSet.Auto, EntryPoint = "SetWindowLongPtr")]
+        private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+        [DllImport("User32.dll", CharSet = CharSet.Auto, EntryPoint = "SetWindowLong")]
+        private static extern IntPtr SetWindowLong(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+        /// <summary>
+        /// Makes <paramref name="window"/> a modal dialog owned by <paramref name="owner"/> and
+        /// shows it. Call after InitializeComponent and after the theme/backdrop are applied.
+        /// </summary>
+        public static void ShowAsOwnedModal(this Window window, Window owner)
+        {
+            var presenter = OverlappedPresenter.CreateForDialog();
+
+            // 1. Set the Win32 owner BEFORE IsModal — IsModal requires an owner.
+            SetWindowOwner(window, owner);
+
+            // 2. Mark the presenter modal, then commit it to the AppWindow.
+            presenter.IsModal = true;
+            window.AppWindow.SetPresenter(presenter);
+
+            // 3. Show via AppWindow.Show() to apply the modal presenter at the OS level.
+            //    Window.Activate() doesn't reliably re-apply IsModal once the window
+            //    has any prior presenter state.
+            window.AppWindow.Show();
+        }
+
+        private static void SetWindowOwner(Window window, Window owner)
+        {
+            var ownerHwnd = WinRT.Interop.WindowNative.GetWindowHandle(owner);
+            var ownedHwnd = Win32Interop.GetWindowFromWindowId(window.AppWindow.Id);
+
+            if (IntPtr.Size == 8)
+                SetWindowLongPtr(ownedHwnd, GWLP_HWNDPARENT, ownerHwnd);
+            else
+                SetWindowLong(ownedHwnd, GWLP_HWNDPARENT, ownerHwnd);
+        }
+    }
+}

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -1,11 +1,28 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using XrayUI.Services;
 
 namespace XrayUI.Models
 {
     public class AppSettings
     {
+        /// <summary>
+        /// Marks the throwaway defaults <see cref="XrayUI.Services.SettingsService.LoadSettingsAsync"/>
+        /// hands back when settings.json cannot be read or parsed. SaveSettingsAsync refuses to
+        /// persist an instance carrying it, because writing these defaults is the data loss.
+        ///
+        /// Provenance has to travel on the instance, not on the service: a caller can hold one of
+        /// these across seconds of awaits (the start sequence spans the wintun preflight and the
+        /// xray launch), and a service-level flag would already have been cleared by any
+        /// successful load in that window — including the one that follows the user repairing the
+        /// file by hand. The stale defaults would then overwrite the repair.
+        ///
+        /// Never serialized, so it cannot survive a round-trip and mislabel good data.
+        /// </summary>
+        [JsonIgnore]
+        internal bool IsFailedLoadFallback { get; init; }
+
         public int LocalMixedPort { get; set; } = 16890;
         /// <summary>When true, the local socks/http inbound listens on 0.0.0.0 instead of
         /// 127.0.0.1 so other devices on the LAN can use this machine as a proxy.</summary>

--- a/Services/PresetImportService.cs
+++ b/Services/PresetImportService.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json.Nodes;
@@ -58,6 +58,17 @@ namespace XrayUI.Services
                 "PresetImport").ConfigureAwait(false);
 
             var target = await _settings.LoadSettingsAsync().ConfigureAwait(false);
+
+            if (target.IsFailedLoadFallback)
+            {
+                // Restoring a preset means "reset to the distributed state", and an unreadable
+                // settings.json is precisely the situation it is meant to rescue — so this is the
+                // one path that must stay able to write. The instance handed back by a failed load
+                // is refused by SaveSettingsAsync, so rebuild on clean defaults instead: whatever
+                // the broken file held could not be read back anyway, and silently reporting a
+                // successful import that wrote nothing is the worse outcome.
+                target = new AppSettings();
+            }
 
             target.Subscriptions = preset.Subscriptions is { Count: > 0 }
                 ? preset.Subscriptions

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -67,7 +67,12 @@ namespace XrayUI.Services
                 }
 
                 var json = await File.ReadAllTextAsync(SettingsFile).ConfigureAwait(false);
-                _cachedSettings = JsonSerializer.Deserialize(json, AppJsonSerializerContext.Default.AppSettings) ?? new AppSettings();
+                // A literal "null" body deserializes to null without throwing. Treat it as a
+                // failed load rather than an empty one, or the next save writes defaults over it.
+                var loaded = JsonSerializer.Deserialize(json, AppJsonSerializerContext.Default.AppSettings)
+                             ?? throw new JsonException("settings.json deserialized to null.");
+
+                _cachedSettings = loaded;
 
                 // One-time migration: settings.json written before XrayLogLevel existed only has
                 // the legacy VerboseXrayLog bool. Populate the new field so every other reader
@@ -78,7 +83,10 @@ namespace XrayUI.Services
             catch (Exception ex)
             {
                 Debug.WriteLine($"[SettingsService] Failed to load settings: {ex.Message}");
-                return new AppSettings();
+                // Deliberately not cached: the next call retries the file, so a hand-repair takes
+                // effect without a restart. The instance is stamped so SaveSettingsAsync refuses
+                // it no matter how much later the caller gets around to saving.
+                return new AppSettings { IsFailedLoadFallback = true };
             }
         }
 
@@ -103,11 +111,27 @@ namespace XrayUI.Services
             return "cn";
         }
 
-        public async Task SaveSettingsAsync(AppSettings settings)
+        /// <summary>
+        /// Persists <paramref name="settings"/>. Returns false — without writing — when the
+        /// instance came from a failed load (see <see cref="AppSettings.IsFailedLoadFallback"/>);
+        /// callers that report success to the user, or act on the save having happened, must check
+        /// it. Throws on I/O failure, as before.
+        /// </summary>
+        public async Task<bool> SaveSettingsAsync(AppSettings settings)
         {
+            if (settings.IsFailedLoadFallback)
+            {
+                // Defaults handed out for an unreadable settings.json: writing them back is the
+                // data loss, not the fix. Why the check rides the instance rather than a flag on
+                // this service is argued in full on AppSettings.IsFailedLoadFallback.
+                Debug.WriteLine("[SettingsService] Save refused: settings came from a failed load.");
+                return false;
+            }
+
             _cachedSettings = settings;
             var json = JsonSerializer.Serialize(settings, AppJsonSerializerContext.Readable<AppSettings>());
             await AtomicFile.WriteAllTextAsync(SettingsFile, json).ConfigureAwait(false);
+            return true;
         }
 
         // ── Server list ───────────────────────────────────────────────────────

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -107,7 +107,7 @@ namespace XrayUI.Services
         {
             _cachedSettings = settings;
             var json = JsonSerializer.Serialize(settings, AppJsonSerializerContext.Readable<AppSettings>());
-            await WriteAtomicAsync(SettingsFile, json).ConfigureAwait(false);
+            await AtomicFile.WriteAllTextAsync(SettingsFile, json).ConfigureAwait(false);
         }
 
         // ── Server list ───────────────────────────────────────────────────────
@@ -141,31 +141,7 @@ namespace XrayUI.Services
         {
             var serverList = servers as List<ServerEntry> ?? servers.ToList();
             var json = JsonSerializer.Serialize(serverList, AppJsonSerializerContext.Readable<List<ServerEntry>>());
-            await WriteAtomicAsync(ServersFile, json).ConfigureAwait(false);
-        }
-
-        // Write-to-temp + atomic swap: a crash or power cut mid-save can never leave a
-        // truncated settings/servers file — the previous complete file survives until the
-        // replace commits. Temp name is per-call (Guid-suffixed) so concurrent saves of the
-        // same file (e.g. two VMs persisting settings.json close together) never write over
-        // each other's temp file or race on the replace.
-        private static async Task WriteAtomicAsync(string path, string contents)
-        {
-            var tmp = $"{path}.{Guid.NewGuid():N}.tmp";
-            try
-            {
-                await File.WriteAllTextAsync(tmp, contents).ConfigureAwait(false);
-
-                if (File.Exists(path))
-                    File.Replace(tmp, path, destinationBackupFileName: null, ignoreMetadataErrors: true);
-                else
-                    File.Move(tmp, path);
-            }
-            catch
-            {
-                try { File.Delete(tmp); } catch { }
-                throw;
-            }
+            await AtomicFile.WriteAllTextAsync(ServersFile, json).ConfigureAwait(false);
         }
     }
 }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -262,6 +262,12 @@
   <data name="Personalize_DataManagement.Text" xml:space="preserve">
     <value>Import &amp; Export</value>
   </data>
+  <data name="Settings_InvalidTitle" xml:space="preserve">
+    <value>settings.json could not be parsed</value>
+  </data>
+  <data name="Settings_InvalidMsg" xml:space="preserve">
+    <value>Changes did not take effect. Saving is paused until the file parses again, so nothing will be overwritten. Fix the JSON, then reopen this panel.</value>
+  </data>
   <data name="Personalize_Done.Content" xml:space="preserve">
     <value>Done</value>
   </data>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -262,6 +262,12 @@
   <data name="Personalize_DataManagement.Text" xml:space="preserve">
     <value>数据管理</value>
   </data>
+  <data name="Settings_InvalidTitle" xml:space="preserve">
+    <value>settings.json 无法解析</value>
+  </data>
+  <data name="Settings_InvalidMsg" xml:space="preserve">
+    <value>改动没有生效。在该文件恢复可解析之前保存已暂停，不会覆盖任何内容。请修好 JSON 后重新打开此面板。</value>
+  </data>
   <data name="Personalize_Done.Content" xml:space="preserve">
     <value>完成</value>
   </data>

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -848,7 +848,8 @@ namespace XrayUI.ViewModels
                 // ConfigureAwait(false) is load-bearing: CleanupTunOnExit blocks the UI
                 // thread in GetResult() on this method (exit/crash paths), so resuming
                 // the continuation on the dispatcher would deadlock the process.
-                await _settings.SaveSettingsAsync(settings).ConfigureAwait(false);
+                if (!await _settings.SaveSettingsAsync(settings).ConfigureAwait(false))
+                    Debug.WriteLine($"[Settings] Refused to {scenario}: settings.json did not parse.");
             }
             catch (Exception ex)
             {

--- a/ViewModels/CustomRulesViewModel.cs
+++ b/ViewModels/CustomRulesViewModel.cs
@@ -121,7 +121,19 @@ namespace XrayUI.ViewModels
 
             try
             {
-                await _settings.SaveSettingsAsync(s);
+                if (!await _settings.SaveSettingsAsync(s))
+                {
+                    // Refused rather than thrown: settings.json did not parse, so the reload
+                    // above built on defaults and everything not re-stated here would be lost
+                    // if it were written back. Stop before reapplying routing — running rules
+                    // the disk does not have is the silent half of this failure — and leave the
+                    // window open, so the edits are still there when the file is repaired.
+                    await _dialogs.ShowErrorAsync(
+                        L.Settings_InvalidTitle,
+                        L.Settings_InvalidMsg,
+                        GetXamlRoot?.Invoke());
+                    return;
+                }
             }
             catch (Exception ex)
             {

--- a/ViewModels/PersonalizeViewModel.cs
+++ b/ViewModels/PersonalizeViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Windows.UI;
 using XrayUI.Helpers;
@@ -163,14 +163,23 @@ namespace XrayUI.ViewModels
             ShowRestartHint = langDiverged || regionDiverged;
         }
 
-        /// <summary>Persist the currently-selected language and routing region. Call right before
-        /// <see cref="App.Restart"/> — both only take effect on the next process start.</summary>
-        public async Task ApplyPendingChangesAsync()
+        /// <summary>
+        /// Persists the restart-gated settings — language and routing region, which only take
+        /// effect on the next process start. Returns false when nothing was written, so the caller
+        /// does not restart into a process that comes back showing the old values.
+        /// </summary>
+        public async Task<bool> ApplyPendingChangesAsync()
         {
             var s = await _settings.LoadSettingsAsync();
+            if (s.IsFailedLoadFallback)
+            {
+                await _dialogs.ShowErrorAsync(L.Settings_InvalidTitle, L.Settings_InvalidMsg);
+                return false;
+            }
+
             s.Language = LanguageHelper.TagAt(SelectedLanguageIndex);
             s.RoutingRegion = SelectedRegionCode;
-            await _settings.SaveSettingsAsync(s);
+            return await _settings.SaveSettingsAsync(s);
         }
 
         [ObservableProperty]
@@ -275,6 +284,25 @@ namespace XrayUI.ViewModels
         public Task<string> ExportPresetAsync() =>
             new PresetExportService(_settings).ExportAsync();
 
+        /// <summary>
+        /// Drops the cache so hand-edits made while this panel was open are picked up, then
+        /// reports whether settings.json is usable. <see cref="SettingsService"/> already refuses
+        /// to save over a failed load, so this is not what prevents the data loss — it is what
+        /// tells the user why their change went nowhere, at the one moment they can act on it.
+        /// </summary>
+        public async Task<bool> ValidateSettingsFileAsync()
+        {
+            var s = await _settings.ReloadAsync();
+
+            if (s.IsFailedLoadFallback)
+            {
+                await _dialogs.ShowErrorAsync(L.Settings_InvalidTitle, L.Settings_InvalidMsg);
+                return false;
+            }
+
+            return true;
+        }
+
         public static bool PresetExists() => PresetImportService.PresetExists();
 
         /// <summary>
@@ -319,6 +347,12 @@ namespace XrayUI.ViewModels
         [RelayCommand]
         private async Task Done()
         {
+            // On a settings.json the user has left unparseable the save below is refused, so
+            // bail here where there is still somewhere to say why. Doubles as the cache drop
+            // that makes the load pick up hand-edits made while this panel was open, so Done
+            // cannot write stale values back over freshly hand-edited ones.
+            if (!await ValidateSettingsFileAsync()) return;
+
             var s = await _settings.LoadSettingsAsync();
             ProtocolColorStore.SaveTo(s);
             GlobalHotkeyStore.SaveTo(s);

--- a/Views/CustomRulesWindow.xaml.cs
+++ b/Views/CustomRulesWindow.xaml.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Media;
 using WinUIEx;
@@ -12,14 +10,6 @@ namespace XrayUI.Views
 {
     public sealed partial class CustomRulesWindow
     {
-        private const int GWLP_HWNDPARENT = -8;
-
-        [DllImport("User32.dll", CharSet = CharSet.Auto, EntryPoint = "SetWindowLongPtr")]
-        private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
-
-        [DllImport("User32.dll", CharSet = CharSet.Auto, EntryPoint = "SetWindowLong")]
-        private static extern IntPtr SetWindowLong(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
-
         private readonly Window _owner;
 
         public CustomRulesViewModel ViewModel { get; }
@@ -41,19 +31,7 @@ namespace XrayUI.Views
 
             ToolTipService.SetToolTip(OpenAdvancedEditorButton, L.CustomRules_AdvancedEditorTooltip);
 
-			var presenter = OverlappedPresenter.CreateForDialog();
-
-            // 1. Set Win32 owner BEFORE IsModal — IsModal requires an owner.
-            SetWindowOwner(owner);
-
-            // 2. Mark presenter modal, then commit it to the AppWindow.
-            presenter.IsModal = true;
-            AppWindow.SetPresenter(presenter);
-
-            // 3. Show via AppWindow.Show() to apply the modal presenter at the OS level.
-            //    Window.Activate() doesn't reliably re-apply IsModal once the
-            //    window has any prior presenter state.
-            AppWindow.Show();
+            this.ShowAsOwnedModal(owner);
 
             // Let the VM route its error dialogs to this window's XamlRoot instead of
             // falling back to MainWindow's — otherwise they render behind.
@@ -146,17 +124,6 @@ namespace XrayUI.Views
         {
             if (sender is FrameworkElement { DataContext: CustomRoutingRule rule })
                 ViewModel.DeleteRuleCommand.Execute(rule);
-        }
-
-        private void SetWindowOwner(Window owner)
-        {
-            var ownerHwnd = WinRT.Interop.WindowNative.GetWindowHandle(owner);
-            var ownedHwnd = Win32Interop.GetWindowFromWindowId(AppWindow.Id);
-
-            if (IntPtr.Size == 8)
-                SetWindowLongPtr(ownedHwnd, GWLP_HWNDPARENT, ownerHwnd);
-            else
-                SetWindowLong(ownedHwnd, GWLP_HWNDPARENT, ownerHwnd);
         }
 
     }

--- a/Views/PersonalizeControl.xaml.cs
+++ b/Views/PersonalizeControl.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.UI.Xaml.Automation;
 using Windows.Storage;
 using Windows.Storage.Pickers;
@@ -137,7 +137,9 @@ namespace XrayUI.Views
 
         private async void LanguageRestartButton_Click(object sender, RoutedEventArgs e)
         {
-            await ViewModel.ApplyPendingChangesAsync();
+            // Restarting after a refused save would bring the app back on the old language and
+            // region with no explanation. ApplyPendingChangesAsync has already said why.
+            if (!await ViewModel.ApplyPendingChangesAsync()) return;
             App.Restart();
         }
 


### PR DESCRIPTION
Groundwork split out of the config-profiles work, useful on its own.

**Extract `AtomicFile` and `ShowAsOwnedModal`** — both were private implementations that a second caller now needs. `WriteAtomicAsync` moves out of `SettingsService`; `CustomRulesWindow`'s hand-rolled owner/modal sequence moves into `ModalWindowHelper`. That sequence is order-dependent in ways nothing in the API signals, and getting it wrong fails silently, so it is worth having in one place. No behavior change.

**Refuse to save settings that came from a failed load** — this one is a real data-loss fix. An unreadable or unparseable `settings.json` made `LoadSettingsAsync` hand back fresh defaults, and the next save wrote those defaults over the file. The whole configuration was gone, and the trigger could be as small as a stray comma in a hand-edit.

`AppSettings` now carries `IsFailedLoadFallback`, stamped on the throwaway instance a failed load returns and never serialized. `SaveSettingsAsync` refuses such an instance and returns `false` instead of writing. The flag rides the instance rather than the service because a caller can hold one across seconds of awaits, by which point a service-level flag would already have been cleared by the very load that read the user's repair.

A literal `null` body counts as a failed load too — it deserialized to null without throwing, straight into the same overwrite.

Preset import is the one path that must still be able to write, since restoring a preset is exactly what an unreadable `settings.json` needs; it rebuilds on clean defaults instead of reporting an import that wrote nothing. Personalize reports the condition where the user can act on it — on Done, and before a language restart that would otherwise come back on the old values with no explanation.

---

**Stack:** this is the base of a 4-PR stack. `feat/startup-in-personalize` targets this branch, and `feat/config-profiles` targets that one. `feat/update-dialog-visual` is independent and targets `main`.

Debug build clean, 130 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)