### PR TITLE
Move startup settings from the gear menu into Personalize

### DIFF
--- a/Helpers/L.cs
+++ b/Helpers/L.cs
@@ -67,11 +67,6 @@ public static class L
     public static string Share_Title    => Loc.GetString("Share_Title");
     public static string Share_CopyLink => Loc.GetString("Share_CopyLink");
 
-    // ── Startup dialog ─────────────────────────────────────────────────────
-    public static string Startup_Title       => Loc.GetString("Startup_Title");
-    public static string Startup_AutoStart   => Loc.GetString("Startup_AutoStart");
-    public static string Startup_AutoConnect => Loc.GetString("Startup_AutoConnect");
-
     // ── Edit server dialog (extras not in stash) ───────────────────────────
     public static string EditServer_SocksUsername        => Loc.GetString("EditServer_SocksUsername");
     public static string EditServer_EchPlaceholder       => Loc.GetString("EditServer_EchPlaceholder");

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.ComponentModel;
@@ -945,62 +945,6 @@ namespace XrayUI.Services
             };
 
             await dialog.ShowAsync();
-        }
-
-        // ── Startup ───────────────────────────────────────────────────────────
-
-        public async Task<(bool enabled, bool autoConnect)?> ShowStartupDialogAsync(bool currentEnabled,
-            bool currentAutoConnect)
-        {
-            var toggle = new ToggleSwitch
-            {
-                IsOn = currentEnabled,
-                OnContent = L.Dialog_On,
-                OffContent = L.Dialog_Off,
-                MinWidth = 0,
-                Margin = new Thickness(0),
-            };
-
-            var toggleLabel = new TextBlock
-            {
-                Text = L.Startup_AutoStart,
-                VerticalAlignment = VerticalAlignment.Center,
-            };
-
-            var toggleRow = new Grid { ColumnSpacing = 8 };
-            toggleRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-            toggleRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-            Grid.SetColumn(toggleLabel, 0);
-            Grid.SetColumn(toggle, 1);
-            toggleRow.Children.Add(toggleLabel);
-            toggleRow.Children.Add(toggle);
-
-            var checkBox = new CheckBox
-            {
-                Content = L.Startup_AutoConnect,
-                IsChecked = currentAutoConnect,
-                IsEnabled = currentEnabled,
-                Margin = new Thickness(16, 0, 0, 0),
-            };
-
-            toggle.Toggled += (_, _) => checkBox.IsEnabled = toggle.IsOn;
-
-            var dialog = CreateDialog();
-            dialog.Title = L.Startup_Title;
-            dialog.PrimaryButtonText = L.Dialog_Confirm;
-            dialog.CloseButtonText = L.Dialog_Cancel;
-            dialog.DefaultButton = ContentDialogButton.Primary;
-            dialog.Content = new StackPanel
-            {
-                Width = 260,
-                Spacing = 12,
-                Children = { toggleRow, checkBox },
-            };
-
-            var result = await dialog.ShowAsync();
-            if (result != ContentDialogResult.Primary) return null;
-
-            return (toggle.IsOn, checkBox.IsChecked == true);
         }
 
         // ── App update confirm ────────────────────────────────────────────────

--- a/Services/IDialogService.cs
+++ b/Services/IDialogService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,7 +22,6 @@ namespace XrayUI.Services
         /// </summary>
         Task<bool> ShowTunConfirmationDialogAsync(AppSettings settings);
         Task ShowShareLinkDialogAsync(string serverName, string link);
-        Task<(bool enabled, bool autoConnect)?> ShowStartupDialogAsync(bool currentEnabled, bool currentAutoConnect);
 
         /// <summary>
         /// Confirmation shown before an app update starts. Returns true when the

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -497,15 +497,6 @@
   <data name="Share_NotSupportedMsg" xml:space="preserve">
     <value>This node protocol does not support generating share links.</value>
   </data>
-  <data name="Startup_Title" xml:space="preserve">
-    <value>Startup</value>
-  </data>
-  <data name="Startup_AutoStart" xml:space="preserve">
-    <value>Launch at startup</value>
-  </data>
-  <data name="Startup_AutoConnect" xml:space="preserve">
-    <value>Auto-connect to last node</value>
-  </data>
   <data name="Startup_SetFailed" xml:space="preserve">
     <value>Startup settings failed</value>
   </data>
@@ -736,9 +727,6 @@
   </data>
   <data name="ControlPanel_NoProxyItem.Text" xml:space="preserve">
     <value>Bypass System Proxy</value>
-  </data>
-  <data name="ControlPanel_StartupItem.Text" xml:space="preserve">
-    <value>Startup</value>
   </data>
   <data name="ControlPanel_RoutingSettingsItem.Text" xml:space="preserve">
     <value>Routing</value>
@@ -1018,6 +1006,21 @@
   </data>
   <data name="Personalize_DetailGroupDesc.Text" xml:space="preserve">
     <value>Show the subscription group on the node card</value>
+  </data>
+  <data name="Personalize_Startup.Text" xml:space="preserve">
+    <value>Startup</value>
+  </data>
+  <data name="Personalize_StartupTitle.Text" xml:space="preserve">
+    <value>Run at startup</value>
+  </data>
+  <data name="Personalize_StartupDesc.Text" xml:space="preserve">
+    <value>Launch XrayUI automatically</value>
+  </data>
+  <data name="Personalize_AutoConnectTitle.Text" xml:space="preserve">
+    <value>Connect after launch</value>
+  </data>
+  <data name="Personalize_AutoConnectDesc.Text" xml:space="preserve">
+    <value>Connect to the last used node when started at boot</value>
   </data>
   <data name="Personalize_OpenFilterPanelOnStartup.Text" xml:space="preserve">
     <value>Expand filter bar on startup</value>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -497,15 +497,6 @@
   <data name="Share_NotSupportedMsg" xml:space="preserve">
     <value>该节点协议暂不支持生成分享链接。</value>
   </data>
-  <data name="Startup_Title" xml:space="preserve">
-    <value>开机启动</value>
-  </data>
-  <data name="Startup_AutoStart" xml:space="preserve">
-    <value>开机自动启动</value>
-  </data>
-  <data name="Startup_AutoConnect" xml:space="preserve">
-    <value>自动连接上次节点</value>
-  </data>
   <data name="Startup_SetFailed" xml:space="preserve">
     <value>开机启动设置失败</value>
   </data>
@@ -736,9 +727,6 @@
   </data>
   <data name="ControlPanel_NoProxyItem.Text" xml:space="preserve">
     <value>不接管代理</value>
-  </data>
-  <data name="ControlPanel_StartupItem.Text" xml:space="preserve">
-    <value>开机启动</value>
   </data>
   <data name="ControlPanel_RoutingSettingsItem.Text" xml:space="preserve">
     <value>路由设置</value>
@@ -1018,6 +1006,21 @@
   </data>
   <data name="Personalize_DetailGroupDesc.Text" xml:space="preserve">
     <value>节点卡片上展示所属订阅分组</value>
+  </data>
+  <data name="Personalize_Startup.Text" xml:space="preserve">
+    <value>启动</value>
+  </data>
+  <data name="Personalize_StartupTitle.Text" xml:space="preserve">
+    <value>开机自启动</value>
+  </data>
+  <data name="Personalize_StartupDesc.Text" xml:space="preserve">
+    <value>登录 Windows 后自动启动 XrayUI</value>
+  </data>
+  <data name="Personalize_AutoConnectTitle.Text" xml:space="preserve">
+    <value>启动后自动连接</value>
+  </data>
+  <data name="Personalize_AutoConnectDesc.Text" xml:space="preserve">
+    <value>开机启动时连接上次使用的节点</value>
   </data>
   <data name="Personalize_OpenFilterPanelOnStartup.Text" xml:space="preserve">
     <value>启动时展开筛选栏</value>

--- a/ViewModels/ControlPanelViewModel.cs
+++ b/ViewModels/ControlPanelViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Threading;
@@ -15,7 +15,6 @@ namespace XrayUI.ViewModels
         private readonly SettingsService _settings;
         private readonly XrayService _xray;
         private readonly TunService _tunService;
-        private readonly StartupService _startupService;
         private readonly IUpdateService _update;
         private UpdateInfo? _availableUpdate;
         private IReadOnlyList<string> _availableUpdateNotes = Array.Empty<string>();
@@ -38,6 +37,11 @@ namespace XrayUI.ViewModels
         // against the live session rather than whatever is now selected in the list.
         private ServerEntry? _activeServer;
         private string _activeServerName = string.Empty;
+
+        /// <summary>Id of the node xray is running right now, or null when stopped. Read by
+        /// PersonalizeViewModel when auto-connect is switched on mid-session, so the boot
+        /// target is the node actually in use rather than whatever the list has selected.</summary>
+        public string? ActiveServerId => IsRunning ? _activeServer?.Id : null;
 
         // Serializes concurrent reapply calls (custom-rules save, routing-mode toggle,
         // proxy-mode toggle can all race) and blocks re-entry.
@@ -75,14 +79,12 @@ namespace XrayUI.ViewModels
             SettingsService settings,
             XrayService xray,
             TunService tunService,
-            StartupService startupService,
             IUpdateService update)
         {
             _dialogs        = dialogs;
             _settings       = settings;
             _xray           = xray;
             _tunService     = tunService;
-            _startupService = startupService;
             _update         = update;
 
             StartStopButtonContent = L.ControlPanel_Start;
@@ -233,7 +235,10 @@ namespace XrayUI.ViewModels
             appSettings.AllowLanConnections = AllowLanConnections;
             appSettings.RoutingMode         = RoutingMode;
             appSettings.IsTunMode           = tunMode;
-            if (IsAutoConnect)
+            // Auto-connect lives in Personalize now; settings are the shared truth and this
+            // load is already on the path, so read the flag from there instead of mirroring
+            // it onto a second property here.
+            if (appSettings.IsAutoConnect)
                 appSettings.LastAutoConnectServerId = server.Id;
 
             if (tunMode)
@@ -774,54 +779,6 @@ namespace XrayUI.ViewModels
             }
         }
 
-        // ── Startup ───────────────────────────────────────────────────────────
-
-        [ObservableProperty]
-        [NotifyPropertyChangedFor(nameof(StartupMenuIcon))]
-        public partial bool IsStartupEnabled { get; set; }
-
-        [ObservableProperty]
-        public partial bool IsAutoConnect { get; set; }
-
-        /// <summary>
-        /// Returns a checkmark icon when auto-start is enabled, null otherwise.
-        /// Bound to MenuFlyoutItem.Icon so the item reflects current state without
-        /// using ToggleMenuFlyoutItem (which has timing issues with Command).
-        /// </summary>
-        private static readonly FontIcon _startupIcon = new() { Glyph = "\uE73E" };
-        public IconElement? StartupMenuIcon => IsStartupEnabled ? _startupIcon : null;
-
-        [RelayCommand]
-        private async Task OpenStartupSettings()
-        {
-            // When startup is off, always show auto-connect as unchecked to avoid confusion.
-            var result = await _dialogs.ShowStartupDialogAsync(IsStartupEnabled, IsStartupEnabled && IsAutoConnect);
-            if (result is null) return;   // user cancelled — leave state unchanged
-
-            var (newEnabled, newAutoConnect) = result.Value;
-
-            var s = await _settings.LoadSettingsAsync();
-            try
-            {
-                _startupService.SetStartupEnabled(newEnabled);
-            }
-            catch (Exception ex)
-            {
-                await _dialogs.ShowErrorAsync(L.Startup_SetFailed, ex.Message);
-                return;
-            }
-
-            s.IsStartupEnabled = newEnabled;
-            s.IsAutoConnect    = newAutoConnect;
-            if (!newAutoConnect)
-                s.LastAutoConnectServerId = null;
-            else if (IsRunning && _activeServer is not null)
-                s.LastAutoConnectServerId = _activeServer.Id;
-            await TrySaveSettingsAsync(s, "persist startup settings");
-
-            IsStartupEnabled = newEnabled;
-            IsAutoConnect    = newAutoConnect;
-        }
 
         // ── Theme ─────────────────────────────────────────────────────────────
 

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -88,8 +88,8 @@ namespace XrayUI.ViewModels
 
             ServerList   = new ServerListViewModel(dialogs, settings, latencyProbe, realLatencyProbe);
             ServerDetail = new ServerDetailViewModel(latencyProbe, aiUnlockCheck);
-            ControlPanel = new ControlPanelViewModel(dialogs, settings, xray, tunService, startupService, updateService);
-            Personalize  = new PersonalizeViewModel(dialogs, settings);
+            ControlPanel = new ControlPanelViewModel(dialogs, settings, xray, tunService, updateService);
+            Personalize  = new PersonalizeViewModel(dialogs, settings, startupService);
 
             // Wire ControlPanel so it knows the current selected server
             ControlPanel.GetSelectedServer = () => ServerList.SelectedServer;
@@ -103,6 +103,7 @@ namespace XrayUI.ViewModels
             ServerList.GroupNamesChanged += ServerDetail.RefreshGroupName;
             ServerList.RequestSwitchToSelectedServer = ControlPanel.SwitchToSelectedServerAsync;
             Personalize.IsProxyRunning = () => ControlPanel.IsRunning;
+            Personalize.GetActiveServerId = () => ControlPanel.ActiveServerId;
             // Live TUN state for the speed test's egress pin — settings.IsTunMode alone lags
             // the UI toggle and can survive a crash as a stale true (see IDialogService remarks).
             realLatencyProbe.IsTunActive = () => ControlPanel.IsRunning && ControlPanel.IsTunMode;
@@ -158,8 +159,7 @@ namespace XrayUI.ViewModels
             // Task Scheduler off the critical path: the ITaskService::Connect RPC can
             // take hundreds of ms at logon, and nothing below needs its result — a boot
             // launch proves the task exists (it started this process).
-            ControlPanel.IsStartupEnabled = s.IsStartupEnabled;
-            ControlPanel.IsAutoConnect    = s.IsAutoConnect;
+            Personalize.LoadStartup(s);
             _ = ReconcileStartupTaskAsync(s, isBootLaunch);
 
             // Translate the legacy name-based auto-connect setting to Id-based so users
@@ -209,14 +209,14 @@ namespace XrayUI.ViewModels
                 // don't flip the toggle off or persist it.
                 if (isBootLaunch && !externalEnabled) return;
 
-                // The user changed the setting (startup dialog) while the RPC was in
+                // The user changed the setting (Personalize toggle) while the RPC was in
                 // flight; their gesture is newer ground truth than our sample.
                 if (s.IsStartupEnabled != persistedAtStart) return;
 
                 if (s.IsStartupEnabled == externalEnabled) return;
 
                 s.IsStartupEnabled = externalEnabled;
-                ControlPanel.IsStartupEnabled = externalEnabled;
+                Personalize.ApplyExternalStartupState(externalEnabled);
                 await _settings.SaveSettingsAsync(s);
             }
             catch (Exception ex)

--- a/ViewModels/PersonalizeViewModel.cs
+++ b/ViewModels/PersonalizeViewModel.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.UI;
 using XrayUI.Helpers;
@@ -11,6 +14,7 @@ namespace XrayUI.ViewModels
     {
         private readonly SettingsService _settings;
         private readonly IDialogService _dialogs;
+        private readonly StartupService _startup;
 
         /// <summary>Exposed so PersonalizeControl code-behind can show the hotkey recorder
         /// dialog — the actual Win32 register/unregister probe stays in code-behind (needs the
@@ -32,10 +36,11 @@ namespace XrayUI.ViewModels
         /// silently leaving the UI showing a "running" state with no active node.</summary>
         public Func<bool>? IsProxyRunning { get; set; }
 
-        public PersonalizeViewModel(IDialogService dialogs, SettingsService settings)
+        public PersonalizeViewModel(IDialogService dialogs, SettingsService settings, StartupService startup)
         {
             _dialogs = dialogs;
             _settings = settings;
+            _startup = startup;
             ShowLatencyInDetails = true;
             ShowAiUnlockInDetails = true;
             ShowGroupInDetails = true;
@@ -218,6 +223,119 @@ namespace XrayUI.ViewModels
                 baseline != (ShowLatencyInDetails, ShowAiUnlockInDetails, ShowGroupInDetails, OpenServerFilterPanelOnStartup);
         }
 
+        // ── Startup ───────────────────────────────────────────────────────────
+        // The odd pair on this page: these two persist the moment they change instead of
+        // on "完成". SetStartupEnabled creates or deletes a real Task Scheduler task, and
+        // the panel can be dismissed with the back button without ever reaching Done — a
+        // task that exists while settings.json says it doesn't just gets "corrected" away
+        // by MainViewModel's reconcile on the next launch.
+
+        /// <summary>Guards the change handlers when we write the value ourselves (initial
+        /// load, external reconcile, failure rollback) rather than the user flipping it.</summary>
+        private bool _isStartupInternalUpdate;
+
+        /// <summary>Wired by MainViewModel to the control panel: id of the node xray is
+        /// running right now, or null when stopped. Turning auto-connect on mid-session
+        /// records it as the boot target — otherwise enabling it after connecting would
+        /// leave nothing to connect to until the next manual connect.</summary>
+        public Func<string?>? GetActiveServerId { get; set; }
+
+        [ObservableProperty]
+        public partial bool IsStartupEnabled { get; set; }
+
+        [ObservableProperty]
+        public partial bool IsAutoConnect { get; set; }
+
+        partial void OnIsStartupEnabledChanged(bool value)
+        {
+            if (_isStartupInternalUpdate) return;
+            _ = ApplyStartupAsync(value);
+        }
+
+        partial void OnIsAutoConnectChanged(bool value)
+        {
+            if (_isStartupInternalUpdate) return;
+            _ = PersistAutoConnectAsync(value);
+        }
+
+        /// <summary>Serializes the two fire-and-forget writers below. Flipping a switch twice
+        /// in quick succession otherwise lets a slow task registration finish after the newer
+        /// gesture's save, leaving settings.json disagreeing with the Task Scheduler.</summary>
+        private readonly SemaphoreSlim _startupWriteLock = new(1, 1);
+
+        private async Task ApplyStartupAsync(bool enabled)
+        {
+            await _startupWriteLock.WaitAsync();
+            try
+            {
+                try
+                {
+                    // Task registration is a COM RPC that can take hundreds of ms — the same
+                    // reason MainViewModel reconciles off the critical path. Keep it off the
+                    // UI thread so the toggle doesn't freeze mid-flip.
+                    await Task.Run(() => _startup.SetStartupEnabled(enabled));
+                }
+                catch (Exception ex)
+                {
+                    await _dialogs.ShowErrorAsync(L.Startup_SetFailed, ex.Message);
+                    // Put the switch back where the Task Scheduler actually left it.
+                    SetStartupInternal(() => IsStartupEnabled = !enabled);
+                    return;
+                }
+
+                var s = await _settings.LoadSettingsAsync();
+                s.IsStartupEnabled = enabled;
+                // Auto-connect without the boot task is dead state, and leaving it set would
+                // make it silently come back on the next time autostart is enabled.
+                if (!enabled)
+                {
+                    SetStartupInternal(() => IsAutoConnect = false);
+                    s.IsAutoConnect = false;
+                    s.LastAutoConnectServerId = null;
+                }
+                await _settings.SaveSettingsAsync(s);
+            }
+            finally
+            {
+                _startupWriteLock.Release();
+            }
+        }
+
+        private async Task PersistAutoConnectAsync(bool enabled)
+        {
+            await _startupWriteLock.WaitAsync();
+            try
+            {
+                var s = await _settings.LoadSettingsAsync();
+                s.IsAutoConnect = enabled;
+                if (!enabled)
+                    s.LastAutoConnectServerId = null;
+                else if (GetActiveServerId?.Invoke() is { } activeId)
+                    s.LastAutoConnectServerId = activeId;
+                // Enabling while stopped deliberately leaves the recorded target alone: the
+                // next successful connect overwrites it anyway (ControlPanelViewModel).
+                await _settings.SaveSettingsAsync(s);
+            }
+            finally
+            {
+                _startupWriteLock.Release();
+            }
+        }
+
+        /// <summary>Adopts the Task Scheduler's own answer (external state is ground truth,
+        /// see MainViewModel.ReconcileStartupTaskAsync). Internal write — the task already
+        /// matches, so re-registering it would be a pointless second RPC.</summary>
+        public void ApplyExternalStartupState(bool enabled) =>
+            SetStartupInternal(() => IsStartupEnabled = enabled);
+
+        /// <summary>Assigns a startup property without running its user-gesture side effect.</summary>
+        private void SetStartupInternal(Action assign)
+        {
+            _isStartupInternalUpdate = true;
+            try { assign(); }
+            finally { _isStartupInternalUpdate = false; }
+        }
+
         // ── Global hotkeys ────────────────────────────────────────────────────
         // No separate enabled flag — a hotkey is active whenever it has a combo assigned,
         // matching PowerToys' shortcut behavior. Assign via the recorder button (which auto-sets
@@ -363,6 +481,11 @@ namespace XrayUI.ViewModels
                 _                    => "Default"
             };
             s.BackdropSetting = ThemeHelper.CurrentBackdrop;
+            // Startup already wrote itself to disk when it was toggled, but a flip made
+            // moments ago can still be in flight — re-stating it here keeps Done from
+            // overwriting it with the value ValidateSettingsFileAsync's reload just read.
+            s.IsStartupEnabled = IsStartupEnabled;
+            s.IsAutoConnect = IsAutoConnect;
             s.ShowLatencyInDetails = ShowLatencyInDetails;
             s.ShowAiUnlockInDetails = ShowAiUnlockInDetails;
             s.ShowGroupInDetails = ShowGroupInDetails;
@@ -412,6 +535,14 @@ namespace XrayUI.ViewModels
             OpenServerFilterPanelOnStartup = settings.OpenServerFilterPanelOnStartup;
             _displaySettingsBaseline = (ShowLatencyInDetails, ShowAiUnlockInDetails, ShowGroupInDetails, OpenServerFilterPanelOnStartup);
         }
+
+        /// <summary>Shows the persisted autostart state. Internal write — displaying what
+        /// was saved must not re-register the task.</summary>
+        public void LoadStartup(AppSettings settings) => SetStartupInternal(() =>
+        {
+            IsStartupEnabled = settings.IsStartupEnabled;
+            IsAutoConnect    = settings.IsAutoConnect;
+        });
 
         public void LoadLanguage(AppSettings settings)
         {

--- a/ViewModels/PersonalizeViewModel.cs
+++ b/ViewModels/PersonalizeViewModel.cs
@@ -465,6 +465,25 @@ namespace XrayUI.ViewModels
         [RelayCommand]
         private async Task Done()
         {
+            // The two startup writers persist on change under this lock, and one of them can
+            // still be in flight here. Hold it across the whole read-modify-write below, or
+            // ValidateSettingsFileAsync's reload reads the pre-flip file back off disk and the
+            // save below puts it there for good. Re-stating the two flags is not enough on its
+            // own: LastAutoConnectServerId is written by those paths too and has no counterpart
+            // here to restore it.
+            await _startupWriteLock.WaitAsync();
+            try
+            {
+                await SaveAndCloseAsync();
+            }
+            finally
+            {
+                _startupWriteLock.Release();
+            }
+        }
+
+        private async Task SaveAndCloseAsync()
+        {
             // On a settings.json the user has left unparseable the save below is refused, so
             // bail here where there is still somewhere to say why. Doubles as the cache drop
             // that makes the load pick up hand-edits made while this panel was open, so Done
@@ -481,9 +500,8 @@ namespace XrayUI.ViewModels
                 _                    => "Default"
             };
             s.BackdropSetting = ThemeHelper.CurrentBackdrop;
-            // Startup already wrote itself to disk when it was toggled, but a flip made
-            // moments ago can still be in flight — re-stating it here keeps Done from
-            // overwriting it with the value ValidateSettingsFileAsync's reload just read.
+            // Redundant while Done holds the startup writers' lock, but kept: these are the
+            // authoritative UI values regardless of what the reload above returned.
             s.IsStartupEnabled = IsStartupEnabled;
             s.IsAutoConnect = IsAutoConnect;
             s.ShowLatencyInDetails = ShowLatencyInDetails;

--- a/Views/ControlPanelControl.xaml
+++ b/Views/ControlPanelControl.xaml
@@ -75,10 +75,6 @@
                                                      CommandParameter="manual" />
                             </MenuFlyoutSubItem>
                             <MenuFlyoutSeparator />
-                            <MenuFlyoutItem x:Uid="ControlPanel_StartupItem"
-                                            Text="开机启动"
-                                            Command="{x:Bind ViewModel.OpenStartupSettingsCommand}"
-                                            Icon="{x:Bind ViewModel.StartupMenuIcon, Mode=OneWay}" />
                             <MenuFlyoutSubItem x:Uid="ControlPanel_RoutingSettingsItem"
                                                Text="路由设置">
                                 <MenuFlyoutItem x:Uid="ControlPanel_RoutingGlobalItem"

--- a/Views/PersonalizeControl.xaml
+++ b/Views/PersonalizeControl.xaml
@@ -501,6 +501,101 @@
                 </Border>
             </StackPanel>
 
+            <!-- ── Startup ─────────────────────────────────────────────────── -->
+            <StackPanel Spacing="10">
+                <TextBlock x:Uid="Personalize_Startup"
+                           Text="启动"
+                           FontSize="15"
+                           FontWeight="SemiBold" />
+
+                <!-- Deliberately no IsExpanded binding: expansion is view state and the switch is
+                     data state. Coupling them reflows everything below the section on a gesture
+                     that was only meant to change a setting, and overrides a collapse the user
+                     chose. Same reason PowerToys leaves its settings expanders alone. -->
+                <Expander HorizontalAlignment="Stretch"
+                          HorizontalContentAlignment="Stretch"
+                          Style="{StaticResource AppSettingsExpanderStyle}">
+                    <Expander.Header>
+                        <!-- Right padding 4, not the 16 the other headers use: ToggleSwitch's
+                             template reserves a fixed 12px trailing spacer, so 4+12 puts the pill
+                             where the language expander's ComboBox sits. -->
+                        <Grid Padding="0,16,4,16"
+                              ColumnSpacing="12"
+                              HorizontalAlignment="Stretch">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <FontIcon Grid.Column="0"
+                                      Glyph="&#xF71C;"
+                                      FontSize="16"
+                                      VerticalAlignment="Center"
+                                      Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+
+                            <StackPanel Grid.Column="1"
+                                        VerticalAlignment="Center"
+                                        Spacing="2">
+                                <TextBlock x:Name="StartupLabel"
+                                           x:Uid="Personalize_StartupTitle"
+                                           Text="开机自启"
+                                           FontSize="14" />
+                                <TextBlock x:Uid="Personalize_StartupDesc"
+                                           Text="登录 Windows 后自动启动 XrayUI"
+                                           FontSize="12"
+                                           TextWrapping="Wrap"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+
+                            <TextBlock Grid.Column="2"
+                                       AutomationProperties.AccessibilityView="Raw"
+                                       Text="{x:Bind OnOffLabel(ViewModel.IsStartupEnabled), Mode=OneWay}"
+                                       VerticalAlignment="Center" />
+
+                            <ToggleSwitch Grid.Column="3"
+                                          AutomationProperties.LabeledBy="{x:Bind StartupLabel}"
+                                          IsOn="{x:Bind ViewModel.IsStartupEnabled, Mode=TwoWay}"
+                                          OnContent=""
+                                          OffContent=""
+                                          MinWidth="0"
+                                          VerticalAlignment="Center" />
+                        </Grid>
+                    </Expander.Header>
+
+                    <!-- Subordinate option, so a CheckBox rather than a second switch: the switch
+                         above turns the boot task on, this only qualifies what that launch does.
+                         Left 58 is the row inset the other AppSettingsExpanderStyle sections use,
+                         which puts the box under the header title. Disabled while autostart is
+                         off — auto-connect only ever runs from the boot task. -->
+                    <CheckBox HorizontalAlignment="Stretch"
+                              HorizontalContentAlignment="Stretch"
+                              Margin="58,10,16,10"
+                              IsEnabled="{x:Bind ViewModel.IsStartupEnabled, Mode=OneWay}"
+                              IsChecked="{x:Bind ViewModel.IsAutoConnect, Mode=TwoWay}">
+                        <StackPanel VerticalAlignment="Center"
+                                    Spacing="2">
+                            <TextBlock x:Uid="Personalize_AutoConnectTitle"
+                                       Text="启动后自动连接"
+                                       FontSize="14" />
+                            <!-- Opacity, not TextFillColorSecondaryBrush like every other
+                                 description on this page: a local Foreground outranks the
+                                 foreground the CheckBox template hands its content when disabled,
+                                 so the brush version stays bright next to a greyed title. Dimming
+                                 the inherited color instead follows the row into the disabled
+                                 state, and in both themes lands within a few percent of the
+                                 secondary brush. -->
+                            <TextBlock x:Uid="Personalize_AutoConnectDesc"
+                                       Text="开机启动时连接上次使用的节点"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       Opacity="0.75" />
+                        </StackPanel>
+                    </CheckBox>
+                </Expander>
+            </StackPanel>
+
             <!-- Display settings -->
             <StackPanel Spacing="10">
                 <TextBlock x:Uid="Personalize_DisplaySettings"


### PR DESCRIPTION
Autostart and auto-connect were a modal dialog behind a gear-menu item, which is the wrong home for two settings nobody changes twice. They are now a section on the Personalize page: a switch in an `Expander` header, with auto-connect as a subordinate checkbox that greys out when the switch is off — auto-connect only ever runs from the boot task.

Unlike the rest of that page these two persist on change rather than on Done. `SetStartupEnabled` creates or deletes a real Task Scheduler task, and the panel can be dismissed with the back button without ever reaching Done; a task that exists while `settings.json` says it does not just gets corrected away by the reconcile on the next launch. A semaphore serializes the two writers so flipping a switch twice in quick succession cannot let a slow registration finish after the newer gesture's save, and the registration runs off the UI thread because the COM RPC can take hundreds of ms.

Turning auto-connect on mid-session now records the node actually running as the boot target, via the new `ControlPanelViewModel.ActiveServerId`. Enabling it after connecting previously left nothing to connect to until the next manual connect.

`ShowStartupDialogAsync` and the `Startup_*` strings go with it. The `Expander` deliberately has no `IsExpanded` binding: expansion is view state and the switch is data state, and coupling them reflows everything below the section on a gesture that was only meant to change a setting.

---

**Stack:** targets `feat/atomic-file-and-settings-guard` (PR #128), not `main` — it builds on the settings-validation changes to `PersonalizeViewModel` from that branch. `feat/config-profiles` targets this one. GitHub will retarget this PR to `main` once #128 merges.

Debug build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)